### PR TITLE
Table container

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -183,12 +183,12 @@ struct EclEpsScalingPointsInfo
     {
         // TODO: support for the SOF2/SOF3 keyword family
         auto tables = eclState->getTableManager();
-        const std::vector<SwofTable>& swofTables = tables->getSwofTables();
-        const std::vector<SgofTable>& sgofTables = tables->getSgofTables();
-        const std::vector<SlgofTable>& slgofTables = tables->getSlgofTables();
-        const std::vector<SwfnTable>& swfnTables = tables->getSwfnTables();
-        const std::vector<SgfnTable>& sgfnTables = tables->getSgfnTables();
-        const std::vector<Sof3Table>& sof3Tables = tables->getSof3Tables();
+        const TableContainer&  swofTables = tables->getSwofTables();
+        const TableContainer&  sgofTables = tables->getSgofTables();
+        const TableContainer& slgofTables = tables->getSlgofTables();
+        const TableContainer&  swfnTables = tables->getSwfnTables();
+        const TableContainer&  sgfnTables = tables->getSgfnTables();
+        const TableContainer&  sof3Tables = tables->getSof3Tables();
 
         bool hasWater = deck->hasKeyword("WATER");
         bool hasGas = deck->hasKeyword("GAS");
@@ -199,10 +199,10 @@ struct EclEpsScalingPointsInfo
             Swu = 0.0;
             Swcr = 0.0;
             if (!sgofTables.empty())
-                extractUnscaledSgof_(sgofTables[satRegionIdx]);
+                extractUnscaledSgof_(sgofTables.getTable<SgofTable>(satRegionIdx));
             else {
                 assert(!slgofTables.empty());
-                extractUnscaledSlgof_(slgofTables[satRegionIdx]);
+                extractUnscaledSlgof_(slgofTables.getTable<SlgofTable>(satRegionIdx));
             }
             return;
         }
@@ -211,7 +211,7 @@ struct EclEpsScalingPointsInfo
             Sgl = 0.0;
             Sgu = 0.0;
             Sgcr = 0.0;
-            extractUnscaledSwof_(swofTables[satRegionIdx]);
+            extractUnscaledSwof_(swofTables.getTable<SwofTable>(satRegionIdx));
             return;
         }
 
@@ -224,26 +224,26 @@ struct EclEpsScalingPointsInfo
         bool family2 = !swfnTables.empty() && !sgfnTables.empty() && !sof3Tables.empty();
 
         if (family1) {
-            extractUnscaledSwof_(swofTables[satRegionIdx]);
+            extractUnscaledSwof_(swofTables.getTable<SwofTable>(satRegionIdx));
 
             if (!sgofTables.empty()) {
                 // gas-oil parameters are specified using the SGOF keyword
-                extractUnscaledSgof_(sgofTables[satRegionIdx]);
+                extractUnscaledSgof_(sgofTables.getTable<SgofTable>(satRegionIdx));
             }
             else {
                 // gas-oil parameters are specified using the SLGOF keyword
                 assert(!slgofTables.empty());
 
-                extractUnscaledSlgof_(slgofTables[satRegionIdx]);
+                extractUnscaledSlgof_(slgofTables.getTable<SlgofTable>(satRegionIdx));
             }
         }
         else if (family2) {
-            extractUnscaledSwfn_(swfnTables[satRegionIdx]);
-            extractUnscaledSgfn_(sgfnTables[satRegionIdx]);
-            extractUnscaledSof3_(sof3Tables[satRegionIdx]);
+            extractUnscaledSwfn_(swfnTables.getTable<SwfnTable>(satRegionIdx));
+            extractUnscaledSgfn_(sgfnTables.getTable<SgfnTable>(satRegionIdx));
+            extractUnscaledSof3_(sof3Tables.getTable<Sof3Table>(satRegionIdx));
 
             // some safety checks mandated by the ECL documentation
-            assert(std::abs(Sowu - (1 - swfnTables[satRegionIdx].getSwColumn().front())) < 1e-30);
+            assert(std::abs(Sowu - (1 - swfnTables.getTable<SwfnTable>(satRegionIdx).getSwColumn().front())) < 1e-30);
             assert(std::abs(maxKrw - maxKrg) < 1e-30);
         }
         else {

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -493,12 +493,12 @@ private:
     SaturationFunctionFamily getSaturationFunctionFamily(Opm::EclipseStateConstPtr eclState) const
     {
         const auto& tableManager = eclState->getTableManager();
-        const std::vector<SwofTable>& swofTables = tableManager->getSwofTables();
-        const std::vector<SlgofTable>& slgofTables = tableManager->getSlgofTables();
-        const std::vector<SgofTable>& sgofTables = tableManager->getSgofTables();
-        const std::vector<SwfnTable>& swfnTables = tableManager->getSwfnTables();
-        const std::vector<SgfnTable>& sgfnTables = tableManager->getSgfnTables();
-        const std::vector<Sof3Table>& sof3Tables = tableManager->getSof3Tables();
+        const TableContainer& swofTables = tableManager->getSwofTables();
+        const TableContainer& slgofTables= tableManager->getSlgofTables();
+        const TableContainer& sgofTables = tableManager->getSgofTables();
+        const TableContainer& swfnTables = tableManager->getSwfnTables();
+        const TableContainer& sgfnTables = tableManager->getSgfnTables();
+        const TableContainer& sof3Tables = tableManager->getSof3Tables();
 
         bool family1 = (!sgofTables.empty() || !slgofTables.empty()) && !swofTables.empty();
         bool family2 = !swfnTables.empty() && !sgfnTables.empty() && !sof3Tables.empty();
@@ -542,15 +542,17 @@ private:
         // handle the twophase case
         const auto& tableManager = eclState->getTableManager();
         if (!hasWater) {
-            if (!tableManager->getSgofTables().empty())
+            const TableContainer& sgofTables  = tableManager->getSgofTables();
+            const TableContainer& slgofTables = tableManager->getSlgofTables();
+            if (!sgofTables.empty())
                 readGasOilEffectiveParametersSgof_(effParams,
                                                    Swco,
-                                                   tableManager->getSgofTables()[satnumIdx]);
+                                                   sgofTables.getTable<SgofTable>(satnumIdx));
             else {
-                assert(!tableManager->getSlgofTables().empty());
+                assert(!slgofTables.empty());
                 readGasOilEffectiveParametersSlgof_(effParams,
                                                     Swco,
-                                                    tableManager->getSlgofTables()[satnumIdx]);
+                                                    slgofTables.getTable<SlgofTable>(satnumIdx));
             }
 
             // Todo (?): support for twophase simulations using family2?
@@ -568,24 +570,27 @@ private:
         switch (getSaturationFunctionFamily(eclState)) {
         case FamilyI:
         {
-            if (!tableManager->getSgofTables().empty())
+            const TableContainer& sgofTables = tableManager->getSgofTables();
+            const TableContainer& slgofTables = tableManager->getSlgofTables();
+            if (!sgofTables.empty())
                 readGasOilEffectiveParametersSgof_(effParams,
                                                    Swco,
-                                                   tableManager->getSgofTables()[satnumIdx]);
-            else if (!tableManager->getSlgofTables().empty())
+                                                   sgofTables.getTable<SgofTable>(satnumIdx));
+            else if (!slgofTables.empty())
                 readGasOilEffectiveParametersSlgof_(effParams,
                                                     Swco,
-                                                    tableManager->getSlgofTables()[satnumIdx]);
-
+                                                    slgofTables.getTable<SlgofTable>(satnumIdx));
             break;
         }
 
         case FamilyII:
         {
+            const Sof3Table& sof3Table = tableManager->getSof3Tables().getTable<Sof3Table>( satnumIdx );
+            const SgfnTable& sgfnTable = tableManager->getSgfnTables().getTable<SgfnTable>( satnumIdx );
             readGasOilEffectiveParametersFamily2_(effParams,
                                                   Swco,
-                                                  tableManager->getSof3Tables()[satnumIdx],
-                                                  tableManager->getSgfnTables()[satnumIdx]);
+                                                  sof3Table,
+                                                  sgfnTable);
             break;
         }
 
@@ -670,7 +675,7 @@ private:
             return;
         }
         else if (!hasGas) {
-            const auto& swofTable = tableManager->getSwofTables()[satnumIdx];
+            const auto& swofTable = tableManager->getSwofTables().getTable<SwofTable>(satnumIdx);
             const auto &SwColumn = swofTable.getSwColumn();
 
             effParams.setKrwSamples(SwColumn, swofTable.getKrwColumn());
@@ -689,7 +694,7 @@ private:
 
         switch (getSaturationFunctionFamily(eclState)) {
         case FamilyI: {
-            const auto& swofTable = tableManager->getSwofTables()[satnumIdx];
+            const auto& swofTable = tableManager->getSwofTables().getTable<SwofTable>(satnumIdx);
             const auto &SwColumn = swofTable.getSwColumn();
 
             effParams.setKrwSamples(SwColumn, swofTable.getKrwColumn());
@@ -700,8 +705,8 @@ private:
         }
         case FamilyII:
         {
-            const auto& swfnTable = tableManager->getSwfnTables()[satnumIdx];
-            const auto& sof3Table = tableManager->getSof3Tables()[satnumIdx];
+            const auto& swfnTable = tableManager->getSwfnTables().getTable<SwfnTable>(satnumIdx);
+            const auto& sof3Table = tableManager->getSof3Tables().getTable<Sof3Table>(satnumIdx);
             const auto &SwColumn = swfnTable.getSwColumn();
 
             // convert the saturations of the SOF3 keyword from oil to water saturations

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -71,7 +71,7 @@ public:
 
             setReferenceDensities(regionIdx, rhoRefO, rhoRefG, rhoRefW);
 
-            const auto& pvdoTable = pvdoTables[regionIdx];
+            const auto& pvdoTable = pvdoTables.getTable<PvdoTable>(regionIdx);
 
             const auto& BColumn(pvdoTable.getFormationFactorColumn());
             std::vector<Scalar> invBColumn(BColumn.size());

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -88,7 +88,7 @@ public:
             // explicitly in the deck.
             setMolarMasses(regionIdx, MO, MG, MW);
 
-            const auto& pvdgTable = pvdgTables[regionIdx];
+            const auto& pvdgTable = pvdgTables.getTable<PvdgTable>(regionIdx);
 
             // say 99.97% of all time: "premature optimization is the root of all
             // evil". Eclipse does this "optimization" for apparently no good reason!


### PR DESCRIPTION
Followup to: OPM/opm-parser#585

Comments are welcome - but this should not be merged before the opm-parser PR is merged.

Two comments from working on this PR:

1. The tests in opm-material are not based on the BOOST unit test framework; any reason for that? 

2. The opm-material codebase is pure header only; in my opinion that means we must be even stricter with tests. For me the situation here was:
```txt
 1) Make incompatible changes to `opm-parser`.
 2) Build `opm-core` to find where  `opm-material` must be updated.
```

I.e. building `opm-material` gives nothing to verify the even most basic level of correctness in the code. I think that is unfortunate 

