### PR TITLE
Ecl satfunc improvements

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -229,7 +229,7 @@ public:
 
         // if it is enabled, use either the drainage or the imbibition curve. if the
         // imbibition curve is used, the saturation must be shifted.
-        if (Sw < params.krwSwMdc())
+        if (Sw <= params.krwSwMdc())
             return EffectiveLaw::twoPhaseSatKrw(params.drainageParams(), Sw);
 
         return EffectiveLaw::twoPhaseSatKrw(params.imbibitionParams(),
@@ -255,7 +255,7 @@ public:
 
         // if it is enabled, use either the drainage or the imbibition curve. if the
         // imbibition curve is used, the saturation must be shifted.
-        if (Sw < params.krnSwMdc())
+        if (Sw <= params.krnSwMdc())
             return EffectiveLaw::twoPhaseSatKrn(params.drainageParams(), Sw);
 
         return EffectiveLaw::twoPhaseSatKrn(params.imbibitionParams(),

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -537,12 +537,19 @@ private:
         auto& effParams = *dest[satnumRegionIdx];
         const auto& sgofTable = eclState->getSgofTables()[satnumRegionIdx];
 
+        // the situation for the gas phase is complicated that all saturations are
+        // shifted by the connate water saturation.
+        Scalar Swco = unscaledEpsInfo_[satnumRegionIdx].Swl;
+
         // convert the saturations of the SGOF keyword from gas to oil saturations
         std::vector<double> SoSamples(sgofTable.numRows());
-        for (size_t sampleIdx = 0; sampleIdx < sgofTable.numRows(); ++ sampleIdx)
+        std::vector<double> SoSamplesKro(sgofTable.numRows());
+        for (size_t sampleIdx = 0; sampleIdx < sgofTable.numRows(); ++ sampleIdx) {
             SoSamples[sampleIdx] = 1 - sgofTable.getSgColumn()[sampleIdx];
+            SoSamplesKro[sampleIdx] = SoSamples[sampleIdx] - Swco;
+        }
 
-        effParams.setKrwSamples(SoSamples, sgofTable.getKrogColumn());
+        effParams.setKrwSamples(SoSamplesKro, sgofTable.getKrogColumn());
         effParams.setKrnSamples(SoSamples, sgofTable.getKrgColumn());
         effParams.setPcnwSamples(SoSamples, sgofTable.getPcogColumn());
         effParams.finalize();

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -2,6 +2,7 @@
 // vi: set et ts=4 sw=4 sts=4:
 /*
   Copyright (C) 2009-2013 by Andreas Lauser
+  Copyright (C) 2015 by IRIS AS
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -141,13 +142,13 @@ public:
      */
     template <class Evaluation>
     static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
-    { return eval_(params.SwSamples(), params.pcnwSamples(), Sw); }
+    { return eval_(params.SwPcwnSamples(), params.pcnwSamples(), Sw); }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatPcnwInv(const Params &params, const Evaluation& pcnw)
     {
         return eval_(params.pcnwSamples(),
-                     params.SwSamples(),
+                     params.SwPcwnSamples(),
                      pcnw);
     }
 
@@ -193,7 +194,7 @@ public:
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
-        const auto& res = eval_(params.SwSamples(), params.krwSamples(), Sw);
+        const auto& res = eval_(params.SwKrwSamples(), params.krwSamples(), Sw);
         return Toolbox::max(0.0, Toolbox::min(1.0, res));
     }
 
@@ -201,7 +202,7 @@ public:
     static Evaluation twoPhaseSatKrwInv(const Params &params, const Evaluation& krw)
     {
         return eval_(params.krwSamples(),
-                     params.SwSamples(),
+                     params.SwKrwSamples(),
                      krw);
     }
 
@@ -224,7 +225,7 @@ public:
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
-        return Toolbox::max(0.0, Toolbox::min(1.0, eval_(params.SwSamples(),
+        return Toolbox::max(0.0, Toolbox::min(1.0, eval_(params.SwKrnSamples(),
                                                          params.krnSamples(),
                                                          Sw)));
     }
@@ -233,7 +234,7 @@ public:
     static Evaluation twoPhaseSatKrnInv(const Params &params, const Evaluation& krn)
     {
         return eval_(params.krnSamples(),
-                     params.SwSamples(),
+                     params.SwKrnSamples(),
                      krn);
     }
 

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -146,11 +146,7 @@ public:
 
     template <class Evaluation>
     static Evaluation twoPhaseSatPcnwInv(const Params &params, const Evaluation& pcnw)
-    {
-        return eval_(params.pcnwSamples(),
-                     params.SwPcwnSamples(),
-                     pcnw);
-    }
+    { return eval_(params.pcnwSamples(), params.SwPcwnSamples(), pcnw); }
 
     /*!
      * \brief The saturation-capillary pressure curve
@@ -191,20 +187,11 @@ public:
 
     template <class Evaluation>
     static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
-    {
-        typedef MathToolbox<Evaluation> Toolbox;
-
-        const auto& res = eval_(params.SwKrwSamples(), params.krwSamples(), Sw);
-        return Toolbox::max(0.0, Toolbox::min(1.0, res));
-    }
+    { return eval_(params.SwKrwSamples(), params.krwSamples(), Sw); }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatKrwInv(const Params &params, const Evaluation& krw)
-    {
-        return eval_(params.krwSamples(),
-                     params.SwKrwSamples(),
-                     krw);
-    }
+    { return eval_(params.krwSamples(), params.SwKrwSamples(), krw); }
 
     /*!
      * \brief The relative permeability for the non-wetting phase
@@ -222,21 +209,11 @@ public:
 
     template <class Evaluation>
     static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
-    {
-        typedef MathToolbox<Evaluation> Toolbox;
-
-        return Toolbox::max(0.0, Toolbox::min(1.0, eval_(params.SwKrnSamples(),
-                                                         params.krnSamples(),
-                                                         Sw)));
-    }
+    { return eval_(params.SwKrnSamples(), params.krnSamples(), Sw); }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatKrnInv(const Params &params, const Evaluation& krn)
-    {
-        return eval_(params.krnSamples(),
-                     params.SwKrnSamples(),
-                     krn);
-    }
+    { return eval_(params.krnSamples(), params.SwKrnSamples(), krn); }
 
 private:
     template <class Evaluation>

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -65,26 +65,35 @@ public:
 
         // revert the order of the sampling points if they were given
         // in reverse direction.
-        if (SwSamples_.front() > SwSamples_.back()) {
-            for (unsigned origSampleIdx = 0;
-                 origSampleIdx < SwSamples_.size() / 2;
-                 ++ origSampleIdx)
-            {
-                unsigned newSampleIdx = SwSamples_.size() - origSampleIdx - 1;
+        if (SwPcwnSamples_.front() > SwPcwnSamples_.back())
+            swapOrder_(SwPcwnSamples_, pcwnSamples_);
 
-                std::swap(SwSamples_[origSampleIdx], SwSamples_[newSampleIdx]);
-                std::swap(pcwnSamples_[origSampleIdx], pcwnSamples_[newSampleIdx]);
-                std::swap(krwSamples_[origSampleIdx], krwSamples_[newSampleIdx]);
-                std::swap(krnSamples_[origSampleIdx], krnSamples_[newSampleIdx]);
-            }
-        }
+        if (SwKrwSamples_.front() > SwKrwSamples_.back())
+            swapOrder_(SwKrwSamples_, krwSamples_);
+
+
+        if (SwKrnSamples_.front() > SwKrnSamples_.back())
+            swapOrder_(SwKrnSamples_, krnSamples_);
+
     }
 
     /*!
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
-    const ValueVector& SwSamples() const
-    { assertFinalized_(); return SwSamples_; }
+    const ValueVector& SwKrwSamples() const
+    { assertFinalized_(); return SwKrwSamples_; }
+
+    /*!
+     * \brief Return the wetting-phase saturation values of all sampling points.
+     */
+    const ValueVector& SwKrnSamples() const
+    { assertFinalized_(); return SwKrnSamples_; }
+
+    /*!
+     * \brief Return the wetting-phase saturation values of all sampling points.
+     */
+    const ValueVector& SwPcwnSamples() const
+    { assertFinalized_(); return SwPcwnSamples_; }
 
     /*!
      * \brief Return the sampling points for the capillary pressure curve.
@@ -105,10 +114,10 @@ public:
         assert(SwValues.size() == values.size());
 
         int n = SwValues.size();
-        SwSamples_.resize(n);
+        SwPcwnSamples_.resize(n);
         pcwnSamples_.resize(n);
 
-        std::copy(SwValues.begin(), SwValues.end(), SwSamples_.begin());
+        std::copy(SwValues.begin(), SwValues.end(), SwPcwnSamples_.begin());
         std::copy(values.begin(), values.end(), pcwnSamples_.begin());
     }
 
@@ -133,10 +142,10 @@ public:
         assert(SwValues.size() == values.size());
 
         int n = SwValues.size();
-        SwSamples_.resize(n);
+        SwKrwSamples_.resize(n);
         krwSamples_.resize(n);
 
-        std::copy(SwValues.begin(), SwValues.end(), SwSamples_.begin());
+        std::copy(SwValues.begin(), SwValues.end(), SwKrwSamples_.begin());
         std::copy(values.begin(), values.end(), krwSamples_.begin());
     }
 
@@ -161,10 +170,10 @@ public:
         assert(SwValues.size() == values.size());
 
         int n = SwValues.size();
-        SwSamples_.resize(n);
+        SwKrnSamples_.resize(n);
         krnSamples_.resize(n);
 
-        std::copy(SwValues.begin(), SwValues.end(), SwSamples_.begin());
+        std::copy(SwValues.begin(), SwValues.end(), SwKrnSamples_.begin());
         std::copy(values.begin(), values.end(), krnSamples_.begin());
     }
 
@@ -179,7 +188,24 @@ private:
     { }
 #endif
 
-    ValueVector SwSamples_;
+    void swapOrder_(ValueVector& swValues, ValueVector& values) const
+    {
+        if (swValues.front() > values.back()) {
+            for (unsigned origSampleIdx = 0;
+                 origSampleIdx < swValues.size() / 2;
+                 ++ origSampleIdx)
+            {
+                unsigned newSampleIdx = swValues.size() - origSampleIdx - 1;
+
+                std::swap(swValues[origSampleIdx], swValues[newSampleIdx]);
+                std::swap(values[origSampleIdx], values[newSampleIdx]);
+            }
+        }
+    }
+
+    ValueVector SwPcwnSamples_;
+    ValueVector SwKrwSamples_;
+    ValueVector SwKrnSamples_;
     ValueVector pcwnSamples_;
     ValueVector krwSamples_;
     ValueVector krnSamples_;


### PR DESCRIPTION
some smallish changes to the ECL saturation functions to improve performance of the Norne deck and to improve correctness. The only thing which affects of the results qualitively is 12ec94e7ec6492c37d5fcbf4be59d9b4dc11477a, but this does not change anything on Norne, because the unscaled connate water saturation is zero there.