### PR TITLE
embed the scaled endpoints directly into the relevant parameter objects

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -140,6 +140,7 @@ public:
         values[gasPhaseIdx] = pcgn<FluidState, Evaluation>(params, state);
         values[oilPhaseIdx] = 0;
         values[waterPhaseIdx] = - pcnw<FluidState, Evaluation>(params, state);
+
         Valgrind::CheckDefined(values[gasPhaseIdx]);
         Valgrind::CheckDefined(values[oilPhaseIdx]);
         Valgrind::CheckDefined(values[waterPhaseIdx]);

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
@@ -72,7 +72,6 @@ public:
         assert(config_);
         if (config_->enableSatScaling()) {
             assert(unscaledPoints_);
-            assert(scaledPoints_);
         }
         assert(effectiveLawParams_);
 
@@ -108,13 +107,19 @@ public:
      * \brief Set the scaling points which are seen by the physical model
      */
     void setScaledPoints(std::shared_ptr<ScalingPoints> value)
-    { scaledPoints_ = value; }
+    { scaledPoints_ = *value; }
 
     /*!
      * \brief Returns the scaling points which are seen by the physical model
      */
     const ScalingPoints& scaledPoints() const
-    { return *scaledPoints_; }
+    { return scaledPoints_; }
+
+    /*!
+     * \brief Returns the scaling points which are seen by the physical model
+     */
+    ScalingPoints& scaledPoints()
+    { return scaledPoints_; }
 
     /*!
      * \brief Sets the parameter object for the effective/nested material law.
@@ -144,7 +149,7 @@ private:
 
     std::shared_ptr<EclEpsConfig> config_;
     std::shared_ptr<ScalingPoints> unscaledPoints_;
-    std::shared_ptr<ScalingPoints> scaledPoints_;
+    ScalingPoints scaledPoints_;
 };
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -102,7 +102,7 @@ public:
                            EclTwoPhaseSystemType twoPhaseSystem)
 
     {
-        drainageParams_ = value;
+        drainageParams_ = *value;
 
 #if 0
         if (twoPhaseSystem == EclGasOilSystem) {
@@ -118,10 +118,13 @@ public:
     }
 
     /*!
-     * \brief Sets the parameters used for the drainage curve
+     * \brief Returns the parameters used for the drainage curve
      */
     const EffLawParams& drainageParams() const
-    { return *drainageParams_; }
+    { return drainageParams_; }
+
+    EffLawParams& drainageParams()
+    { return drainageParams_; }
 
     /*!
      * \brief Sets the parameters used for the imbibition curve
@@ -130,7 +133,7 @@ public:
                              const EclEpsScalingPointsInfo<Scalar>& info,
                              EclTwoPhaseSystemType twoPhaseSystem)
     {
-        imbibitionParams_ = value;
+        imbibitionParams_ = *value;
 
 /*
         if (twoPhaseSystem == EclGasOilSystem) {
@@ -144,10 +147,13 @@ public:
     }
 
     /*!
-     * \brief Sets the parameters used for the imbibition curve
+     * \brief Returns the parameters used for the imbibition curve
      */
     const EffLawParams& imbibitionParams() const
-    { return *imbibitionParams_; }
+    { return imbibitionParams_; }
+
+    EffLawParams& imbibitionParams()
+    { return imbibitionParams_; }
 
     /*!
      * \brief Set the saturation of the wetting phase where the last switch from the main
@@ -324,11 +330,9 @@ private:
 #endif
     }
 
-    std::shared_ptr<EffLawParams> effectiveLawParams_;
-
     std::shared_ptr<EclHysteresisConfig> config_;
-    std::shared_ptr<EffLawParams> imbibitionParams_;
-    std::shared_ptr<EffLawParams> drainageParams_;
+    EffLawParams imbibitionParams_;
+    EffLawParams drainageParams_;
 
     // largest wettinging phase saturation which is on the main-drainage curve. These are
     // three different values because the sourounding code can choose to use different

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -206,28 +206,22 @@ public:
 
     MaterialLawParams& materialLawParams(int elemIdx)
     {
-        assert(0 <= elemIdx && elemIdx < (int) materialLawParams_.size());
-
-        int paramIdx;
-        if (hasElementSpecificParameters())
-            paramIdx = elemIdx;
+        if (hasElementSpecificParameters()) {
+            assert(0 <= elemIdx && elemIdx < (int) materialLawParams_.size());
+            return *materialLawParams_[elemIdx];
+        }
         else
-            paramIdx = satnumRegionIdx_[elemIdx];
-
-        return *materialLawParams_[paramIdx];
+            return *materialLawParams_[satnumRegionIdx_[elemIdx]];
     }
 
     const MaterialLawParams& materialLawParams(int elemIdx) const
     {
-        assert(0 <= elemIdx && elemIdx < materialLawParams_.size());
-
-        int paramIdx;
-        if (hasElementSpecificParameters())
-            paramIdx = elemIdx;
+        if (hasElementSpecificParameters()) {
+            assert(0 <= elemIdx && elemIdx < (int) materialLawParams_.size());
+            return *materialLawParams_[elemIdx];
+        }
         else
-            paramIdx = satnumRegionIdx_[elemIdx];
-
-        return *materialLawParams_[paramIdx];
+            return *materialLawParams_[satnumRegionIdx_[elemIdx]];
     }
 
     template <class FluidState>

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -187,7 +187,7 @@ public:
             Scalar pcowAtSw = pc[oilPhaseIdx] - pc[waterPhaseIdx];
             if (pcowAtSw > 0.0) {
                 elemScaledEpsInfo.maxPcow *= pcow/pcowAtSw;
-                auto& elemEclEpsScalingPoints = *oilWaterScaledEpsPointsDrainage_[elemIdx];
+                auto& elemEclEpsScalingPoints = getOilWaterScaledEpsPointsDrainage_(elemIdx);
                 elemEclEpsScalingPoints.init(elemScaledEpsInfo, *oilWaterEclEpsConfig_, Opm::EclOilWaterSystem);
             }
         }
@@ -402,7 +402,7 @@ private:
         OilWaterScalingInfoVector oilWaterScaledImbInfoVector;
 
         GasOilScalingPointsVector gasOilScaledPointsVector(numCompressedElems);
-        oilWaterScaledEpsPointsDrainage_.resize(numCompressedElems);
+        GasOilScalingPointsVector oilWaterScaledEpsPointsDrainage(numCompressedElems);
         GasOilScalingPointsVector gasOilScaledImbPointsVector;
         OilWaterScalingPointsVector oilWaterScaledImbPointsVector;
 
@@ -424,7 +424,7 @@ private:
                                     epsGridProperties,
                                     elemIdx);
             readOilWaterScaledPoints_(oilWaterScaledEpsInfoDrainage_,
-                                      oilWaterScaledEpsPointsDrainage_,
+                                      oilWaterScaledEpsPointsDrainage,
                                       oilWaterConfig,
                                       epsGridProperties,
                                       elemIdx);
@@ -475,7 +475,7 @@ private:
             auto oilWaterDrainParams = std::make_shared<OilWaterEpsTwoPhaseParams>();
             oilWaterDrainParams->setConfig(oilWaterConfig);
             oilWaterDrainParams->setUnscaledPoints(oilWaterUnscaledPointsVector[satnumRegionIdx]);
-            oilWaterDrainParams->setScaledPoints(oilWaterScaledEpsPointsDrainage_[elemIdx]);
+            oilWaterDrainParams->setScaledPoints(oilWaterScaledEpsPointsDrainage[elemIdx]);
             oilWaterDrainParams->setEffectiveLawParams(oilWaterEffectiveParamVector[satnumRegionIdx]);
             oilWaterDrainParams->finalize();
 
@@ -678,13 +678,33 @@ private:
         }
     }
 
+    EclEpsScalingPoints<Scalar>& getOilWaterScaledEpsPointsDrainage_(int elemIdx)
+    {
+        auto& materialParams = *materialLawParams_[elemIdx];
+        switch (materialParams.approach()) {
+        case EclStone1Approach: {
+            auto& realParams = materialParams.template getRealParams<Opm::EclStone1Approach>();
+            return realParams.oilWaterParams().drainageParams().scaledPoints();
+        }
+
+        case EclStone2Approach: {
+            auto& realParams = materialParams.template getRealParams<Opm::EclStone2Approach>();
+            return realParams.oilWaterParams().drainageParams().scaledPoints();
+        }
+
+        case EclDefaultApproach: {
+            auto& realParams = materialParams.template getRealParams<Opm::EclDefaultApproach>();
+            return realParams.oilWaterParams().drainageParams().scaledPoints();
+        }
+        }
+    }
+
     bool enableEndPointScaling_;
     std::shared_ptr<EclHysteresisConfig> hysteresisConfig_;
 
     std::shared_ptr<EclEpsConfig> oilWaterEclEpsConfig_;
     std::vector<Opm::EclEpsScalingPointsInfo<Scalar>> unscaledEpsInfo_;
     OilWaterScalingInfoVector oilWaterScaledEpsInfoDrainage_;
-    OilWaterScalingPointsVector oilWaterScaledEpsPointsDrainage_;
 
     EclMultiplexerApproach threePhaseApproach_;
     std::vector<std::shared_ptr<MaterialLawParams> > materialLawParams_;


### PR DESCRIPTION
this hopefully improves performance slightly.