### PR TITLE
various improvements to the ECL satfuncs

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -335,7 +335,7 @@ public:
         Scalar Sg = FsToolbox::value(fluidState.saturation(gasPhaseIdx));
 
         if (params.inconsistentHysteresisUpdate()) {
-            Sg = std::min(1.0, std::max(0.0, Sg));
+            Sg = std::min(Scalar(1.0), std::max(Scalar(0.0), Sg));
             // NOTE: the saturations which are passed to update the hysteresis curves are
             // inconsistent with the ones used to calculate the relative permabilities. We do
             // it like this anyway because (a) the saturation functions of opm-core do it
@@ -350,8 +350,8 @@ public:
         }
         else {
             Scalar Swco = params.Swl();
-            Sw = std::min(1.0, std::max(0.0, Sw));
-            Sg = std::min(1.0, std::max(0.0, Sg));
+            Sw = std::min(Scalar(1.0), std::max(Scalar(0.0), Sw));
+            Sg = std::min(Scalar(1.0), std::max(Scalar(0.0), Sg));
 
             Scalar Sw_ow = Sg + std::max(Swco, Sw);
             Scalar So_go = 1 + Sw_ow;


### PR DESCRIPTION
- 9daf36c is a cleanup in terminology of the endpoint scaling code which hopefully makes it easier to understand
- 4b529f2 changes how the oil relperms are calulated in `EclDefaultMaterial` to the way it is documented by the technical description in contrast to what's currently used by opm-core (and probably MRST). The differences are quite small for the Norne deck, but they can be seen.
-  0712766 tries to be a bit smarter about the division by zero which is in `EclDefaultMaterial`
-  ef132c3 implements support for two-phase ECL decks. I've already updated the PRs for the `opm-core` and `opm-autodiff` modules, to adapt to the (small) API change implied by this. Barring any twophase decks, I cannot guarantee that it Works Like Advertised, though.

with these patches Norne runs using the opm-material satfuncs are silghtly faster than what's currently in master when doing the measurement on my machine using the toolchain I tested and with the same flags. (i.e., your mileage may vary).