### PR TITLE
Revert "Add support for saturation family 2 keywords"

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -2,7 +2,6 @@
 // vi: set et ts=4 sw=4 sts=4:
 /*
   Copyright (C) 2015 by Andreas Lauser
-  Copyright (C) 2015 by IRIS AS
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -182,146 +181,68 @@ struct EclEpsScalingPointsInfo
                          Opm::EclipseStateConstPtr eclState,
                          int satRegionIdx)
     {
-        // TODO: support for SOF2, SLGOF, SGWFN and 2d tables
+        // TODO: support for the SOF2/SOF3 keyword family
+        const auto& swofTable = eclState->getSwofTables()[satRegionIdx];
+        const auto& sgofTable = eclState->getSgofTables()[satRegionIdx];
 
-        size_t saturationFunctionFamily = eclState->getSaturationFunctionFamily();
-        switch (saturationFunctionFamily) {
-        case 1:
-        {
-            const auto& swofTable = eclState->getSwofTables()[satRegionIdx];
-            const auto& sgofTable = eclState->getSgofTables()[satRegionIdx];
+        // connate saturations
+        Swl = swofTable.getSwColumn().front();
+        Sowl = 1.0 - swofTable.getSwColumn().back();
+        Sgl = sgofTable.getSgColumn().front();
+        Sogl = 1.0 - sgofTable.getSgColumn().back();
 
-            // connate saturations
-            Swl = swofTable.getSwColumn().front();
-            Sowl = 1.0 - swofTable.getSwColumn().back();
-            Sgl = sgofTable.getSgColumn().front();
-            Sogl = 1.0 - sgofTable.getSgColumn().back();
-
-            // critical water saturation
-            for (unsigned rowIdx = 0; rowIdx < swofTable.numRows(); ++ rowIdx) {
-                if (swofTable.getKrwColumn()[rowIdx] > 0) {
-                    assert(rowIdx > 0);
-                    Swcr = swofTable.getSwColumn()[rowIdx - 1];
-                    break;
-                };
-            }
-
-            // critical oil saturation of oil-water system
-            for (int rowIdx = swofTable.numRows() - 1; rowIdx >= 0; -- rowIdx) {
-                if (swofTable.getKrowColumn()[rowIdx] > 0) {
-                    assert(rowIdx < (int) swofTable.numRows() - 1);
-                    Sowcr = 1.0 - swofTable.getSwColumn()[rowIdx + 1];
-                    break;
-                };
-            }
-
-            // critical gas saturation
-            for (unsigned rowIdx = 0; rowIdx < sgofTable.numRows(); ++ rowIdx) {
-                if (sgofTable.getKrgColumn()[rowIdx] > 0) {
-                    assert(rowIdx > 0);
-                    Sgcr = sgofTable.getSgColumn()[rowIdx - 1];
-                    break;
-                };
-            }
-
-            // critical oil saturation of gas-oil system
-            for (int rowIdx = sgofTable.numRows() - 1; rowIdx >= 0; -- rowIdx) {
-                if (sgofTable.getKrogColumn()[rowIdx] > 0) {
-                    assert(rowIdx < (int) sgofTable.numRows() - 1);
-                    Sogcr = 1.0 - sgofTable.getSgColumn()[rowIdx + 1];
-                    break;
-                };
-            }
-
-            // maximum saturations
-            Swu = swofTable.getSwColumn().back();
-            Sowu = 1.0 - swofTable.getSwColumn().front();
-            Sgu = sgofTable.getSgColumn().back();
-            Sogu = 1.0 - sgofTable.getSgColumn().front();
-
-            // maximum capillary pressures
-            maxPcow = swofTable.getPcowColumn().front();
-            maxPcgo = sgofTable.getPcogColumn().back();
-
-            // maximum relative permeabilities
-            maxKrw = swofTable.getKrwColumn().back();
-            maxKrow = swofTable.getKrowColumn().front();
-
-            maxKrg = sgofTable.getKrgColumn().back();
-            maxKrog = sgofTable.getKrogColumn().front();
-            break;
-        }
-        case 2:
-        {
-            const auto& swfnTable = eclState->getSwfnTables()[satRegionIdx];
-            const auto& sof3Table = eclState->getSof3Tables()[satRegionIdx];
-            const auto& sgfnTable = eclState->getSgfnTables()[satRegionIdx];
-
-            // connate saturations
-            Swl = swfnTable.getSwColumn().front();
-            Sowl = sof3Table.getSoColumn().front() + Sgl;
-            Sgl = sgfnTable.getSgColumn().front();
-            Sogl = sof3Table.getSoColumn().front() + Swl;
-
-            // critical water saturation
-            for (unsigned rowIdx = 0; rowIdx < swfnTable.numRows(); ++ rowIdx) {
-                if (swfnTable.getKrwColumn()[rowIdx] > 0) {
-                    assert(rowIdx > 0);
-                    Swcr = swfnTable.getSwColumn()[rowIdx - 1];
-                    break;
-                };
-            }
-
-            // critical oil saturation of oil-water system
-            for (int rowIdx = 0 ; rowIdx < sof3Table.numRows(); ++ rowIdx) {
-                if (sof3Table.getKrowColumn()[rowIdx] > 0) {
-                    assert(rowIdx > 0);
-                    Sowcr = sof3Table.getSoColumn()[rowIdx - 1];
-                    break;
-                };
-            }
-
-            // critical oil saturation of gas-oil system
-            for (int rowIdx = 0 ; rowIdx < sof3Table.numRows(); ++ rowIdx) {
-                if (sof3Table.getKrogColumn()[rowIdx] > 0) {
-                    assert(rowIdx > 0);
-                    Sogcr = sof3Table.getSoColumn()[rowIdx - 1];
-                    break;
-                };
-            }
-
-            // critical gas saturation
-            for (unsigned rowIdx = 0; rowIdx < sgfnTable.numRows(); ++ rowIdx) {
-                if (sgfnTable.getKrgColumn()[rowIdx] > 0) {
-                    assert(rowIdx > 0);
-                    Sgcr = sgfnTable.getSgColumn()[rowIdx - 1];
-                    break;
-                };
-            }
-            // maximum saturations
-            Swu = swfnTable.getSwColumn().back();
-            Sowu = sof3Table.getSoColumn().back();
-            assert(Sowu == 1 - swfnTableSwColumn.front());
-            Sgu = sgfnTable.getSgColumn().back();
-            Sogu = 1 - sgfnTable.getSgColumn().front();
-
-            // maximum capillary pressures
-            maxPcow = swfnTable.getPcowColumn().front();
-            maxPcgo = sgfnTable.getPcogColumn().back();
-
-            // maximum relative permeabilities
-            maxKrw = swfnTable.getKrwColumn().back();
-            maxKrow = sof3Table.getKrowColumn().back();
-
-            maxKrg = sgfnTable.getKrgColumn().back();
-            maxKrog = sof3Table.getKrogColumn().back();
-
-            assert(maxKrw == maxKrg);
-
-            break;
-        }
+        // critical water saturation
+        for (unsigned rowIdx = 0; rowIdx < swofTable.numRows(); ++ rowIdx) {
+            if (swofTable.getKrwColumn()[rowIdx] > 0) {
+                assert(rowIdx > 0);
+                Swcr = swofTable.getSwColumn()[rowIdx - 1];
+                break;
+            };
         }
 
+        // critical oil saturation of oil-water system
+        for (int rowIdx = swofTable.numRows() - 1; rowIdx >= 0; -- rowIdx) {
+            if (swofTable.getKrowColumn()[rowIdx] > 0) {
+                assert(rowIdx < (int) swofTable.numRows() - 1);
+                Sowcr = 1.0 - swofTable.getSwColumn()[rowIdx + 1];
+                break;
+            };
+        }
+
+        // critical gas saturation
+        for (unsigned rowIdx = 0; rowIdx < sgofTable.numRows(); ++ rowIdx) {
+            if (sgofTable.getKrgColumn()[rowIdx] > 0) {
+                assert(rowIdx > 0);
+                Sgcr = sgofTable.getSgColumn()[rowIdx - 1];
+                break;
+            };
+        }
+
+        // critical oil saturation of gas-oil system
+        for (int rowIdx = sgofTable.numRows() - 1; rowIdx >= 0; -- rowIdx) {
+            if (sgofTable.getKrogColumn()[rowIdx] > 0) {
+                assert(rowIdx < (int) sgofTable.numRows() - 1);
+                Sogcr = 1.0 - sgofTable.getSgColumn()[rowIdx + 1];
+                break;
+            };
+        }
+
+        // maximum saturations
+        Swu = swofTable.getSwColumn().back();
+        Sowu = 1.0 - swofTable.getSwColumn().front();
+        Sgu = sgofTable.getSgColumn().back();
+        Sogu = 1.0 - sgofTable.getSgColumn().front();
+
+        // maximum capillary pressures
+        maxPcow = swofTable.getPcowColumn().front();
+        maxPcgo = sgofTable.getPcogColumn().back();
+
+        // maximum relative permeabilities
+        maxKrw = swofTable.getKrwColumn().back();
+        maxKrow = swofTable.getKrowColumn().front();
+
+        maxKrg = sgofTable.getKrgColumn().back();
+        maxKrog = sgofTable.getKrogColumn().front();
     }
 #endif
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -2,7 +2,6 @@
 // vi: set et ts=4 sw=4 sts=4:
 /*
   Copyright (C) 2015 by Andreas Lauser
-  Copyright (C) 2015 by IRIS AS
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -536,47 +535,18 @@ private:
         dest[satnumRegionIdx] = std::make_shared<GasOilEffectiveTwoPhaseParams>();
 
         auto& effParams = *dest[satnumRegionIdx];
-        size_t saturationFunctionFamily = eclState->getSaturationFunctionFamily();
+        const auto& sgofTable = eclState->getSgofTables()[satnumRegionIdx];
 
-        switch (saturationFunctionFamily) {
-        case 1:
-        {
-            const auto& sgofTable = eclState->getSgofTables()[satnumRegionIdx];
-            // convert the saturations of the SGOF keyword from gas to oil saturations
-            std::vector<double> SoSamples(sgofTable.numRows());
-            for (size_t sampleIdx = 0; sampleIdx < sgofTable.numRows(); ++ sampleIdx)
-                SoSamples[sampleIdx] = 1 - sgofTable.getSgColumn()[sampleIdx];
+        // convert the saturations of the SGOF keyword from gas to oil saturations
+        std::vector<double> SoSamples(sgofTable.numRows());
+        for (size_t sampleIdx = 0; sampleIdx < sgofTable.numRows(); ++ sampleIdx)
+            SoSamples[sampleIdx] = 1 - sgofTable.getSgColumn()[sampleIdx];
 
-            effParams.setKrwSamples(SoSamples, sgofTable.getKrogColumn());
-            effParams.setKrnSamples(SoSamples, sgofTable.getKrgColumn());
-            effParams.setPcnwSamples(SoSamples, sgofTable.getPcogColumn());
-            effParams.finalize();
-            break;
-        }
+        effParams.setKrwSamples(SoSamples, sgofTable.getKrogColumn());
+        effParams.setKrnSamples(SoSamples, sgofTable.getKrgColumn());
+        effParams.setPcnwSamples(SoSamples, sgofTable.getPcogColumn());
+        effParams.finalize();
 
-        case 2:
-        {
-            const auto& sgfnTable = eclState->getSgfnTables()[satnumRegionIdx];
-            const auto& sof3Table = eclState->getSof3Tables()[satnumRegionIdx];
-
-            const auto &SoColumn = sof3Table.getSoColumn();
-            // convert the saturations of the SGFN keyword from gas to oil saturations
-            std::vector<double> SoSamples(sgfnTable.numRows());
-            for (size_t sampleIdx = 0; sampleIdx < sgfnTable.numRows(); ++ sampleIdx)
-                SoSamples[sampleIdx] = 1 - sgfnTable.getSgColumn()[sampleIdx];
-
-            for (size_t sampleIdx = 0; sampleIdx < sgfnTable.numRows(); ++ sampleIdx){
-                std::cout << SoColumn[sampleIdx] << " " << SoSamples[sampleIdx] << std::endl;
-
-            }
-
-            effParams.setKrwSamples(SoColumn, sof3Table.getKrogColumn());
-            effParams.setKrnSamples(SoSamples, sgfnTable.getKrgColumn());
-            effParams.setPcnwSamples(SoSamples, sgfnTable.getPcogColumn());
-            effParams.finalize();
-            break;
-        }
-        }
     }
 
     template <class Container>
@@ -587,39 +557,15 @@ private:
         dest[satnumRegionIdx] = std::make_shared<OilWaterEffectiveTwoPhaseParams>();
 
         auto& effParams = *dest[satnumRegionIdx];
-        size_t saturationFunctionFamily = eclState->getSaturationFunctionFamily();
+        const auto& swofTable = eclState->getSwofTables()[satnumRegionIdx];
 
-        switch (saturationFunctionFamily) {
-        case 1: {
-            const auto& swofTable = eclState->getSwofTables()[satnumRegionIdx];
-            const auto &SwColumn = swofTable.getSwColumn();
+        const auto &SwColumn = swofTable.getSwColumn();
 
-            effParams.setKrwSamples(SwColumn, swofTable.getKrwColumn());
-            effParams.setKrnSamples(SwColumn, swofTable.getKrowColumn());
-            effParams.setPcnwSamples(SwColumn, swofTable.getPcowColumn());
-            effParams.finalize();
-            break;
-        }
-        case 2:
-        {
-            const auto& swfnTable = eclState->getSwfnTables()[satnumRegionIdx];
-            const auto& sof3Table = eclState->getSof3Tables()[satnumRegionIdx];
-            const auto &SwColumn = swfnTable.getSwColumn();
-
-            // convert the saturations of the SOF3 keyword from oil to water saturations
-            std::vector<double> SwSamples(sof3Table.numRows());
-            for (size_t sampleIdx = 0; sampleIdx < sof3Table.numRows(); ++ sampleIdx)
-                SwSamples[sampleIdx] = 1 - sof3Table.getSoColumn()[sampleIdx];
-
-            effParams.setKrwSamples(SwColumn, swfnTable.getKrwColumn());
-            effParams.setKrnSamples(SwSamples, sof3Table.getKrowColumn());
-            effParams.setPcnwSamples(SwColumn, swfnTable.getPcowColumn());
-            effParams.finalize();
-            break;
-        }
-        }
+        effParams.setKrwSamples(SwColumn, swofTable.getKrwColumn());
+        effParams.setKrnSamples(SwColumn, swofTable.getKrowColumn());
+        effParams.setPcnwSamples(SwColumn, swofTable.getPcowColumn());
+        effParams.finalize();
     }
-
 
     template <class Container>
     void readGasOilUnscaledPoints_(Container &dest,

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -2,7 +2,6 @@
 // vi: set et ts=4 sw=4 sts=4:
 /*
   Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2015 by IRIS AS
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -142,13 +141,13 @@ public:
      */
     template <class Evaluation>
     static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
-    { return eval_(params.SwPcwnSamples(), params.pcnwSamples(), Sw); }
+    { return eval_(params.SwSamples(), params.pcnwSamples(), Sw); }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatPcnwInv(const Params &params, const Evaluation& pcnw)
     {
         return eval_(params.pcnwSamples(),
-                     params.SwPcwnSamples(),
+                     params.SwSamples(),
                      pcnw);
     }
 
@@ -194,7 +193,7 @@ public:
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
-        const auto& res = eval_(params.SwKrwSamples(), params.krwSamples(), Sw);
+        const auto& res = eval_(params.SwSamples(), params.krwSamples(), Sw);
         return Toolbox::max(0.0, Toolbox::min(1.0, res));
     }
 
@@ -202,7 +201,7 @@ public:
     static Evaluation twoPhaseSatKrwInv(const Params &params, const Evaluation& krw)
     {
         return eval_(params.krwSamples(),
-                     params.SwKrwSamples(),
+                     params.SwSamples(),
                      krw);
     }
 
@@ -225,7 +224,7 @@ public:
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
-        return Toolbox::max(0.0, Toolbox::min(1.0, eval_(params.SwKrnSamples(),
+        return Toolbox::max(0.0, Toolbox::min(1.0, eval_(params.SwSamples(),
                                                          params.krnSamples(),
                                                          Sw)));
     }
@@ -234,7 +233,7 @@ public:
     static Evaluation twoPhaseSatKrnInv(const Params &params, const Evaluation& krn)
     {
         return eval_(params.krnSamples(),
-                     params.SwKrnSamples(),
+                     params.SwSamples(),
                      krn);
     }
 

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -65,35 +65,26 @@ public:
 
         // revert the order of the sampling points if they were given
         // in reverse direction.
-        if (SwPcwnSamples_.front() > SwPcwnSamples_.back())
-            swapOrder_(SwPcwnSamples_, pcwnSamples_);
+        if (SwSamples_.front() > SwSamples_.back()) {
+            for (unsigned origSampleIdx = 0;
+                 origSampleIdx < SwSamples_.size() / 2;
+                 ++ origSampleIdx)
+            {
+                unsigned newSampleIdx = SwSamples_.size() - origSampleIdx - 1;
 
-        if (SwKrwSamples_.front() > SwKrwSamples_.back())
-            swapOrder_(SwKrwSamples_, krwSamples_);
-
-
-        if (SwKrnSamples_.front() > SwKrnSamples_.back())
-            swapOrder_(SwKrnSamples_, krnSamples_);
-
+                std::swap(SwSamples_[origSampleIdx], SwSamples_[newSampleIdx]);
+                std::swap(pcwnSamples_[origSampleIdx], pcwnSamples_[newSampleIdx]);
+                std::swap(krwSamples_[origSampleIdx], krwSamples_[newSampleIdx]);
+                std::swap(krnSamples_[origSampleIdx], krnSamples_[newSampleIdx]);
+            }
+        }
     }
 
     /*!
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
-    const ValueVector& SwKrwSamples() const
-    { assertFinalized_(); return SwKrwSamples_; }
-
-    /*!
-     * \brief Return the wetting-phase saturation values of all sampling points.
-     */
-    const ValueVector& SwKrnSamples() const
-    { assertFinalized_(); return SwKrnSamples_; }
-
-    /*!
-     * \brief Return the wetting-phase saturation values of all sampling points.
-     */
-    const ValueVector& SwPcwnSamples() const
-    { assertFinalized_(); return SwPcwnSamples_; }
+    const ValueVector& SwSamples() const
+    { assertFinalized_(); return SwSamples_; }
 
     /*!
      * \brief Return the sampling points for the capillary pressure curve.
@@ -114,10 +105,10 @@ public:
         assert(SwValues.size() == values.size());
 
         int n = SwValues.size();
-        SwPcwnSamples_.resize(n);
+        SwSamples_.resize(n);
         pcwnSamples_.resize(n);
 
-        std::copy(SwValues.begin(), SwValues.end(), SwPcwnSamples_.begin());
+        std::copy(SwValues.begin(), SwValues.end(), SwSamples_.begin());
         std::copy(values.begin(), values.end(), pcwnSamples_.begin());
     }
 
@@ -142,10 +133,10 @@ public:
         assert(SwValues.size() == values.size());
 
         int n = SwValues.size();
-        SwKrwSamples_.resize(n);
+        SwSamples_.resize(n);
         krwSamples_.resize(n);
 
-        std::copy(SwValues.begin(), SwValues.end(), SwKrwSamples_.begin());
+        std::copy(SwValues.begin(), SwValues.end(), SwSamples_.begin());
         std::copy(values.begin(), values.end(), krwSamples_.begin());
     }
 
@@ -170,10 +161,10 @@ public:
         assert(SwValues.size() == values.size());
 
         int n = SwValues.size();
-        SwKrnSamples_.resize(n);
+        SwSamples_.resize(n);
         krnSamples_.resize(n);
 
-        std::copy(SwValues.begin(), SwValues.end(), SwKrnSamples_.begin());
+        std::copy(SwValues.begin(), SwValues.end(), SwSamples_.begin());
         std::copy(values.begin(), values.end(), krnSamples_.begin());
     }
 
@@ -188,24 +179,7 @@ private:
     { }
 #endif
 
-    void swapOrder_(ValueVector& swValues, ValueVector& values) const
-    {
-        if (swValues.front() > values.back()) {
-            for (unsigned origSampleIdx = 0;
-                 origSampleIdx < swValues.size() / 2;
-                 ++ origSampleIdx)
-            {
-                unsigned newSampleIdx = swValues.size() - origSampleIdx - 1;
-
-                std::swap(swValues[origSampleIdx], swValues[newSampleIdx]);
-                std::swap(values[origSampleIdx], values[newSampleIdx]);
-            }
-        }
-    }
-
-    ValueVector SwPcwnSamples_;
-    ValueVector SwKrwSamples_;
-    ValueVector SwKrnSamples_;
+    ValueVector SwSamples_;
     ValueVector pcwnSamples_;
     ValueVector krwSamples_;
     ValueVector krnSamples_;


### PR DESCRIPTION
This reverts commit ea502561eaa3897f0da66249e17c2bb062f59eda.

it does not compile with the current opm-parser. that's due to the fact that the `getSaturationFunctionFamily()` method is not in an publicly accessible place in the version which went into opm-parser.