### PR TITLE
Silence warnings

### DIFF
--- a/opm/material/common/MathToolbox.hpp
+++ b/opm/material/common/MathToolbox.hpp
@@ -112,7 +112,7 @@ public:
      * regard to x. For scalar evaluations (which do not consider derivatives), this
      * method does nothing.
      */
-    static Scalar createVariable(Scalar value, int varIdx)
+    static Scalar createVariable(Scalar value, int /* varIdx */)
     { return value; }
 
     /*!

--- a/opm/material/common/Valgrind.hpp
+++ b/opm/material/common/Valgrind.hpp
@@ -77,6 +77,7 @@ inline bool CheckDefined(const T &value)
     auto tmp = VALGRIND_CHECK_MEM_IS_DEFINED(&value, sizeof(T));
     return tmp == 0;
 #else
+    static_cast<void>(value);
     return true;
 #endif
 }
@@ -113,6 +114,8 @@ inline bool CheckDefined(const T *value, int size)
     auto tmp = VALGRIND_CHECK_MEM_IS_DEFINED(value, size*sizeof(T));
     return tmp == 0;
 #else
+    static_cast<void>(value);
+    static_cast<void>(size);
     return true;
 #endif
 }
@@ -140,6 +143,7 @@ inline void SetUndefined(const T &value)
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_UNDEFINED(&value, sizeof(T));
 #endif
+    static_cast<void>(value);
 }
 
 /*!
@@ -166,6 +170,8 @@ inline void SetUndefined(const T *value, int size)
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_UNDEFINED(value, size*sizeof(T));
 #endif
+    static_cast<void>(value);
+    static_cast<void>(size);
 }
 
 /*!
@@ -190,6 +196,7 @@ inline void SetDefined(const T &value)
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_DEFINED(&value, sizeof(T));
 #endif
+    static_cast<void>(value);
 }
 
 /*!
@@ -216,6 +223,8 @@ inline void SetDefined(const T *value, int n)
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_DEFINED(value, n*sizeof(T));
 #endif
+    static_cast<void>(value);
+    static_cast<void>(n);
 }
 
 /*!
@@ -240,6 +249,7 @@ inline void SetNoAccess(const T &value)
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_NOACCESS(&value, sizeof(T));
 #endif
+    static_cast<void>(value);
 }
 
 /*!
@@ -264,6 +274,8 @@ inline void SetNoAccess(const T *value, int size)
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_NOACCESS(value, size*sizeof(T));
 #endif
+    static_cast<void>(value);
+    static_cast<void>(size);
 }
 
 } // namespace Valgrind

--- a/opm/material/components/Component.hpp
+++ b/opm/material/components/Component.hpp
@@ -58,8 +58,8 @@ public:
      *
      * This function throws a warning when called: "No init routine defined - make sure that this is not necessary!"
      */
-    static void init(Scalar tempMin, Scalar tempMax, unsigned nTemp,
-                     Scalar pressMin, Scalar pressMax, unsigned nPress)
+    static void init(Scalar /* tempMin */, Scalar /* tempMax */, unsigned /* nTemp */,
+                     Scalar /* pressMin */, Scalar /* pressMax */, unsigned /* nPress */)
     { }
 
     /*!
@@ -123,7 +123,7 @@ public:
      * \param temperature temperature of the component in \f$\mathrm{[K]}\f$
      */
     template <class Evaluation>
-    static Evaluation vaporPressure(const Evaluation& temperature)
+    static Evaluation vaporPressure(const Evaluation& /* temperature */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::vaporPressure()"); }
 
     /*!
@@ -133,7 +133,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation gasDensity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasDensity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::gasDensity()"); }
 
     /*!
@@ -143,7 +143,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDensity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidDensity()"); }
 
     /*!
@@ -153,7 +153,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation gasEnthalpy(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasEnthalpy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::gasEnthalpy()"); }
 
     /*!
@@ -163,7 +163,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidEnthalpy(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidEnthalpy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidEnthalpy()"); }
 
     /*!
@@ -173,7 +173,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation gasInternalEnergy(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasInternalEnergy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::gasInternalEnergy()"); }
 
     /*!
@@ -183,7 +183,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidInternalEnergy(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidInternalEnergy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidInternalEnergy()"); }
 
     /*!
@@ -194,7 +194,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation gasViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasViscosity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::gasViscosity()"); }
 
     /*!
@@ -204,35 +204,35 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidViscosity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidViscosity()"); }
 
     /*!
      * \brief Thermal conductivity of the component [W/(m^2 K/m)] as a gas.
      */
     template <class Evaluation>
-    static Evaluation gasThermalConductivity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasThermalConductivity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::gasThermalConductivity()"); }
 
     /*!
      * \brief Thermal conductivity of the component [W/(m^2 K/m)] as a liquid.
      */
     template <class Evaluation>
-    static Evaluation liquidThermalConductivity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidThermalConductivity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidThermalConductivity()"); }
 
     /*!
      * \brief Specific isobaric heat capacity of the component [J/kg] as a gas.
      */
     template <class Evaluation>
-    static Evaluation gasHeatCapacity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasHeatCapacity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::gasHeatCapacity()"); }
 
     /*!
      * \brief Specific isobaric heat capacity of the component [J/kg] as a liquid.
      */
     template <class Evaluation>
-    static Evaluation liquidHeatCapacity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidHeatCapacity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidHeatCapacity()"); }
 };
 

--- a/opm/material/components/Unit.hpp
+++ b/opm/material/components/Unit.hpp
@@ -84,7 +84,7 @@ public:
      * \copydoc Component::vaporPressure
      */
     template <class Evaluation>
-    static Evaluation vaporPressure(const Evaluation& T)
+    static Evaluation vaporPressure(const Evaluation& /* temperature */)
     { return 1.0; }
 
     /*!
@@ -109,28 +109,28 @@ public:
      * \copydoc Component::liquidDensity
      */
     template <class Evaluation>
-    static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDensity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
     /*!
      * \copydoc Component::liquidViscosity
      */
     template <class Evaluation>
-    static Evaluation liquidViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidViscosity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
     /*!
      * \copydoc Component::gasDensity
      */
     template <class Evaluation>
-    static Evaluation gasDensity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasDensity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
     /*!
      * \copydoc Component::gasViscosity
      */
     template <class Evaluation>
-    static Evaluation gasViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasViscosity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
 
@@ -138,56 +138,56 @@ public:
      * \copydoc Component::gasEnthalpy
      */
     template <class Evaluation>
-    static Evaluation gasEnthalpy(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasEnthalpy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
     /*!
      * \copydoc Component::liquidEnthalpy
      */
     template <class Evaluation>
-    static Evaluation liquidEnthalpy(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidEnthalpy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
     /*!
      * \copydoc Component::gasInternalEnergy
      */
     template <class Evaluation>
-    static Evaluation gasInternalEnergy(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasInternalEnergy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
     /*!
      * \copydoc Component::liquidInternalEnergy
      */
     template <class Evaluation>
-    static Evaluation liquidInternalEnergy(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidInternalEnergy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
     /*!
      * \copydoc Component::gasThermalConductivity
      */
     template <class Evaluation>
-    static Evaluation gasThermalConductivity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasThermalConductivity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
     /*!
      * \copydoc Component::liquidThermalConductivity
      */
     template <class Evaluation>
-    static Evaluation liquidThermalConductivity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidThermalConductivity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
     /*!
      * \copydoc Component::gasHeatCapacity
      */
     template <class Evaluation>
-    static Evaluation gasHeatCapacity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasHeatCapacity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 
     /*!
      * \copydoc Component::liquidHeatCapacity
      */
     template <class Evaluation>
-    static Evaluation liquidHeatCapacity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidHeatCapacity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
     { return 1.0; }
 };
 

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -192,6 +192,9 @@ public:
                             const Params &params,
                             const FluidState &fs)
     {
+        static_cast<void>(values);
+        static_cast<void>(params);
+        static_cast<void>(fs);
         OPM_THROW(std::logic_error, "Not implemented: saturations()");
     }
 
@@ -202,6 +205,8 @@ public:
     static Evaluation Sg(const Params &params,
                          const FluidState &fluidState)
     {
+        static_cast<void>(params);
+        static_cast<void>(fluidState);
         OPM_THROW(std::logic_error, "Not implemented: Sg()");
     }
 
@@ -212,6 +217,8 @@ public:
     static Evaluation Sn(const Params &params,
                          const FluidState &fluidState)
     {
+        static_cast<void>(params);
+        static_cast<void>(fluidState);
         OPM_THROW(std::logic_error, "Not implemented: Sn()");
     }
 
@@ -222,6 +229,8 @@ public:
     static Evaluation Sw(const Params &params,
                          const FluidState &fluidState)
     {
+        static_cast<void>(params);
+        static_cast<void>(fluidState);
         OPM_THROW(std::logic_error, "Not implemented: Sw()");
     }
 

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -52,7 +52,7 @@ class EclEpsGridProperties
 
 public:
 #if HAVE_OPM_PARSER
-    void initFromDeck(Opm::DeckConstPtr deck,
+    void initFromDeck(Opm::DeckConstPtr /* deck */,
                       Opm::EclipseStateConstPtr eclState,
                       bool useImbibition)
     {
@@ -453,7 +453,7 @@ private:
         Sowu = sof3Table.getSoColumn().back();
 
         // critical oil saturation of oil-water system
-        for (int rowIdx = 0 ; rowIdx < sof3Table.numRows(); ++ rowIdx) {
+        for (size_t rowIdx = 0 ; rowIdx < sof3Table.numRows(); ++ rowIdx) {
             if (sof3Table.getKrowColumn()[rowIdx] > 0) {
                 assert(rowIdx > 0);
                 Sowcr = sof3Table.getSoColumn()[rowIdx - 1];
@@ -462,7 +462,7 @@ private:
         }
 
         // critical oil saturation of gas-oil system
-        for (int rowIdx = 0 ; rowIdx < sof3Table.numRows(); ++ rowIdx) {
+        for (size_t rowIdx = 0 ; rowIdx < sof3Table.numRows(); ++ rowIdx) {
             if (sof3Table.getKrogColumn()[rowIdx] > 0) {
                 assert(rowIdx > 0);
                 Sogcr = sof3Table.getSoColumn()[rowIdx - 1];

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -63,19 +63,19 @@ public:
         else
             satnum = &eclState->getIntGridProperty("SATNUM")->getData();
 
-        retrieveGridPropertyData_(&swl, deck, eclState, kwPrefix+"SWL");
-        retrieveGridPropertyData_(&sgl, deck, eclState, kwPrefix+"SGL");
-        retrieveGridPropertyData_(&swcr, deck, eclState, kwPrefix+"SWCR");
-        retrieveGridPropertyData_(&sgcr, deck, eclState, kwPrefix+"SGCR");
-        retrieveGridPropertyData_(&sowcr, deck, eclState, kwPrefix+"SOWCR");
-        retrieveGridPropertyData_(&sogcr, deck, eclState, kwPrefix+"SOGCR");
-        retrieveGridPropertyData_(&swu, deck, eclState, kwPrefix+"SWU");
-        retrieveGridPropertyData_(&sgu, deck, eclState, kwPrefix+"SGU");
-        retrieveGridPropertyData_(&pcw, deck, eclState, kwPrefix+"PCW");
-        retrieveGridPropertyData_(&pcg, deck, eclState, kwPrefix+"PCG");
-        retrieveGridPropertyData_(&krw, deck, eclState, kwPrefix+"KRW");
-        retrieveGridPropertyData_(&kro, deck, eclState, kwPrefix+"KRO");
-        retrieveGridPropertyData_(&krg, deck, eclState, kwPrefix+"KRG");
+        retrieveGridPropertyData_(&swl, eclState, kwPrefix+"SWL");
+        retrieveGridPropertyData_(&sgl, eclState, kwPrefix+"SGL");
+        retrieveGridPropertyData_(&swcr, eclState, kwPrefix+"SWCR");
+        retrieveGridPropertyData_(&sgcr, eclState, kwPrefix+"SGCR");
+        retrieveGridPropertyData_(&sowcr, eclState, kwPrefix+"SOWCR");
+        retrieveGridPropertyData_(&sogcr, eclState, kwPrefix+"SOGCR");
+        retrieveGridPropertyData_(&swu, eclState, kwPrefix+"SWU");
+        retrieveGridPropertyData_(&sgu, eclState, kwPrefix+"SGU");
+        retrieveGridPropertyData_(&pcw, eclState, kwPrefix+"PCW");
+        retrieveGridPropertyData_(&pcg, eclState, kwPrefix+"PCG");
+        retrieveGridPropertyData_(&krw, eclState, kwPrefix+"KRW");
+        retrieveGridPropertyData_(&kro, eclState, kwPrefix+"KRO");
+        retrieveGridPropertyData_(&krg, eclState, kwPrefix+"KRG");
     }
 #endif
 
@@ -100,7 +100,6 @@ private:
     // this method makes sure that a grid property is not created if it is not explicitly
     // mentioned in the deck. (saves memory.)
     void retrieveGridPropertyData_(const DoubleData **data,
-                                   Opm::DeckConstPtr deck,
                                    Opm::EclipseStateConstPtr eclState,
                                    const std::string& properyName)
     {

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -108,6 +108,9 @@ public:
     template <class Container, class FluidState>
     static void capillaryPressures(Container &values, const Params &params, const FluidState &fs)
     {
+        static_cast<void>(values);
+        static_cast<void>(params);
+        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The capillaryPressures(fs) method is not yet implemented");
     }
@@ -125,6 +128,9 @@ public:
     template <class Container, class FluidState>
     static void relativePermeabilities(Container &values, const Params &params, const FluidState &fs)
     {
+        static_cast<void>(values);
+        static_cast<void>(params);
+        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The pcnw(fs) method is not yet implemented");
     }
@@ -143,6 +149,8 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation pcnw(const Params &params, const FluidState &fs)
     {
+        static_cast<void>(params);
+        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The pcnw(fs) method is not yet implemented");
     }
@@ -169,6 +177,9 @@ public:
     template <class Container, class FluidState>
     static void saturations(Container &values, const Params &params, const FluidState &fs)
     {
+        static_cast<void>(values);
+        static_cast<void>(params);
+        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The saturations(fs) method is not yet implemented");
     }
@@ -180,6 +191,8 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sw(const Params &params, const FluidState &fs)
     {
+        static_cast<void>(params);
+        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The Sw(fs) method is not yet implemented");
     }
@@ -187,6 +200,8 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatSw(const Params &params, const Evaluation& pc)
     {
+        static_cast<void>(params);
+        static_cast<void>(pc);
         OPM_THROW(NotAvailable,
                   "The twoPhaseSatSw(pc) method is not yet implemented");
     }
@@ -198,6 +213,8 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sn(const Params &params, const FluidState &fs)
     {
+        static_cast<void>(params);
+        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The Sn(pc) method is not yet implemented");
     }
@@ -205,6 +222,8 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatSn(const Params &params, const Evaluation& pc)
     {
+        static_cast<void>(params);
+        static_cast<void>(pc);
         OPM_THROW(NotAvailable,
                   "The twoPhaseSatSn(pc) method is not yet implemented");
     }
@@ -221,6 +240,8 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation krw(const Params &params, const FluidState &fs)
     {
+        static_cast<void>(params);
+        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The krw(fs) method is not yet implemented");
     }
@@ -247,6 +268,8 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation krn(const Params &params, const FluidState &fs)
     {
+        static_cast<void>(params);
+        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The krn(fs) method is not yet implemented");
     }

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -97,7 +97,9 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container &values, const Params &params, const FluidState &fs)
+    static void capillaryPressures(Container& /* values */,
+                                   const Params& /* params */,
+                                   const FluidState& /* fs */)
     {
         OPM_THROW(NotAvailable,
                   "The capillaryPressures(fs) method is not yet implemented");
@@ -114,7 +116,9 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container &values, const Params &params, const FluidState &fs)
+    static void relativePermeabilities(Container& /* values */,
+                                       const Params& /* params */,
+                                       const FluidState& /* fs */)
     {
         OPM_THROW(NotAvailable,
                   "The pcnw(fs) method is not yet implemented");
@@ -132,7 +136,8 @@ public:
      *         Genuchten, linear...)
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fs)
+    static Evaluation pcnw(const Params& /* params */,
+                           const FluidState& /* fs */)
     {
         OPM_THROW(NotAvailable,
                   "The pcnw(fs) method is not yet implemented");
@@ -161,7 +166,9 @@ public:
      * \brief The saturation-capillary pressure curves.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &values, const Params &params, const FluidState &fs)
+    static void saturations(Container& /* values */,
+                            const Params& /* params */,
+                            const FluidState& /* fs */)
     {
         OPM_THROW(NotAvailable,
                   "The saturations(fs) method is not yet implemented");
@@ -172,14 +179,16 @@ public:
      *        the rest of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fs)
+    static Evaluation Sw(const Params& /* params */,
+                         const FluidState& /* fs */)
     {
         OPM_THROW(NotAvailable,
                   "The Sw(fs) method is not yet implemented");
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &params, const Evaluation& pc)
+    static Evaluation twoPhaseSatSw(const Params& /* params */,
+                                    const Evaluation& /* pc */)
     {
         OPM_THROW(NotAvailable,
                   "The twoPhaseSatSw(pc) method is not yet implemented");
@@ -190,14 +199,16 @@ public:
      *        the rest of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fs)
+    static Evaluation Sn(const Params& /* params */,
+                         const FluidState& /* fs */)
     {
         OPM_THROW(NotAvailable,
                   "The Sn(pc) method is not yet implemented");
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params &params, const Evaluation& pc)
+    static Evaluation twoPhaseSatSn(const Params& /* params */,
+                                    const Evaluation& /* pc */)
     {
         OPM_THROW(NotAvailable,
                   "The twoPhaseSatSn(pc) method is not yet implemented");
@@ -213,7 +224,8 @@ public:
      *
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fs)
+    static Evaluation krw(const Params& /* params */,
+                          const FluidState& /* fs */)
     {
         OPM_THROW(NotAvailable,
                   "The krw(fs) method is not yet implemented");
@@ -240,7 +252,8 @@ public:
      * \brief The relative permeability of the non-wetting phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fs)
+    static Evaluation krn(const Params& /* params */,
+                          const FluidState& /* fs */)
     {
         OPM_THROW(NotAvailable,
                   "The krn(fs) method is not yet implemented");

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -101,8 +101,8 @@ public:
      * \brief Sets the parameters used for the drainage curve
      */
     void setDrainageParams(std::shared_ptr<EffLawParams> value,
-                           const EclEpsScalingPointsInfo<Scalar>& info,
-                           EclTwoPhaseSystemType twoPhaseSystem)
+                           const EclEpsScalingPointsInfo<Scalar>& /* info */,
+                           EclTwoPhaseSystemType /* twoPhaseSystem */)
 
     {
         drainageParams_ = *value;
@@ -133,8 +133,8 @@ public:
      * \brief Sets the parameters used for the imbibition curve
      */
     void setImbibitionParams(std::shared_ptr<EffLawParams> value,
-                             const EclEpsScalingPointsInfo<Scalar>& info,
-                             EclTwoPhaseSystemType twoPhaseSystem)
+                             const EclEpsScalingPointsInfo<Scalar>& /* info */,
+                             EclTwoPhaseSystemType /* twoPhaseSystem */)
     {
         imbibitionParams_ = *value;
 
@@ -177,7 +177,7 @@ public:
      *        drainage curve (MDC) to imbibition happend on the relperm curve for the
      *        wetting phase.
      */
-    void setKrwSwMdc(Scalar value)
+    void setKrwSwMdc(Scalar /* value */)
     {}
     //    { krwSwMdc_ = value; };
 
@@ -213,7 +213,7 @@ public:
      * This means that krw(Sw) = krw_drainage(Sw) if Sw < SwMdc and
      * krw(Sw) = krw_imbibition(Sw + Sw_shift,krw) else
      */
-    void setDeltaSwImbKrw(Scalar value)
+    void setDeltaSwImbKrw(Scalar /* value */)
     {}
     //    { deltaSwImbKrw_ = value; }
 
@@ -274,7 +274,7 @@ public:
      * This updates the scanning curves and the imbibition<->drainage reversal points as
      * appropriate.
      */
-    void update(Scalar pcSw, Scalar krwSw, Scalar krnSw)
+    void update(Scalar pcSw, Scalar /* krwSw */, Scalar krnSw)
     {
         bool updateParams = false;
         if (pcSw < pcSwMdc_) {

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -106,18 +106,6 @@ public:
 
     {
         drainageParams_ = *value;
-
-#if 0
-        if (twoPhaseSystem == EclGasOilSystem) {
-            Sncrd_ = info.Sgcr;
-            Snmaxd_ = 1 - info.Sogcr;
-        }
-        else {
-            assert(twoPhaseSystem == EclOilWaterSystem);
-            Sncrd_ = info.Sowcr;
-            Snmaxd_ = 1 - info.Swcr;
-        }
-#endif
     }
 
     /*!
@@ -247,26 +235,6 @@ public:
      */
     Scalar deltaSwImbKrn() const
     { return deltaSwImbKrn_; }
-
-#if 0
-    /*!
-     * \brief Sets the "trapped" non-wetting phase saturation.
-     *
-     * This quantity is used for capillary pressure hysteresis. How it should be
-     * calculated depends on the hysteresis model.
-     */
-    void setSncrt(Scalar value)
-    { Sncrt_ = value; }
-
-    /*!
-     * \brief Returns the "trapped" non-wetting phase saturation.
-     *
-     * This quantity is used for capillary pressure hysteresis. How it should be
-     * calculated depends on the hysteresis model.
-     */
-    Scalar Sncrt() const
-    { return Sncrt_; }
-#endif
 
     /*!
      * \brief Notify the hysteresis law that a given wetting-phase saturation has been seen

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -380,7 +380,7 @@ private:
         }
 
         materialLawParams_.resize(numCompressedElems);
-        for (int elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
+        for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
             int satnumRegionIdx = satnumRegionIdx_[elemIdx];
             materialLawParams_[elemIdx] = satRegionParams[satnumRegionIdx];
         }
@@ -800,8 +800,8 @@ private:
     template <class Container>
     void readGasOilUnscaledPoints_(Container &dest,
                                    std::shared_ptr<EclEpsConfig> config,
-                                   Opm::DeckConstPtr deck,
-                                   Opm::EclipseStateConstPtr eclState,
+                                   Opm::DeckConstPtr /* deck */,
+                                   Opm::EclipseStateConstPtr /* eclState */,
                                    int satnumRegionIdx)
     {
         dest[satnumRegionIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
@@ -811,8 +811,8 @@ private:
     template <class Container>
     void readOilWaterUnscaledPoints_(Container &dest,
                                      std::shared_ptr<EclEpsConfig> config,
-                                     Opm::DeckConstPtr deck,
-                                     Opm::EclipseStateConstPtr eclState,
+                                     Opm::DeckConstPtr /* deck */,
+                                     Opm::EclipseStateConstPtr /* eclState */,
                                      int satnumRegionIdx)
     {
         dest[satnumRegionIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -118,7 +118,7 @@ public:
         compressedToCartesianElemIdx_ = compressedToCartesianElemIdx;
         // get the number of saturation regions and the number of cells in the deck
         int numSatRegions = deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0);
-        unsigned numCompressedElems = compressedToCartesianElemIdx.size();;
+        int numCompressedElems = compressedToCartesianElemIdx.size();
 
         // copy the SATNUM grid property. in some cases this is not necessary, but it
         // should not require much memory anyway...
@@ -332,7 +332,7 @@ private:
         OilWaterParamVector oilWaterParams(numSatRegions);
         MaterialLawParamsVector satRegionParams(numSatRegions);
         EclEpsScalingPointsInfo<Scalar> dummyInfo;
-        for (int satnumRegionIdx = 0; satnumRegionIdx < numSatRegions; ++satnumRegionIdx) {
+        for (size_t satnumRegionIdx = 0; satnumRegionIdx < numSatRegions; ++satnumRegionIdx) {
             // the parameters for the effective two-phase matererial laws
             readGasOilEffectiveParameters_(gasOilEffectiveParamVector, deck, eclState, satnumRegionIdx);
             readOilWaterEffectiveParameters_(oilWaterEffectiveParamVector, deck, eclState, satnumRegionIdx);
@@ -512,24 +512,24 @@ private:
             if (enableHysteresis()) {
                 int imbRegionIdx = imbnumData[elemIdx] - 1;
 
-                auto gasOilImbParams = std::make_shared<GasOilEpsTwoPhaseParams>();
-                gasOilImbParams->setConfig(gasOilConfig);
-                gasOilImbParams->setUnscaledPoints(gasOilUnscaledPointsVector[imbRegionIdx]);
-                gasOilImbParams->setScaledPoints(gasOilScaledImbPointsVector[elemIdx]);
-                gasOilImbParams->setEffectiveLawParams(gasOilEffectiveParamVector[imbRegionIdx]);
-                gasOilImbParams->finalize();
+                auto gasOilImbParamsHyst = std::make_shared<GasOilEpsTwoPhaseParams>();
+                gasOilImbParamsHyst->setConfig(gasOilConfig);
+                gasOilImbParamsHyst->setUnscaledPoints(gasOilUnscaledPointsVector[imbRegionIdx]);
+                gasOilImbParamsHyst->setScaledPoints(gasOilScaledImbPointsVector[elemIdx]);
+                gasOilImbParamsHyst->setEffectiveLawParams(gasOilEffectiveParamVector[imbRegionIdx]);
+                gasOilImbParamsHyst->finalize();
 
-                auto oilWaterImbParams = std::make_shared<OilWaterEpsTwoPhaseParams>();
-                oilWaterImbParams->setConfig(oilWaterConfig);
-                oilWaterImbParams->setUnscaledPoints(oilWaterUnscaledPointsVector[imbRegionIdx]);
-                oilWaterImbParams->setScaledPoints(oilWaterScaledImbPointsVector[elemIdx]);
-                oilWaterImbParams->setEffectiveLawParams(oilWaterEffectiveParamVector[imbRegionIdx]);
-                oilWaterImbParams->finalize();
+                auto oilWaterImbParamsHyst = std::make_shared<OilWaterEpsTwoPhaseParams>();
+                oilWaterImbParamsHyst->setConfig(oilWaterConfig);
+                oilWaterImbParamsHyst->setUnscaledPoints(oilWaterUnscaledPointsVector[imbRegionIdx]);
+                oilWaterImbParamsHyst->setScaledPoints(oilWaterScaledImbPointsVector[elemIdx]);
+                oilWaterImbParamsHyst->setEffectiveLawParams(oilWaterEffectiveParamVector[imbRegionIdx]);
+                oilWaterImbParamsHyst->finalize();
 
-                gasOilParams[elemIdx]->setImbibitionParams(gasOilImbParams,
+                gasOilParams[elemIdx]->setImbibitionParams(gasOilImbParamsHyst,
                                                                *gasOilScaledImbInfoVector[elemIdx],
                                                                EclGasOilSystem);
-                oilWaterParams[elemIdx]->setImbibitionParams(oilWaterImbParams,
+                oilWaterParams[elemIdx]->setImbibitionParams(oilWaterImbParamsHyst,
                                                                  *gasOilScaledImbInfoVector[elemIdx],
                                                                  EclGasOilSystem);
             }
@@ -854,7 +854,7 @@ private:
     }
 
     void initThreePhaseParams_(Opm::DeckConstPtr deck,
-                               Opm::EclipseStateConstPtr eclState,
+                               Opm::EclipseStateConstPtr /* eclState */,
                                MaterialLawParams& materialParams,
                                int satnumIdx,
                                const EclEpsScalingPointsInfo<Scalar>& epsInfo,

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -167,8 +167,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcgn(const Params &params,
-                           const FluidState &fs)
+    static Evaluation pcgn(const Params& /* params */,
+                           const FluidState& /* fs */)
     {
         OPM_THROW(std::logic_error, "Not implemented: pcgn()");
     }
@@ -183,8 +183,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params,
-                           const FluidState &fs)
+    static Evaluation pcnw(const Params& /* params */,
+                           const FluidState& /* fs */)
     {
         OPM_THROW(std::logic_error, "Not implemented: pcnw()");
     }
@@ -193,9 +193,9 @@ public:
      * \brief The inverse of the capillary pressure
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &values,
-                            const Params &params,
-                            const FluidState &fs)
+    static void saturations(ContainerT& /* values */,
+                            const Params& /* params */,
+                            const FluidState& /* fs */)
     {
         OPM_THROW(std::logic_error, "Not implemented: saturations()");
     }
@@ -204,8 +204,8 @@ public:
      * \brief The saturation of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sg(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sg(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sg()");
     }
@@ -214,8 +214,8 @@ public:
      * \brief The saturation of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sn(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sn()");
     }
@@ -224,8 +224,8 @@ public:
      * \brief The saturation of the wetting (i.e., water) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sw(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sw()");
     }
@@ -281,8 +281,8 @@ public:
      * \brief The relative permeability of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krg(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krg(const Params& /* params */,
+                          const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: krg()");
     }
@@ -291,8 +291,8 @@ public:
      * \brief The relative permeability of the wetting phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krw(const Params& /* params */,
+                          const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: krw()");
     }
@@ -301,8 +301,8 @@ public:
      * \brief The relative permeability of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krn(const Params& /* params */,
+                          const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: krn()");
     }

--- a/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
@@ -191,9 +191,9 @@ public:
      * \brief The inverse of the capillary pressure
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &values,
-                            const Params &params,
-                            const FluidState &fs)
+    static void saturations(ContainerT& /* values */,
+                            const Params& /* params */,
+                            const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: saturations()");
     }
@@ -202,8 +202,8 @@ public:
      * \brief The saturation of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sg(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sg(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sg()");
     }
@@ -212,8 +212,8 @@ public:
      * \brief The saturation of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sn(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sn()");
     }
@@ -222,8 +222,8 @@ public:
      * \brief The saturation of the wetting (i.e., water) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sw(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sw()");
     }

--- a/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
@@ -190,9 +190,9 @@ public:
      * \brief The inverse of the capillary pressure
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &values,
-                            const Params &params,
-                            const FluidState &fs)
+    static void saturations(ContainerT& /*values */,
+                            const Params& /* params */,
+                            const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: saturations()");
     }
@@ -201,8 +201,8 @@ public:
      * \brief The saturation of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sg(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sg(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sg()");
     }
@@ -211,8 +211,8 @@ public:
      * \brief The saturation of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sn(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sn()");
     }
@@ -221,8 +221,8 @@ public:
      * \brief The saturation of the wetting (i.e., water) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sw(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sw()");
     }

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -170,8 +170,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcgn(const Params &params,
-                           const FluidState &fs)
+    static Evaluation pcgn(const Params& /* params */,
+                           const FluidState& /* fs */)
     {
         OPM_THROW(std::logic_error, "Not implemented: pcgn()");
     }
@@ -186,8 +186,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params,
-                           const FluidState &fs)
+    static Evaluation pcnw(const Params& /* params */,
+                           const FluidState& /* fs */)
     {
         OPM_THROW(std::logic_error, "Not implemented: pcnw()");
     }
@@ -196,9 +196,9 @@ public:
      * \brief The inverse of the capillary pressure
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &values,
-                            const Params &params,
-                            const FluidState &fs)
+    static void saturations(ContainerT& /* values */,
+                            const Params& /* params */,
+                            const FluidState& /* fs */)
     {
         OPM_THROW(std::logic_error, "Not implemented: saturations()");
     }
@@ -207,8 +207,8 @@ public:
      * \brief The saturation of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sg(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sg(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sg()");
     }
@@ -217,8 +217,8 @@ public:
      * \brief The saturation of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sn(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sn()");
     }
@@ -227,8 +227,8 @@ public:
      * \brief The saturation of the wetting (i.e., water) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sw(const Params& /* params */,
+                         const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: Sw()");
     }
@@ -290,8 +290,8 @@ public:
      * \brief The relative permeability of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krg(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krg(const Params& /* params */,
+                          const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: krg()");
     }
@@ -300,8 +300,8 @@ public:
      * \brief The relative permeability of the wetting phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krw(const Params& /* params */,
+                          const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: krw()");
     }
@@ -310,8 +310,8 @@ public:
      * \brief The relative permeability of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krn(const Params& /* params */,
+                          const FluidState& /* fluidState */)
     {
         OPM_THROW(std::logic_error, "Not implemented: krn()");
     }

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -109,7 +109,7 @@ public:
      *        pressure differences.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &values, const Params &params, const FluidState &fs)
+    static void saturations(Container& /* values */, const Params& /* params */, const FluidState& /* fs */)
     { OPM_THROW(std::logic_error, "Not implemented: saturations()"); }
 
     /*!
@@ -152,11 +152,11 @@ public:
      * \brief The saturation-capillary pressure curve
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fs)
+    static Evaluation Sw(const Params& /* params */, const FluidState& /* fs */)
     { OPM_THROW(std::logic_error, "Not implemented: Sw()"); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &params, const Evaluation& pC)
+    static Evaluation twoPhaseSatSw(const Params& /* params */, const Evaluation& /* pC */)
     { OPM_THROW(std::logic_error, "Not implemented: twoPhaseSatSw()"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStateCompositionModules.hpp
+++ b/opm/material/fluidstates/FluidStateCompositionModules.hpp
@@ -229,7 +229,7 @@ public:
      *        state.
      */
     template <class FluidState>
-    void assign(const FluidState& fs)
+    void assign(const FluidState& /* fs */)
     { }
 
     /*!
@@ -264,13 +264,13 @@ public:
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    Scalar moleFraction(int phaseIdx, int compIdx) const
+    Scalar moleFraction(int /* phaseIdx */, int /* compIdx */) const
     { OPM_THROW(std::logic_error, "Mole fractions are not provided by this fluid state"); }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
-    Scalar massFraction(int phaseIdx, int compIdx) const
+    Scalar massFraction(int /* phaseIdx */, int /* compIdx */) const
     { OPM_THROW(std::logic_error, "Mass fractions are not provided by this fluid state"); }
 
     /*!
@@ -281,7 +281,7 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    Scalar averageMolarMass(int phaseIdx) const
+    Scalar averageMolarMass(int /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Mean molar masses are not provided by this fluid state"); }
 
     /*!
@@ -293,7 +293,7 @@ public:
      *
      * http://en.wikipedia.org/wiki/Concentration
      */
-    Scalar molarity(int phaseIdx, int compIdx) const
+    Scalar molarity(int /* phaseIdx */, int /* compIdx */) const
     { OPM_THROW(std::logic_error, "Molarities are not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStateDensityModules.hpp
+++ b/opm/material/fluidstates/FluidStateDensityModules.hpp
@@ -123,19 +123,19 @@ public:
     /*!
      * \brief The density of a fluid phase [kg/m^3]
      */
-    const Scalar& density(int phaseIdx) const
+    const Scalar& density(int /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Density is not provided by this fluid state"); }
 
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
-    Scalar molarDensity(int phaseIdx) const
+    Scalar molarDensity(int /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Molar density is not provided by this fluid state"); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
-    Scalar molarVolume(int phaseIdx) const
+    Scalar molarVolume(int /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Molar volume is not provided by this fluid state"); }
 
     /*!
@@ -143,7 +143,7 @@ public:
      *        state.
      */
     template <class FluidState>
-    void assign(const FluidState& fs)
+    void assign(const FluidState& /* fs */)
     { }
 
     /*!

--- a/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
+++ b/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
@@ -117,7 +117,7 @@ public:
     /*!
      * \brief The specific internal energy of a fluid phase [J/kg]
      */
-    const Scalar& internalEnergy(int phaseIdx) const
+    const Scalar& internalEnergy(int /* phaseIdx */) const
     {
         static Scalar tmp = 0;
         Valgrind::SetUndefined(tmp);
@@ -127,7 +127,7 @@ public:
     /*!
      * \brief The specific enthalpy of a fluid phase [J/kg]
      */
-    const Scalar& enthalpy(int phaseIdx) const
+    const Scalar& enthalpy(int /* phaseIdx */) const
     {
         static Scalar tmp = 0;
         Valgrind::SetUndefined(tmp);
@@ -139,7 +139,7 @@ public:
      *        state.
      */
     template <class FluidState>
-    void assign(const FluidState& fs)
+    void assign(const FluidState& /* fs */)
     { }
 
     /*!

--- a/opm/material/fluidstates/FluidStateFugacityModules.hpp
+++ b/opm/material/fluidstates/FluidStateFugacityModules.hpp
@@ -185,13 +185,13 @@ public:
     /*!
      * \brief The fugacity coefficient of a component in a phase []
      */
-    const Scalar& fugacityCoefficient(int phaseIdx, int compIdx) const
+    const Scalar& fugacityCoefficient(int /* phaseIdx */, int /* compIdx */) const
     { OPM_THROW(std::logic_error, "Fugacity coefficients are not provided by this fluid state"); }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
-    const Scalar& fugacity(int phaseIdx, int compIdx) const
+    const Scalar& fugacity(int /* phaseIdx */, int /* compIdx */) const
     { OPM_THROW(std::logic_error, "Fugacities coefficients are not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStatePressureModules.hpp
+++ b/opm/material/fluidstates/FluidStatePressureModules.hpp
@@ -106,7 +106,7 @@ public:
     /*!
      * \brief The pressure of a fluid phase [Pa]
      */
-    const Scalar& pressure(int phaseIdx) const
+    const Scalar& pressure(int /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Pressure is not provided by this fluid state"); }
 
 
@@ -115,7 +115,7 @@ public:
      *        state.
      */
     template <class FluidState>
-    void assign(const FluidState& fs)
+    void assign(const FluidState& /* fs */)
     { }
 
     /*!

--- a/opm/material/fluidstates/FluidStateSaturationModules.hpp
+++ b/opm/material/fluidstates/FluidStateSaturationModules.hpp
@@ -106,7 +106,7 @@ public:
     /*!
      * \brief The saturation of a fluid phase [-]
      */
-    const Scalar& saturation(int phaseIdx) const
+    const Scalar& saturation(int /* phaseIdx */) const
     { OPM_THROW(std::runtime_error, "Saturation is not provided by this fluid state"); }
 
     /*!
@@ -114,7 +114,7 @@ public:
      *        state.
      */
     template <class FluidState>
-    void assign(const FluidState& fs)
+    void assign(const FluidState& /* fs */)
     { }
 
     /*!

--- a/opm/material/fluidstates/FluidStateTemperatureModules.hpp
+++ b/opm/material/fluidstates/FluidStateTemperatureModules.hpp
@@ -108,7 +108,7 @@ public:
     /*!
      * \brief The temperature of a fluid phase [-]
      */
-    Scalar temperature(int phaseIdx) const
+    Scalar temperature(int /* phaseIdx */) const
     { return temperature_; }
 
     /*!
@@ -168,7 +168,7 @@ public:
     /*!
      * \brief The temperature of a fluid phase [-]
      */
-    Scalar temperature(int phaseIdx) const
+    Scalar temperature(int /* phaseIdx */) const
     { OPM_THROW(std::runtime_error, "Temperature is not provided by this fluid state"); }
 
     /*!
@@ -176,7 +176,7 @@ public:
      *        state.
      */
     template <class FluidState>
-    void assign(const FluidState& fs)
+    void assign(const FluidState& /* fs */)
     { }
 
     /*!

--- a/opm/material/fluidstates/FluidStateViscosityModules.hpp
+++ b/opm/material/fluidstates/FluidStateViscosityModules.hpp
@@ -108,7 +108,7 @@ public:
     /*!
      * \brief The viscosity of a fluid phase [-]
      */
-    Scalar viscosity(int phaseIdx) const
+    Scalar viscosity(int /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Viscosity is not provided by this fluid state"); }
 
     /*!
@@ -116,7 +116,7 @@ public:
      *        state.
      */
     template <class FluidState>
-    void assign(const FluidState& fs)
+    void assign(const FluidState& /* fs */)
     { }
 
     /*!

--- a/opm/material/localad/Evaluation.hpp
+++ b/opm/material/localad/Evaluation.hpp
@@ -297,13 +297,13 @@ public:
 
     bool isSame(const Evaluation& other, Scalar tolerance) const
     {
-        Scalar tmp = other.value - other.value;
-        if (std::abs(tmp) > tolerance && std::abs(tmp)/tolerance > 1.0)
+        Scalar value_diff = other.value - other.value;
+        if (std::abs(value_diff) > tolerance && std::abs(value_diff)/tolerance > 1.0)
             return false;
 
         for (int varIdx= 0; varIdx < size; ++varIdx) {
-            Scalar tmp = other.derivatives[varIdx] - this->derivatives[varIdx];
-            if (std::abs(tmp) > tolerance && std::abs(tmp)/tolerance > 1.0)
+            Scalar deriv_diff = other.derivatives[varIdx] - this->derivatives[varIdx];
+            if (std::abs(deriv_diff) > tolerance && std::abs(deriv_diff)/tolerance > 1.0)
                 return false;
         }
 

--- a/tests/test_2dtables.cpp
+++ b/tests/test_2dtables.cpp
@@ -36,10 +36,10 @@
 
 typedef double Scalar;
 
-Scalar testFn1(Scalar x, Scalar y)
+Scalar testFn1(Scalar x, Scalar /* y */)
 { return x; }
 
-Scalar testFn2(Scalar x, Scalar y)
+Scalar testFn2(Scalar /* x */, Scalar y)
 { return y; }
 
 Scalar testFn3(Scalar x, Scalar y)


### PR DESCRIPTION
This should only silence warnings (mostly unused argument), and not make any functional changes.
(Checked that it compiles and runs with SPE9.)