### PR TITLE
make the c++-2011 feature set of GCC 4.4 mandatory

### DIFF
--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -291,3 +291,44 @@ foreach(_HEADER tuple tr1/tuple type_traits tr1/type_traits)
   string(TOUPPER ${_HEADER_VAR} _HEADER_VAR )
   check_include_file_cxx(${_HEADER} "HAVE_${_HEADER_VAR}")
 endforeach(_HEADER tuple tr1/tuple tr1/type_traits)
+
+# make sure that the C++-11 features implemented by the compiler are a
+# superset of those provided by GCC 4.4. This makes the test fail on
+# all GCC compilers before 4.4.
+set(CXX_FEATURES_MISSING "")
+if (NOT HAVE_ARRAY)
+  set(CXX_FEATURES_MISSING
+      "${CXX_FEATURES_MISSING} - Statically sized arrays (the std::array class)\n")
+endif()
+if (NOT HAVE_STATIC_ASSERT)
+  set(CXX_FEATURES_MISSING
+      "${CXX_FEATURES_MISSING} - Static assertations (the static_assert() mechanism)\n")
+endif()
+if (NOT HAVE_AUTO)
+  set(CXX_FEATURES_MISSING
+      "${CXX_FEATURES_MISSING} - Automatically typed variables (the 'auto' keyword)\n")
+endif()
+if (NOT HAVE_VARIADIC_TEMPLATES)
+  set(CXX_FEATURES_MISSING
+      "${CXX_FEATURES_MISSING} - Variable number of template arguments\n")
+endif()
+if (NOT HAVE_VARIADIC_CONSTRUCTOR_SFINAE)
+  set(CXX_FEATURES_MISSING
+      "${CXX_FEATURES_MISSING} - Constructors with variable number of template arguments obeying the SFINAE (specialization failure is not an error) rule\n")
+endif()
+if (NOT HAVE_RVALUE_REFERENCES)
+  set(CXX_FEATURES_MISSING
+      "${CXX_FEATURES_MISSING} - References to rvalue objects\n")
+endif()
+if (NOT HAVE_TUPLE)
+  set(CXX_FEATURES_MISSING
+      "${CXX_FEATURES_MISSING} - Tuples (the std::tuple class)\n")
+endif()
+
+if(CXX_FEATURES_MISSING)
+  message(FATAL_ERROR
+    "Your C++ compiler does not support the minimum set of C++-2011 features required. "
+    "Make sure to use a compiler which implements all C++-2011 features provided by GCC 4.4. "
+    "Your compiler does not seem to implement the following features:\n"
+    "${CXX_FEATURES_MISSING}")  
+endif()


### PR DESCRIPTION
we now produce an error even if the module in question does not
actually use some of these features.
