### PR TITLE
Synchronise build system with OPM-Core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ endmacro (sources_hook)
 macro (fortran_hook)
 endmacro (fortran_hook)
 
+macro (files_hook)
+endmacro (files_hook)
+
 macro (tests_hook)
 endmacro (tests_hook)
 

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -13,6 +13,7 @@
 # fortran_hook    Determine whether Fortran support is necessary or not
 #	sources_hook    Do special processing before sources are compiled
 #	tests_hook      Do special processing before tests are compiled
+#	files_hook      Do special processing before final targets are added
 
 # include special
 if (CMAKE_VERSION VERSION_LESS "2.8.3")
@@ -107,6 +108,9 @@ include (UseDynamicBoost)
 
 # needed for Debian installation scheme
 include (UseMultiArch)
+
+# Run conditional file hook
+files_hook()
 
 # this module contains code to figure out which files is where
 include (OpmFiles)


### PR DESCRIPTION
This change-set (partially) synchronises the build system with that of opm-core.  In particular, we introduce the notion of a `files_hook()` in module `OpmLibMain.cmake` that allows (conditionally) modifying the list of files that will be built, just prior to the final definition of the build targets.
