### PR TITLE
Fix masochistic warnings

### DIFF
--- a/opm/material/binarycoefficients/Air_Mesitylene.hpp
+++ b/opm/material/binarycoefficients/Air_Mesitylene.hpp
@@ -43,7 +43,7 @@ public:
      *
      */
     template <class Evaluation>
-    static Evaluation henry(const Evaluation& temperature)
+    static Evaluation henry(const Evaluation& /*temperature*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Henry coefficient of air in mesitylene"); }
 
     /*!
@@ -93,7 +93,7 @@ public:
      * \brief Diffusion coefficent [m^2/s] for molecular mesitylene in liquid water.
      */
     template <class Evaluation>
-    static Evaluation liquidDiffCoeff(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDiffCoeff(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Binary liquid diffusion coefficients of air and mesitylene"); }
 };
 

--- a/opm/material/binarycoefficients/Air_Xylene.hpp
+++ b/opm/material/binarycoefficients/Air_Xylene.hpp
@@ -41,7 +41,7 @@ public:
      *
      */
     template <class Evaluation>
-    static Evaluation henry(const Evaluation& temperature)
+    static Evaluation henry(const Evaluation& /*temperature*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Henry coefficient of air in xylene"); }
 
     /*!
@@ -91,7 +91,7 @@ public:
      * \todo
      */
     template <class Evaluation>
-    static Evaluation liquidDiffCoeff(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDiffCoeff(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Binary liquid diffusion coefficients of air and xylene"); }
 };
 

--- a/opm/material/binarycoefficients/Brine_CO2.hpp
+++ b/opm/material/binarycoefficients/Brine_CO2.hpp
@@ -72,12 +72,10 @@ public:
      * \param pressure the phase pressure [Pa]
      */
     template <class Evaluation>
-    static Evaluation liquidDiffCoeff(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDiffCoeff(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-
         //Diffusion coefficient of CO2 in the brine phase
-        return Toolbox::createConstant(2e-9);
+        return 2e-9;
     }
 
     /*!

--- a/opm/material/binarycoefficients/H2O_Air.hpp
+++ b/opm/material/binarycoefficients/H2O_Air.hpp
@@ -104,7 +104,7 @@ public:
      * Vol. 12, No. 1, pp. 111-115, 1967
      */
     template <class Evaluation>
-    static Evaluation liquidDiffCoeff(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDiffCoeff(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         const double Texp = 273.15 + 25; // [K]
         const double Dexp = 2.01e-9; // [m^2/s]

--- a/opm/material/binarycoefficients/H2O_CO2.hpp
+++ b/opm/material/binarycoefficients/H2O_CO2.hpp
@@ -86,7 +86,7 @@ public:
      * \brief Diffusion coefficent [m^2/s] for molecular CO2 in liquid water.
      */
     template <class Scalar, class Evaluation = Scalar>
-    static Evaluation liquidDiffCoeff(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDiffCoeff(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Binary liquid diffusion coefficients of CO2 and CH4"); }
 };
 

--- a/opm/material/binarycoefficients/H2O_Mesitylene.hpp
+++ b/opm/material/binarycoefficients/H2O_Mesitylene.hpp
@@ -47,7 +47,7 @@ public:
      *  Sanders1999 Henry collection
      */
     template <class Evaluation>
-    static Evaluation henry(const Evaluation& temperature)
+    static Evaluation henry(const Evaluation& /*temperature*/)
     {
         // after Sanders
         double sanderH = 1.7e-1; // [M/atm]
@@ -103,7 +103,7 @@ public:
      * \brief Diffusion coefficent [m^2/s] for mesitylene in liquid water.
      */
     template <class Evaluation>
-    static Evaluation liquidDiffCoeff(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDiffCoeff(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     {
         // This is just an order of magnitude estimate. Please improve!
         return 1e-9;

--- a/opm/material/binarycoefficients/H2O_N2.hpp
+++ b/opm/material/binarycoefficients/H2O_N2.hpp
@@ -99,7 +99,7 @@ public:
      * Vol. 12, No. 1, pp. 111-115, 1967
      */
     template <class Evaluation>
-    static Evaluation liquidDiffCoeff(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDiffCoeff(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         const double Texp = 273.15 + 25; // [K]
         const double Dexp = 2.01e-9; // [m^2/s]

--- a/opm/material/binarycoefficients/H2O_Xylene.hpp
+++ b/opm/material/binarycoefficients/H2O_Xylene.hpp
@@ -46,7 +46,7 @@ public:
      */
 
     template <class Evaluation>
-    static Evaluation henry(const Evaluation& temperature)
+    static Evaluation henry(const Evaluation& /*temperature*/)
     {
         // after Sanders
         double sanderH = 1.5e-1;    //[M/atm]
@@ -102,7 +102,7 @@ public:
      * \todo
      */
     template <class Evaluation>
-    static Evaluation liquidDiffCoeff(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDiffCoeff(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     {
         return 1.e-9;  // This is just an order of magnitude. Please improve it!
     }

--- a/opm/material/common/PolynomialUtils.hpp
+++ b/opm/material/common/PolynomialUtils.hpp
@@ -50,7 +50,8 @@ int invertLinearPolynomial(SolContainer &sol,
                            Scalar a,
                            Scalar b)
 {
-    if (a == 0.0)
+    typedef MathToolbox<Scalar> Toolbox;
+    if (std::abs(Toolbox::value(a)) < 1e-30)
         return 0;
 
     sol[0] = -b/a;
@@ -82,7 +83,7 @@ int invertQuadraticPolynomial(SolContainer &sol,
     typedef MathToolbox<Scalar> Toolbox;
 
     // check for a line
-    if (a == 0.0)
+    if (std::abs(Toolbox::value(a)) < 1e-30)
         return invertLinearPolynomial(sol, b, c);
 
     // discriminant
@@ -118,7 +119,7 @@ void invertCubicPolynomialPostProcess_(SolContainer &sol,
         Scalar fOld = d + x*(c + x*(b + x*a));
 
         Scalar fPrime = c + x*(2*b + x*3*a);
-        if (fPrime == 0.0)
+        if (std::abs(Toolbox::value(fPrime)) < 1e-30)
             continue;
         x -= fOld/fPrime;
 
@@ -156,7 +157,7 @@ int invertCubicPolynomial(SolContainer *sol,
     typedef MathToolbox<Scalar> Toolbox;
 
     // reduces to a quadratic polynomial
-    if (a == 0)
+    if (std::abs(Toolbox::value(a)) < 1e-30)
         return invertQuadraticPolynomial(sol, b, c, d);
 
     // normalize the polynomial
@@ -169,7 +170,7 @@ int invertCubicPolynomial(SolContainer *sol,
     Scalar p = c - b*b/3;
     Scalar q = d + (2*b*b*b - 9*b*c)/27;
 
-    if (p != 0.0 && q != 0.0) {
+    if (std::abs(Toolbox::value(p)) > 1e-30 && std::abs(Toolbox::value(q)) > 1e-30) {
         // At this point
         //
         // t^3 + p*t + q = 0
@@ -279,12 +280,12 @@ int invertCubicPolynomial(SolContainer *sol,
     }
     // Handle some (pretty unlikely) special cases required to avoid
     // divisions by zero in the code above...
-    else if (p == 0.0 && q == 0.0) {
+    else if (std::abs(Toolbox::value(p)) < 1e-30 && std::abs(Toolbox::value(q)) < 1e-30) {
         // t^3 = 0, i.e. triple root at t = 0
         sol[0] = sol[1] = sol[2] = 0.0 - b/3;
         return 3;
     }
-    else if (p == 0.0 && q != 0.0) {
+    else if (std::abs(Toolbox::value(p)) < 1e-30 && std::abs(Toolbox::value(q)) > 1e-30) {
         // t^3 + q = 0,
         //
         // i. e. single real root at t=curt(q)
@@ -296,7 +297,7 @@ int invertCubicPolynomial(SolContainer *sol,
         return 1;
     }
 
-    assert(p != 0.0 && q == 0.0);
+    assert(std::abs(Toolbox::value(p)) > 1e-30 && std::abs(Toolbox::value(q)) > 1e-30);
 
     // t^3 + p*t = 0 = t*(t^2 + p),
     //

--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -136,7 +136,7 @@ public:
      * \param periodic Indicates whether a natural or a periodic spline should be created
      */
     template <class ScalarArrayX, class ScalarArrayY>
-    Spline(int nSamples,
+    Spline(size_t nSamples,
            const ScalarArrayX &x,
            const ScalarArrayY &y,
            SplineType splineType = Natural,
@@ -151,7 +151,7 @@ public:
      * \param periodic Indicates whether a natural or a periodic spline should be created
      */
     template <class PointArray>
-    Spline(int nSamples,
+    Spline(size_t nSamples,
            const PointArray &points,
            SplineType splineType = Natural,
            bool sortInputs = false)
@@ -194,7 +194,7 @@ public:
      * \param sortInputs Indicates whether the sample points should be sorted (this is not necessary if they are already sorted in ascending or descending order)
      */
     template <class ScalarArray>
-    Spline(int nSamples,
+    Spline(size_t nSamples,
            const ScalarArray &x,
            const ScalarArray &y,
            Scalar m0,
@@ -212,7 +212,7 @@ public:
      * \param sortInputs Indicates whether the sample points should be sorted (this is not necessary if they are already sorted in ascending or descending order)
      */
     template <class PointArray>
-    Spline(int nSamples,
+    Spline(size_t nSamples,
            const PointArray &points,
            Scalar m0,
            Scalar m1,
@@ -254,7 +254,7 @@ public:
     /*!
      * \brief Returns the number of sampling points.
      */
-    int numSamples() const
+    size_t numSamples() const
     { return xPos_.size(); }
 
     /*!
@@ -324,7 +324,7 @@ public:
      * sampling points must be larger than 1.
      */
     template <class ScalarArrayX, class ScalarArrayY>
-    void setXYArrays(int nSamples,
+    void setXYArrays(size_t nSamples,
                      const ScalarArrayX &x,
                      const ScalarArrayY &y,
                      Scalar m0, Scalar m1,
@@ -333,7 +333,7 @@ public:
         assert(nSamples > 1);
 
         setNumSamples_(nSamples);
-        for (int i = 0; i < nSamples; ++i) {
+        for (size_t i = 0; i < nSamples; ++i) {
             xPos_[i] = x[i];
             yPos_[i] = y[i];
         }
@@ -392,7 +392,7 @@ public:
      * the number of sampling points must be larger than 1.
      */
     template <class PointArray>
-    void setArrayOfPoints(int nSamples,
+    void setArrayOfPoints(size_t nSamples,
                           const PointArray &points,
                           Scalar m0,
                           Scalar m1,
@@ -403,7 +403,7 @@ public:
         assert(nSamples > 1);
 
         setNumSamples_(nSamples);
-        for (int i = 0; i < nSamples; ++i) {
+        for (size_t i = 0; i < nSamples; ++i) {
             xPos_[i] = points[i][0];
             yPos_[i] = points[i][1];
         }
@@ -441,7 +441,7 @@ public:
         setNumSamples_(points.size());
         typename XYContainer::const_iterator it = points.begin();
         typename XYContainer::const_iterator endIt = points.end();
-        for (int i = 0; it != endIt; ++i, ++it) {
+        for (size_t i = 0; it != endIt; ++i, ++it) {
             xPos_[i] = (*it)[0];
             yPos_[i] = (*it)[1];
         }
@@ -512,7 +512,7 @@ public:
      * sampling points must be larger than 1.
      */
     template <class ScalarArrayX, class ScalarArrayY>
-    void setXYArrays(int nSamples,
+    void setXYArrays(size_t nSamples,
                      const ScalarArrayX &x,
                      const ScalarArrayY &y,
                      SplineType splineType = Natural,
@@ -521,7 +521,7 @@ public:
         assert(nSamples > 1);
 
         setNumSamples_(nSamples);
-        for (int i = 0; i < nSamples; ++i) {
+        for (size_t i = 0; i < nSamples; ++i) {
             xPos_[i] = x[i];
             yPos_[i] = y[i];
         }
@@ -593,7 +593,7 @@ public:
      * the number of sampling points must be larger than 1.
      */
     template <class PointArray>
-    void setArrayOfPoints(int nSamples,
+    void setArrayOfPoints(size_t nSamples,
                           const PointArray &points,
                           SplineType splineType = Natural,
                           bool sortInputs = false)
@@ -603,7 +603,7 @@ public:
         assert(nSamples > 1);
 
         setNumSamples_(nSamples);
-        for (int i = 0; i < nSamples; ++i) {
+        for (size_t i = 0; i < nSamples; ++i) {
             xPos_[i] = points[i][0];
             yPos_[i] = points[i][1];
         }
@@ -646,7 +646,7 @@ public:
         setNumSamples_(points.size());
         typename XYContainer::const_iterator it = points.begin();
         typename XYContainer::const_iterator endIt = points.end();
-        for (int i = 0; it != endIt; ++ i, ++it) {
+        for (size_t i = 0; it != endIt; ++ i, ++it) {
             xPos_[i] = (*it)[0];
             yPos_[i] = (*it)[1];
         }
@@ -758,12 +758,12 @@ public:
      "spline.csv" using 1:4 w p ti "Monotonic"
      ----------- snap -----------
     */
-    void printCSV(Scalar xi0, Scalar xi1, int k, std::ostream &os = std::cout) const
+    void printCSV(Scalar xi0, Scalar xi1, size_t k, std::ostream &os = std::cout) const
     {
         Scalar x0 = std::min(xi0, xi1);
         Scalar x1 = std::max(xi0, xi1);
-        const int n = numSamples() - 1;
-        for (int i = 0; i <= k; ++i) {
+        const size_t n = numSamples() - 1;
+        for (size_t i = 0; i <= k; ++i) {
             double x = i*(x1 - x0)/k + x0;
             double x_p1 = x + (x1 - x0)/k;
             double y;
@@ -958,12 +958,12 @@ public:
         assert(applies(x0) && applies(x1));
 
         Evaluation tmpSol[3], sol = 0;
-        int nSol = 0;
-        int iFirst = segmentIdx_(x0);
-        int iLast = segmentIdx_(x1);
-        for (int i = iFirst; i <= iLast; ++i)
+        size_t nSol = 0;
+        size_t iFirst = segmentIdx_(x0);
+        size_t iLast = segmentIdx_(x1);
+        for (size_t i = iFirst; i <= iLast; ++i)
         {
-            int nCur = intersectSegment_(tmpSol, i, a, b, c, d, x0, x1);
+            size_t nCur = intersectSegment_(tmpSol, i, a, b, c, d, x0, x1);
             if (nCur == 1)
                 sol = tmpSol[0];
 
@@ -991,7 +991,7 @@ public:
      */
     int monotonic(Scalar x0, Scalar x1, OPM_UNUSED bool extrapolate = false) const
     {
-        assert(x0 != x1);
+        assert(std::abs(x0 - x1) > 1e-30);
 
         // make sure that x0 is smaller than x1
         if (x0 > x1)
@@ -1008,7 +1008,7 @@ public:
             x0 = xMin();
         };
 
-        int i = segmentIdx_(x0);
+        size_t i = segmentIdx_(x0);
         if (x_(i + 1) >= x1) {
             // interval is fully contained within a single spline
             // segment
@@ -1023,7 +1023,7 @@ public:
 
         // make sure that the segments which are completly in the
         // interval [x0, x1] all exhibit the same monotonicity.
-        int iEnd = segmentIdx_(x1);
+        size_t iEnd = segmentIdx_(x1);
         for (; i < iEnd - 1; ++i) {
             monotonic_(i, x_(i), x_(i + 1), r);
             if (!r)
@@ -1066,9 +1066,9 @@ protected:
     {
         ComparatorX_(const std::vector<Scalar> &x)
             : x_(x)
-        {};
+        {}
 
-        bool operator ()(int idxA, int idxB) const
+        bool operator ()(unsigned idxA, unsigned idxB) const
         { return x_.at(idxA) < x_.at(idxB); }
 
         const std::vector<Scalar> &x_;
@@ -1079,12 +1079,12 @@ protected:
      */
     void sortInput_()
     {
-        int n = numSamples();
+        size_t n = numSamples();
 
         // create a vector containing 0...n-1
-        std::vector<int> idxVector(n);
-        for (int i = 0; i < n; ++i)
-            idxVector[i] = i;
+        std::vector<unsigned> idxVector(static_cast<unsigned>(n));
+        for (unsigned i = 0; i < n; ++i)
+            idxVector[static_cast<unsigned>(i)] = i;
 
         // sort the indices according to the x values of the sample
         // points
@@ -1108,8 +1108,8 @@ protected:
     void reverseSamplingPoints_()
     {
         // reverse the arrays
-        int n = numSamples();
-        for (int i = 0; i <= (n - 1)/2; ++i) {
+        size_t n = numSamples();
+        for (unsigned i = 0; i <= (n - 1)/2; ++i) {
             std::swap(xPos_[i], xPos_[n - i - 1]);
             std::swap(yPos_[i], yPos_[n - i - 1]);
         }
@@ -1118,7 +1118,7 @@ protected:
     /*!
      * \brief Resizes the internal vectors to store the sample points.
      */
-    void setNumSamples_(int nSamples)
+    void setNumSamples_(size_t nSamples)
     {
         xPos_.resize(nSamples);
         yPos_.resize(nSamples);
@@ -1188,8 +1188,8 @@ protected:
         M.solve(moments, d);
 
         moments.resize(numSamples());
-        for (int i = numSamples() - 2; i >= 0; --i)
-            moments[i+1] = moments[i];
+        for (int i = static_cast<int>(numSamples()) - 2; i >= 0; --i)
+            moments[static_cast<unsigned>(i+1)] = moments[static_cast<unsigned>(i)];
         moments[0] = moments[numSamples() - 1];
 
         // convert the moments to slopes at the sample points
@@ -1295,7 +1295,7 @@ protected:
     {
         makeNaturalSystem_(M, d);
 
-        int n = numSamples() - 1;
+        size_t n = numSamples() - 1;
         // first row
         M[0][1] = 1;
         d[0] = 6/h_(1) * ( (y_(1) - y_(0))/h_(1) - m0);
@@ -1321,10 +1321,10 @@ protected:
 
         // See: J. Stoer: "Numerische Mathematik 1", 9th edition,
         // Springer, 2005, p. 111
-        const int n = numSamples() - 1;
+        size_t n = numSamples() - 1;
 
         // second to next to last rows
-        for (int i = 1; i < n; ++i) {
+        for (size_t i = 1; i < n; ++i) {
             Scalar lambda_i = h_(i + 1) / (h_(i) + h_(i + 1));
             Scalar mu_i = 1 - lambda_i;
             Scalar d_i =
@@ -1367,7 +1367,7 @@ protected:
 
         // See: J. Stoer: "Numerische Mathematik 1", 9th edition,
         // Springer, 2005, p. 111
-        const size_t n = numSamples() - 1;
+        size_t n = numSamples() - 1;
 
         assert(M.rows() == n);
 
@@ -1429,18 +1429,17 @@ protected:
 
         // calculate the slopes of the secant lines
         std::vector<Scalar> delta(n);
-        for (int k = 0; k < n - 1; ++k) {
+        for (size_t k = 0; k < n - 1; ++k)
             delta[k] = (y_(k + 1) - y_(k))/(x_(k + 1) - x_(k));
-        }
 
         // calculate the "raw" slopes at the sample points
-        for (int k = 1; k < n - 1; ++k)
+        for (size_t k = 1; k < n - 1; ++k)
             slopes[k] = (delta[k - 1] + delta[k])/2;
         slopes[0] = delta[0];
         slopes[n - 1] = delta[n - 2];
 
         // post-process the "raw" slopes at the sample points
-        for (int k = 0; k < n - 1; ++k) {
+        for (size_t k = 0; k < n - 1; ++k) {
             if (std::abs(delta[k]) < 1e-50) {
                 // make the spline flat if the inputs are equal
                 slopes[k] = 0;
@@ -1475,7 +1474,7 @@ protected:
     template <class MomentsVector, class SlopeVector>
     void setSlopesFromMoments_(SlopeVector &slopes, const MomentsVector &moments)
     {
-        int n = numSamples();
+        size_t n = numSamples();
 
         // evaluate slope at the rightmost point.
         // See: J. Stoer: "Numerische Mathematik 1", 9th edition,
@@ -1501,7 +1500,7 @@ protected:
         }
 
         // evaluate the slope for the first n-1 sample points
-        for (int i = 0; i < n - 1; ++ i) {
+        for (size_t i = 0; i < n - 1; ++ i) {
             // See: J. Stoer: "Numerische Mathematik 1", 9th edition,
             // Springer, 2005, p. 109
             Scalar h_i = this->h_(i + 1);
@@ -1527,7 +1526,7 @@ protected:
 
     // evaluate the spline at a given the position and given the
     // segment index
-    Scalar eval_(Scalar x, int i) const
+    Scalar eval_(Scalar x, size_t i) const
     {
         // See http://en.wikipedia.org/wiki/Cubic_Hermite_spline
         Scalar delta = h_(i + 1);
@@ -1543,7 +1542,7 @@ protected:
     // evaluate the spline at a given the position and given the
     // segment index
     template <class Evaluation>
-    Evaluation eval_(const Evaluation& x, int i) const
+    Evaluation eval_(const Evaluation& x, size_t i) const
     {
         // See http://en.wikipedia.org/wiki/Cubic_Hermite_spline
         Scalar delta = h_(i + 1);
@@ -1565,7 +1564,7 @@ protected:
 
     // evaluate the derivative of a spline given the actual position
     // and the segment index
-    Scalar evalDerivative_(Scalar x, int i) const
+    Scalar evalDerivative_(Scalar x, size_t i) const
     {
         // See http://en.wikipedia.org/wiki/Cubic_Hermite_spline
         Scalar delta = h_(i + 1);
@@ -1582,7 +1581,7 @@ protected:
 
     // evaluate the second derivative of a spline given the actual
     // position and the segment index
-    Scalar evalDerivative2_(Scalar x, int i) const
+    Scalar evalDerivative2_(Scalar x, size_t i) const
     {
         // See http://en.wikipedia.org/wiki/Cubic_Hermite_spline
         Scalar delta = h_(i + 1);
@@ -1599,7 +1598,7 @@ protected:
 
     // evaluate the third derivative of a spline given the actual
     // position and the segment index
-    Scalar evalDerivative3_(Scalar x, int i) const
+    Scalar evalDerivative3_(Scalar x, size_t i) const
     {
         // See http://en.wikipedia.org/wiki/Cubic_Hermite_spline
         Scalar delta = h_(i + 1);
@@ -1674,7 +1673,7 @@ protected:
     // 1: spline is monotonously increasing in the specified interval
     // 0: spline is not monotonic (or constant) in the specified interval
     // -1: spline is monotonously decreasing in the specified interval
-    int monotonic_(int i, Scalar x0, Scalar x1, int &r) const
+    int monotonic_(size_t i, Scalar x0, Scalar x1, int &r) const
     {
         // coefficients of derivative in monomial basis
         Scalar a = 3*a_(i);
@@ -1701,9 +1700,9 @@ protected:
         Scalar xE1 = (-b + disc)/(2*a);
         Scalar xE2 = (-b - disc)/(2*a);
 
-        if (disc == 0) {
+        if (std::abs(disc) < 1e-30) {
             // saddle point -> no extrema
-            if (xE1 == x0)
+            if (std::abs(xE1 - x0) < 1e-30)
                 // make sure that we're not picking the saddle point
                 // to determine whether we're monotonically increasing
                 // or decreasing
@@ -1742,13 +1741,13 @@ protected:
      *        with a cubic polynomial within a specified interval.
      */
     template <class Evaluation>
-    int intersectSegment_(Evaluation *sol,
-                          int segIdx,
-                          const Evaluation& a,
-                          const Evaluation& b,
-                          const Evaluation& c,
-                          const Evaluation& d,
-                          Scalar x0 = -1e100, Scalar x1 = 1e100) const
+    size_t intersectSegment_(Evaluation *sol,
+                             size_t segIdx,
+                             const Evaluation& a,
+                             const Evaluation& b,
+                             const Evaluation& c,
+                             const Evaluation& d,
+                             Scalar x0 = -1e100, Scalar x1 = 1e100) const
     {
         int n = Opm::invertCubicPolynomial(sol,
                                            a_(segIdx) - a,
@@ -1759,7 +1758,7 @@ protected:
         x1 = std::min(x_(segIdx+1), x1);
 
         // filter the intersections outside of the specified interval
-        int k = 0;
+        size_t k = 0;
         for (int j = 0; j < n; ++j) {
             if (x0 <= sol[j] && sol[j] <= x1) {
                 sol[k] = sol[j];
@@ -1770,14 +1769,14 @@ protected:
     }
 
     // find the segment index for a given x coordinate
-    int segmentIdx_(Scalar x) const
+    size_t segmentIdx_(Scalar x) const
     {
         // bisection
-        int iLow = 0;
-        int iHigh = numSamples() - 1;
+        size_t iLow = 0;
+        size_t iHigh = numSamples() - 1;
 
         while (iLow + 1 < iHigh) {
-            int i = (iLow + iHigh) / 2;
+            size_t i = (iLow + iHigh) / 2;
             if (x_(i) > x)
                 iHigh = i;
             else
@@ -1789,7 +1788,7 @@ protected:
     /*!
      * \brief Returns x[i] - x[i - 1]
      */
-    Scalar h_(int i) const
+    Scalar h_(size_t i) const
     {
         assert(x_(i) > x_(i-1)); // the sampling points must be given
                                  // in ascending order
@@ -1799,40 +1798,40 @@ protected:
     /*!
      * \brief Returns the y coordinate of the i-th sampling point.
      */
-    Scalar x_(int i) const
+    Scalar x_(size_t i) const
     { return xPos_[i]; }
 
     /*!
      * \brief Returns the y coordinate of the i-th sampling point.
      */
-    Scalar y_(int i) const
+    Scalar y_(size_t i) const
     { return yPos_[i]; }
 
     /*!
      * \brief Returns the slope (i.e. first derivative) of the spline at
      *        the i-th sampling point.
      */
-    Scalar slope_(int i) const
+    Scalar slope_(size_t i) const
     { return slopeVec_[i]; }
 
     // returns the coefficient in front of the x^3 term. In Stoer this
     // is delta.
-    Scalar a_(int i) const
+    Scalar a_(size_t i) const
     { return evalDerivative3_(/*x=*/Scalar(0.0), i)/6.0; }
 
     // returns the coefficient in front of the x^2 term In Stoer this
     // is gamma.
-    Scalar b_(int i) const
+    Scalar b_(size_t i) const
     { return evalDerivative2_(/*x=*/Scalar(0.0), i)/2.0; }
 
     // returns the coefficient in front of the x^1 term. In Stoer this
     // is beta.
-    Scalar c_(int i) const
+    Scalar c_(size_t i) const
     { return evalDerivative_(/*x=*/Scalar(0.0), i); }
 
     // returns the coefficient in front of the x^0 term. In Stoer this
     // is alpha.
-    Scalar d_(int i) const
+    Scalar d_(size_t i) const
     { return eval_(/*x=*/Scalar(0.0), i); }
 
     Vector xPos_;

--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -28,6 +28,7 @@
 #include <opm/material/common/TridiagonalMatrix.hpp>
 #include <opm/material/common/PolynomialUtils.hpp>
 #include <opm/material/common/ErrorMacros.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <ostream>
 #include <vector>
@@ -988,7 +989,7 @@ public:
      * In the corner case that the spline is constant within the given
      * interval, this method returns 3.
      */
-    int monotonic(Scalar x0, Scalar x1, bool extrapolate=false) const
+    int monotonic(Scalar x0, Scalar x1, OPM_UNUSED bool extrapolate = false) const
     {
         assert(x0 != x1);
 
@@ -1000,7 +1001,6 @@ public:
 
         int r = 3;
         if (x0 < xMin()) {
-            static_cast<void>(extrapolate);
             assert(extrapolate);
             Scalar m = evalDerivative_(xMin(), /*segmentIdx=*/0);
             if (std::abs(m) < 1e-20)

--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -27,6 +27,7 @@
 
 #include <opm/material/common/ErrorMacros.hpp>
 #include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -368,7 +369,7 @@ public:
      * In the corner case that the function is constant within the given
      * interval, this method returns 3.
      */
-    int monotonic(Scalar x0, Scalar x1, bool extrapolate=false) const
+    int monotonic(Scalar x0, Scalar x1, bool extrapolate OPM_UNUSED = false) const
     {
         assert(x0 != x1);
 
@@ -380,7 +381,6 @@ public:
 
         int r = 3;
         if (x0 < xMin()) {
-            static_cast<void>(extrapolate);
             assert(extrapolate);
 
             x0 = xMin();

--- a/opm/material/common/TridiagonalMatrix.hpp
+++ b/opm/material/common/TridiagonalMatrix.hpp
@@ -51,7 +51,7 @@ class TridiagonalMatrix
         TridiagRow_(TridiagonalMatrix &m, size_t rowIdx)
             : matrix_(m)
             , rowIdx_(rowIdx)
-        {};
+        {}
 
         Scalar &operator[](size_t colIdx)
         { return matrix_.at(rowIdx_, colIdx); }
@@ -109,22 +109,22 @@ public:
     typedef TridiagRow_ iterator;
     typedef TridiagRow_ const_iterator;
 
-    explicit TridiagonalMatrix(int numRows = 0)
+    explicit TridiagonalMatrix(size_t numRows = 0)
     {
         resize(numRows);
-    };
+    }
 
-    TridiagonalMatrix(int numRows, Scalar value)
+    TridiagonalMatrix(size_t numRows, Scalar value)
     {
         resize(numRows);
         this->operator=(value);
-    };
+    }
 
     /*!
      * \brief Copy constructor.
      */
     TridiagonalMatrix(const TridiagonalMatrix &source)
-    { *this = source; };
+    { *this = source; }
 
     /*!
      * \brief Return the number of rows/columns of the matrix.
@@ -171,7 +171,7 @@ public:
                 return diag_[0][n - 1];
         }
 
-        int diagIdx = 1 + colIdx - rowIdx;
+        size_t diagIdx = 1 + colIdx - rowIdx;
         // make sure that the requested column is in range
         assert(0 <= diagIdx && diagIdx < 3);
         return diag_[diagIdx][colIdx];
@@ -711,7 +711,7 @@ public:
     template <class XVector, class BVector>
     void solve(XVector &x, const BVector &b) const
     {
-        if (size() > 2 && diag_[2][0] != 0)
+        if (size() > 2 && std::abs(diag_[2][0]) < 1e-30)
             solveWithUpperRight_(x, b);
         else
             solveWithoutUpperRight_(x, b);
@@ -793,8 +793,9 @@ private:
 
         // backward elimination
         x[n - 1] = bStar[n - 1]/mainDiag[n-1];
-        for (int i = n - 2; i >= 0; --i) {
-            x[i] = (bStar[i] - x[i + 1]*upperDiag[i+1] - x[n-1]*lastColumn[i])/mainDiag[i];
+        for (int i = static_cast<int>(n) - 2; i >= 0; --i) {
+            unsigned iu = static_cast<unsigned>(i);
+            x[iu] = (bStar[iu] - x[iu + 1]*upperDiag[iu+1] - x[n-1]*lastColumn[iu])/mainDiag[iu];
         }
     }
 
@@ -831,8 +832,9 @@ private:
 
         // backward elimination
         x[n - 1] = bStar[n - 1]/mainDiag[n-1];
-        for (int i = n - 2; i >= 0; --i) {
-            x[i] = (bStar[i] - x[i + 1]*upperDiag[i+1])/mainDiag[i];
+        for (int i = static_cast<int>(n) - 2; i >= 0; --i) {
+            unsigned iu = static_cast<unsigned>(i);
+            x[iu] = (bStar[iu] - x[iu + 1]*upperDiag[iu+1])/mainDiag[iu];
         }
     }
 

--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -55,8 +55,8 @@ public:
       * \brief Constructor where the tabulation parameters are already
       *        provided.
       */
-    UniformTabulated2DFunction(Scalar xMin, Scalar xMax, int m,
-                               Scalar yMin, Scalar yMax, int n)
+    UniformTabulated2DFunction(Scalar xMin, Scalar xMax, unsigned m,
+                               Scalar yMin, Scalar yMax, unsigned n)
     {
         resize(xMin, xMax, m, yMin, yMax, n);
     }
@@ -64,8 +64,8 @@ public:
     /*!
      * \brief Resize the tabulation to a new range.
      */
-    void resize(Scalar xMin, Scalar xMax, int m,
-                Scalar yMin, Scalar yMax, int n)
+    void resize(Scalar xMin, Scalar xMax, unsigned m,
+                Scalar yMin, Scalar yMax, unsigned n)
     {
         samples_.resize(m*n);
 
@@ -106,19 +106,19 @@ public:
     /*!
      * \brief Returns the number of sampling points in X direction.
      */
-    int numX() const
+    unsigned numX() const
     { return m_; }
 
     /*!
      * \brief Returns the number of sampling points in Y direction.
      */
-    int numY() const
+    unsigned numY() const
     { return n_; }
 
     /*!
      * \brief Return the position on the x-axis of the i-th interval.
      */
-    Scalar iToX(int i) const
+    Scalar iToX(unsigned i) const
     {
         assert(0 <= i && i < numX());
 
@@ -128,7 +128,7 @@ public:
     /*!
      * \brief Return the position on the y-axis of the j-th interval.
       */
-    Scalar jToY(int j) const
+    Scalar jToY(unsigned j) const
     {
         assert(0 <= j && j < numY());
 
@@ -196,8 +196,10 @@ public:
         Evaluation alpha = xToI(x);
         Evaluation beta = yToJ(y);
 
-        int i = std::max(0, std::min<int>(numX() - 2, Toolbox::value(alpha)));
-        int j = std::max(0, std::min<int>(numY() - 2, Toolbox::value(beta)));
+        unsigned i = std::max(0U, std::min(static_cast<unsigned>(numX()) - 2,
+                                           static_cast<unsigned>(Toolbox::value(alpha))));
+        unsigned j = std::max(0U, std::min(static_cast<unsigned>(numY()) - 2,
+                                           static_cast<unsigned>(Toolbox::value(beta))));
 
         alpha -= i;
         beta -= j;
@@ -213,7 +215,7 @@ public:
      *         intersection of the \f$i\f$-th interval of the x-Axis
      *         and the \f$j\f$-th of the y-Axis.
      */
-    Scalar getSamplePoint(int i, int j) const
+    Scalar getSamplePoint(unsigned i, unsigned j) const
     {
         assert(0 <= i && i < m_);
         assert(0 <= j && j < n_);
@@ -226,7 +228,7 @@ public:
      *        intersection of the \f$i\f$-th interval of the x-Axis
      *        and the \f$j\f$-th of the y-Axis.
      */
-    void setSamplePoint(int i, int j, Scalar value)
+    void setSamplePoint(unsigned i, unsigned j, Scalar value)
     {
         assert(0 <= i && i < m_);
         assert(0 <= j && j < n_);
@@ -241,10 +243,10 @@ private:
     std::vector<Scalar> samples_;
 
     // the number of sample points in x direction
-    int m_;
+    unsigned m_;
 
     // the number of sample points in y direction
-    int n_;
+    unsigned n_;
 
     // the range of the tabulation on the x axis
     Scalar xMin_;

--- a/opm/material/common/Valgrind.hpp
+++ b/opm/material/common/Valgrind.hpp
@@ -71,13 +71,12 @@ inline bool IsRunning()
  *         occupied by the object.
  */
 template <class T>
-inline bool CheckDefined(const T &value)
+inline bool CheckDefined(const T& value OPM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto tmp = VALGRIND_CHECK_MEM_IS_DEFINED(&value, sizeof(T));
     return tmp == 0;
 #else
-    static_cast<void>(value);
     return true;
 #endif
 }
@@ -108,14 +107,12 @@ inline bool CheckDefined(const T &value)
  *         occupied by the array.
  */
 template <class T>
-inline bool CheckDefined(const T *value, int size)
+inline bool CheckDefined(const T* value OPM_UNUSED, int size OPM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto tmp = VALGRIND_CHECK_MEM_IS_DEFINED(value, size*sizeof(T));
     return tmp == 0;
 #else
-    static_cast<void>(value);
-    static_cast<void>(size);
     return true;
 #endif
 }
@@ -138,12 +135,11 @@ inline bool CheckDefined(const T *value, int size)
  * \param value The object which's memory valgrind should be told is undefined
  */
 template <class T>
-inline void SetUndefined(const T &value)
+inline void SetUndefined(const T &value OPM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_UNDEFINED(&value, sizeof(T));
 #endif
-    static_cast<void>(value);
 }
 
 /*!
@@ -165,13 +161,11 @@ inline void SetUndefined(const T &value)
  * \param size The size of the array in number of objects
  */
 template <class T>
-inline void SetUndefined(const T *value, int size)
+inline void SetUndefined(const T* value OPM_UNUSED, int size OPM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_UNDEFINED(value, size*sizeof(T));
 #endif
-    static_cast<void>(value);
-    static_cast<void>(size);
 }
 
 /*!
@@ -191,12 +185,11 @@ inline void SetUndefined(const T *value, int size)
  * \param value The object which's memory valgrind should consider as defined
  */
 template <class T>
-inline void SetDefined(const T &value)
+inline void SetDefined(const T& value OPM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_DEFINED(&value, sizeof(T));
 #endif
-    static_cast<void>(value);
 }
 
 /*!
@@ -218,13 +211,11 @@ inline void SetDefined(const T &value)
  * \param n The size of the array in number of objects
  */
 template <class T>
-inline void SetDefined(const T *value, int n)
+inline void SetDefined(const T *value OPM_UNUSED, int n OPM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_DEFINED(value, n*sizeof(T));
 #endif
-    static_cast<void>(value);
-    static_cast<void>(n);
 }
 
 /*!
@@ -244,12 +235,11 @@ inline void SetDefined(const T *value, int n)
  * \param value The object which's memory valgrind should complain if accessed
  */
 template <class T>
-inline void SetNoAccess(const T &value)
+inline void SetNoAccess(const T &value OPM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_NOACCESS(&value, sizeof(T));
 #endif
-    static_cast<void>(value);
 }
 
 /*!
@@ -269,13 +259,11 @@ inline void SetNoAccess(const T &value)
  * \param size The size of the array in number of objects
  */
 template <class T>
-inline void SetNoAccess(const T *value, int size)
+inline void SetNoAccess(const T *value OPM_UNUSED, int size OPM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto OPM_UNUSED result = VALGRIND_MAKE_MEM_NOACCESS(value, size*sizeof(T));
 #endif
-    static_cast<void>(value);
-    static_cast<void>(size);
 }
 
 } // namespace Valgrind

--- a/opm/material/components/Air.hpp
+++ b/opm/material/components/Air.hpp
@@ -135,7 +135,7 @@ public:
      *
      */
     template <class Evaluation>
-    static Evaluation gasViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasViscosity(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -160,7 +160,7 @@ public:
 
     // simpler method, from old constrelAir.hh
     template <class Evaluation>
-    static Evaluation simpleGasViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation simpleGasViscosity(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -183,7 +183,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation gasEnthalpy(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasEnthalpy(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         return 1005*(temperature - 273.15);
     }
@@ -220,8 +220,8 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation gasThermalConductivity(const Evaluation& temperature,
-                                             const Evaluation& pressure)
+    static Evaluation gasThermalConductivity(const Evaluation& /*temperature*/,
+                                             const Evaluation& /*pressure*/)
     {
         // Isobaric Properties for Nitrogen in: NIST Standard
         // see http://webbook.nist.gov/chemistry/fluid/
@@ -250,7 +250,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasHeatCapacity(const Evaluation& temperature,
-                                      const Evaluation& pressure)
+                                      const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 

--- a/opm/material/components/Brine.hpp
+++ b/opm/material/components/Brine.hpp
@@ -326,7 +326,7 @@ public:
      *   "Equations of State for basin geofluids"
      */
     template <class Evaluation>
-    static Evaluation liquidViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidViscosity(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 

--- a/opm/material/components/Component.hpp
+++ b/opm/material/components/Component.hpp
@@ -35,7 +35,7 @@ namespace Opm {
  * \ingroup Components
  * \brief Abstract base class of a pure chemical species.
  *
- * \tparam Scalar The type used for scalar values
+ * \tparam ScalarT The type used for scalar values
  * \tparam Implementation Necessary for static polymorphism
  */
 template <class ScalarT, class Implementation>

--- a/opm/material/components/Dnapl.hpp
+++ b/opm/material/components/Dnapl.hpp
@@ -85,11 +85,9 @@ public:
      * \param T temperature of component in \f$\mathrm{[K]}\f$
      */
     template <class Evaluation>
-    static Evaluation vaporPressure(const Evaluation& T)
+    static Evaluation vaporPressure(const Evaluation& /*T*/)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-
-        return Toolbox::createConstant(3900); // [Pa] (at 20C)
+        return 3900; // [Pa] (at 20C)
     }
 
     /*!
@@ -99,7 +97,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation gasDensity(Evaluation temperature, Evaluation pressure)
+    static Evaluation gasDensity(const Evaluation& temperature, const Evaluation& pressure)
     {
         return IdealGas<Scalar>::density(Evaluation(molarMass()),
                                          temperature,
@@ -113,11 +111,9 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidDensity(Evaluation temperature, Evaluation pressure)
+    static Evaluation liquidDensity(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-
-        return Toolbox::createConstant(1460.0); // [kg/m^3]
+        return 1460.0; // [kg/m^3]
     }
 
     /*!
@@ -127,11 +123,9 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidViscosity(Evaluation temperature, Evaluation pressure)
+    static Evaluation liquidViscosity(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-
-        return Toolbox::createConstant(5.7e-4); // [Pa s]
+        return 5.7e-4; // [Pa s]
     }
 
     /*!
@@ -141,7 +135,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidEnthalpy(Evaluation temperature, Evaluation pressure)
+    static Evaluation liquidEnthalpy(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         return 120.0/molarMass() * temperature; // [J/kg]
     }
@@ -155,11 +149,9 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidThermalConductivity(Evaluation temperature, Evaluation pressure)
+    static Evaluation liquidThermalConductivity(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-
-        return Toolbox::createConstant(0.3);
+        return 0.3;
     }
 };
 

--- a/opm/material/components/Lnapl.hpp
+++ b/opm/material/components/Lnapl.hpp
@@ -60,7 +60,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDensity(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     { return 890; }
 
     /*!
@@ -70,7 +70,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidViscosity(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     { return 8e-3; }
 };
 

--- a/opm/material/components/Mesitylene.hpp
+++ b/opm/material/components/Mesitylene.hpp
@@ -141,12 +141,12 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation heatVap(Evaluation temperature, const Evaluation& pressure)
+    static Evaluation heatVap(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
-        temperature = Toolbox::min(temperature, criticalTemperature()); // regularization
-        temperature = Toolbox::max(temperature, 0.0); // regularization
+        Evaluation T = Toolbox::min(temperature, criticalTemperature()); // regularization
+        T = Toolbox::max(T, 0.0); // regularization
 
         const Scalar T_crit = criticalTemperature();
         const Scalar Tr1 = boilingTemperature()/criticalTemperature();
@@ -159,7 +159,7 @@ public:
             / (1.07 - Tr1); /* [J/mol] */
 
         /* Variation with temp according to Watson relation eq 7-12.1*/
-        const Evaluation& Tr2 = temperature/criticalTemperature();
+        const Evaluation& Tr2 = T/criticalTemperature();
         const Scalar n = 0.375;
         const Evaluation& DH_vap = DH_v_boil * Toolbox::pow(((1.0 - Tr2)/(1.0 - Tr1)), n);
 
@@ -199,7 +199,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& /*pressure*/)
     { return molarLiquidDensity_(temperature)*molarMass(); }
 
     /*!
@@ -228,7 +228,7 @@ public:
      * \param regularize defines, if the functions is regularized or not, set to true by default
      */
     template <class Evaluation>
-    static Evaluation gasViscosity(Evaluation temperature, const Evaluation& pressure, bool regularize=true)
+    static Evaluation gasViscosity(Evaluation temperature, const Evaluation& /*pressure*/, bool /*regularize*/=true)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -256,7 +256,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidViscosity(Evaluation temperature, const Evaluation& pressure)
+    static Evaluation liquidViscosity(Evaluation temperature, const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -280,7 +280,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidHeatCapacity(const Evaluation& temperature,
-                                     const Evaluation& pressure)
+                                         const Evaluation& /*pressure*/)
     {
         /* according Reid et al. : Missenard group contrib. method (s. example 5-8) */
         /* Mesitylen: C9H12  : 3* CH3 ; 1* C6H5 (phenyl-ring) ; -2* H (this was to much!) */

--- a/opm/material/components/N2.hpp
+++ b/opm/material/components/N2.hpp
@@ -177,7 +177,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& temperature,
-                                  const Evaluation& pressure)
+                                  const Evaluation& /*pressure*/)
     {
         // method of Joback
         const Scalar cpVapA = 31.15;
@@ -235,7 +235,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasHeatCapacity(const Evaluation& temperature,
-                                      const Evaluation& pressure)
+                                      const Evaluation& /*pressure*/)
     {
         // method of Joback
         const Scalar cpVapA = 31.15;
@@ -266,7 +266,7 @@ public:
      *
      */
     template <class Evaluation>
-    static Evaluation gasViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasViscosity(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -304,8 +304,8 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation gasThermalConductivity(const Evaluation& temperature,
-                                             const Evaluation& pressure)
+    static Evaluation gasThermalConductivity(const Evaluation& /*temperature*/,
+                                             const Evaluation& /*pressure*/)
     { return 0.024572; }
 };
 

--- a/opm/material/components/SimpleCO2.hpp
+++ b/opm/material/components/SimpleCO2.hpp
@@ -101,7 +101,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& temperature,
-                                  const Evaluation& pressure)
+                                  const Evaluation& /*pressure*/)
     { return 571.3e3 + (temperature - 298.15)*0.85e3; }
 
     /*!
@@ -109,7 +109,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidEnthalpy(const Evaluation& temperature,
-                                     const Evaluation& pressure)
+                                     const Evaluation& /*pressure*/)
     { return (temperature - 298.15)*5e3; }
 
     /*!
@@ -144,7 +144,7 @@ public:
      * edition, McGraw-Hill, 1987, pp 396-397, 667
      */
     template <class Evaluation>
-    static Evaluation gasViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasViscosity(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         const Scalar Tc = criticalTemperature();
         const Scalar Vc = 93.9; // critical specific volume [cm^3/mol]

--- a/opm/material/components/SimpleH2O.hpp
+++ b/opm/material/components/SimpleH2O.hpp
@@ -160,7 +160,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& temperature,
-                                  const Evaluation& pressure)
+                                  const Evaluation& /*pressure*/)
     { return 1976*(temperature - 293.15) + 2.45e6; }
 
     /*!
@@ -171,7 +171,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidEnthalpy(const Evaluation& temperature,
-                                     const Evaluation& pressure)
+                                     const Evaluation& /*pressure*/)
     { return 4180*(temperature - 293.15); }
 
     /*!
@@ -219,11 +219,10 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidThermalConductivity(const Evaluation& temperature,
-                                                const Evaluation& pressure)
+    static Evaluation liquidThermalConductivity(const Evaluation& /*temperature*/,
+                                                const Evaluation& /*pressure*/)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-        return Toolbox::createConstant(0.578078); // conductivity of liquid water [W / (m K ) ] IAPWS evaluated at p=.1 MPa, T=8°C
+        return 0.578078; // conductivity of liquid water [W / (m K ) ] IAPWS evaluated at p=.1 MPa, T=8°C
     }
 
     /*!
@@ -233,11 +232,10 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation gasThermalConductivity(const Evaluation& temperature,
-                                             const Evaluation& pressure)
+    static Evaluation gasThermalConductivity(const Evaluation& /*temperature*/,
+                                             const Evaluation& /*pressure*/)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-        return Toolbox::createConstant(0.028224); // conductivity of steam [W / (m K ) ] IAPWS evaluated at p=.1 MPa, T=8°C
+        return 0.028224; // conductivity of steam [W / (m K ) ] IAPWS evaluated at p=.1 MPa, T=8°C
     }
 
     /*!
@@ -273,10 +271,9 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDensity(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-        return Toolbox::createConstant(1000);
+        return 1000;
     }
 
     /*!
@@ -286,7 +283,7 @@ public:
      * \param density density of component in \f$\mathrm{[kg/m^3]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidPressure(const Evaluation& temperature, const Evaluation& density)
+    static Evaluation liquidPressure(const Evaluation& /*temperature*/, const Evaluation& /*density*/)
     {
         OPM_THROW(std::logic_error,
                   "The liquid pressure is undefined for incompressible fluids");
@@ -300,11 +297,10 @@ public:
      * \param regularize defines, if the functions is regularized or not, set to true by default
      */
     template <class Evaluation>
-    static Evaluation gasViscosity(const Evaluation& temperature,
-                                   const Evaluation& pressure)
+    static Evaluation gasViscosity(const Evaluation& /*temperature*/,
+                                   const Evaluation& /*pressure*/)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-        return Toolbox::createConstant(1e-05);
+        return 1e-05;
     }
 
     /*!
@@ -314,10 +310,9 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidViscosity(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-        return Toolbox::createConstant(1e-03);
+        return 1e-03;
     }
 };
 

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -565,14 +565,23 @@ private:
             return Toolbox::createConstant(std::numeric_limits<Scalar>::quiet_NaN());
         }
 
-        unsigned iT = std::max<int>(0, std::min<int>(nTemp_ - 2, Toolbox::value(alphaT)));
+        size_t iT =
+            std::max<size_t>(0,
+                             std::min<size_t>(nTemp_ - 2,
+                                              static_cast<size_t>(Toolbox::value(alphaT))));
         alphaT -= iT;
 
         Evaluation alphaP1 = pressLiquidIdx_(p, iT);
         Evaluation alphaP2 = pressLiquidIdx_(p, iT + 1);
 
-        unsigned iP1 = std::max<int>(0, std::min<int>(nPress_ - 2, Toolbox::value(alphaP1)));
-        unsigned iP2 = std::max<int>(0, std::min<int>(nPress_ - 2, Toolbox::value(alphaP2)));
+        size_t iP1 =
+            std::max<size_t>(0,
+                             std::min<size_t>(nPress_ - 2,
+                                              static_cast<size_t>(Toolbox::value(alphaP1))));
+        size_t iP2 =
+            std::max<size_t>(0,
+                             std::min<size_t>(nPress_ - 2,
+                                              static_cast<size_t>(Toolbox::value(alphaP2))));
         alphaP1 -= iP1;
         alphaP2 -= iP2;
 
@@ -607,13 +616,21 @@ private:
             return Toolbox::createConstant(std::numeric_limits<Scalar>::quiet_NaN());
         }
 
-        unsigned iT = std::max<int>(0, std::min<int>(nTemp_ - 2, Toolbox::value(alphaT)));
+        size_t iT =
+            std::max<size_t>(0,
+                             std::min<size_t>(nTemp_ - 2,
+                                              static_cast<size_t>(Toolbox::value(alphaT))));
         alphaT -= iT;
 
         Evaluation alphaP1 = pressGasIdx_(p, iT);
         Evaluation alphaP2 = pressGasIdx_(p, iT + 1);
-        unsigned iP1 = std::max<int>(0, std::min<int>(nPress_ - 2, Toolbox::value(alphaP1)));
-        unsigned iP2 = std::max<int>(0, std::min<int>(nPress_ - 2, Toolbox::value(alphaP2)));
+        size_t iP1 =
+            std::max<size_t>(0, std::min<size_t>(nPress_ - 2,
+                                           static_cast<size_t>(Toolbox::value(alphaP1))));
+        size_t iP2 =
+            std::max<size_t>(0,
+                             std::min<size_t>(nPress_ - 2,
+                                              static_cast<size_t>(Toolbox::value(alphaP2))));
         alphaP1 -= iP1;
         alphaP2 -= iP2;
 
@@ -692,7 +709,7 @@ private:
 
     // returns the index of an entry in a pressure field
     template <class Evaluation>
-    static Evaluation pressLiquidIdx_(const Evaluation& pressure, unsigned tempIdx)
+    static Evaluation pressLiquidIdx_(const Evaluation& pressure, size_t tempIdx)
     {
         Scalar plMin = minLiquidPressure_(tempIdx);
         Scalar plMax = maxLiquidPressure_(tempIdx);
@@ -702,7 +719,7 @@ private:
 
     // returns the index of an entry in a temperature field
     template <class Evaluation>
-    static Evaluation pressGasIdx_(const Evaluation& pressure, unsigned tempIdx)
+    static Evaluation pressGasIdx_(const Evaluation& pressure, size_t tempIdx)
     {
         Scalar pgMin = minGasPressure_(tempIdx);
         Scalar pgMax = maxGasPressure_(tempIdx);
@@ -712,7 +729,7 @@ private:
 
     // returns the index of an entry in a density field
     template <class Evaluation>
-    static Evaluation densityLiquidIdx_(const Evaluation& density, unsigned tempIdx)
+    static Evaluation densityLiquidIdx_(const Evaluation& density, size_t tempIdx)
     {
         Scalar densityMin = minLiquidDensity_(tempIdx);
         Scalar densityMax = maxLiquidDensity_(tempIdx);
@@ -721,7 +738,7 @@ private:
 
     // returns the index of an entry in a density field
     template <class Evaluation>
-    static Evaluation densityGasIdx_(const Evaluation& density, unsigned tempIdx)
+    static Evaluation densityGasIdx_(const Evaluation& density, size_t tempIdx)
     {
         Scalar densityMin = minGasDensity_(tempIdx);
         Scalar densityMax = maxGasDensity_(tempIdx);
@@ -730,7 +747,7 @@ private:
 
     // returns the minimum tabulized liquid pressure at a given
     // temperature index
-    static Scalar minLiquidPressure_(int tempIdx)
+    static Scalar minLiquidPressure_(size_t tempIdx)
     {
         if (!useVaporPressure)
             return pressMin_;
@@ -740,7 +757,7 @@ private:
 
     // returns the maximum tabulized liquid pressure at a given
     // temperature index
-    static Scalar maxLiquidPressure_(int tempIdx)
+    static Scalar maxLiquidPressure_(size_t tempIdx)
     {
         if (!useVaporPressure)
             return pressMax_;
@@ -750,7 +767,7 @@ private:
 
     // returns the minumum tabulized gas pressure at a given
     // temperature index
-    static Scalar minGasPressure_(int tempIdx)
+    static Scalar minGasPressure_(size_t tempIdx)
     {
         if (!useVaporPressure)
             return pressMin_;
@@ -760,7 +777,7 @@ private:
 
     // returns the maximum tabulized gas pressure at a given
     // temperature index
-    static Scalar maxGasPressure_(int tempIdx)
+    static Scalar maxGasPressure_(size_t tempIdx)
     {
         if (!useVaporPressure)
             return pressMax_;
@@ -771,22 +788,22 @@ private:
 
     // returns the minimum tabulized liquid density at a given
     // temperature index
-    static Scalar minLiquidDensity_(int tempIdx)
+    static Scalar minLiquidDensity_(size_t tempIdx)
     { return minLiquidDensity__[tempIdx]; }
 
     // returns the maximum tabulized liquid density at a given
     // temperature index
-    static Scalar maxLiquidDensity_(int tempIdx)
+    static Scalar maxLiquidDensity_(size_t tempIdx)
     { return maxLiquidDensity__[tempIdx]; }
 
     // returns the minumum tabulized gas density at a given
     // temperature index
-    static Scalar minGasDensity_(int tempIdx)
+    static Scalar minGasDensity_(size_t tempIdx)
     { return minGasDensity__[tempIdx]; }
 
     // returns the maximum tabulized gas density at a given
     // temperature index
-    static Scalar maxGasDensity_(int tempIdx)
+    static Scalar maxGasDensity_(size_t tempIdx)
     { return maxGasDensity__[tempIdx]; }
 
     // 1D fields with the temperature as degree of freedom

--- a/opm/material/components/Xylene.hpp
+++ b/opm/material/components/Xylene.hpp
@@ -112,7 +112,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation spHeatCapLiquidPhase(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation spHeatCapLiquidPhase(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         Evaluation CH3,C6H5,H;
         // after Reid et al. : Missenard group contrib. method (s. example 5-8)
@@ -181,7 +181,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation heatVap(Evaluation temperature,
-                              const Evaluation& pressure)
+                              const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -248,7 +248,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation molarLiquidDensity(Evaluation temperature, const Evaluation& pressure)
+    static Evaluation molarLiquidDensity(Evaluation temperature, const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -293,7 +293,7 @@ public:
      * \copydoc Component::gasViscosity
      */
     template <class Evaluation>
-    static Evaluation gasViscosity(Evaluation temperature, const Evaluation& pressure)
+    static Evaluation gasViscosity(Evaluation temperature, const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -314,7 +314,7 @@ public:
      * \copydoc Component::liquidViscosity
      */
     template <class Evaluation>
-    static Evaluation liquidViscosity(Evaluation temperature, const Evaluation& pressure)
+    static Evaluation liquidViscosity(Evaluation temperature, const Evaluation& /*pressure*/)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 

--- a/opm/material/components/iapws/Region1.hpp
+++ b/opm/material/components/iapws/Region1.hpp
@@ -111,7 +111,7 @@ public:
      *
      * \param pressure temperature of component in \f$\mathrm{[Pa]}\f$
      */
-    static Scalar dpi_dp(Scalar pressure)
+    static Scalar dpi_dp(Scalar /*pressure*/)
     { return 1.0 / 16.53e6; }
 
     /*!
@@ -120,7 +120,7 @@ public:
      *
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
-    static Scalar dp_dpi(Scalar pressure)
+    static Scalar dp_dpi(Scalar /*pressure*/)
     { return 16.53e6; }
 
     /*!

--- a/opm/material/components/iapws/Region2.hpp
+++ b/opm/material/components/iapws/Region2.hpp
@@ -107,7 +107,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Scalar dpi_dp(const Evaluation& pressure)
+    static Scalar dpi_dp(const Evaluation& /*pressure*/)
     { return 1.0 / 1e6; }
 
     /*!
@@ -117,7 +117,7 @@ public:
      * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation dp_dpi(const Evaluation& pressure)
+    static Evaluation dp_dpi(const Evaluation& /*pressure*/)
     { return 1e6; }
 
     /*!

--- a/opm/material/constraintsolvers/CompositionFromFugacities.hpp
+++ b/opm/material/constraintsolvers/CompositionFromFugacities.hpp
@@ -58,15 +58,15 @@ public:
      */
     template <class FluidState>
     static void guessInitial(FluidState &fluidState,
-                             ParameterCache &paramCache,
-                             int phaseIdx,
-                             const ComponentVector &fugVec)
+                             ParameterCache &/*paramCache*/,
+                             unsigned phaseIdx,
+                             const ComponentVector &/*fugVec*/)
     {
         if (FluidSystem::isIdealMixture(phaseIdx))
             return;
 
         // Pure component fugacities
-        for (int i = 0; i < numComponents; ++ i) {
+        for (unsigned i = 0; i < numComponents; ++ i) {
             //std::cout << f << " -> " << mutParams.fugacity(phaseIdx, i)/f << "\n";
             fluidState.setMoleFraction(phaseIdx,
                                        i,
@@ -83,7 +83,7 @@ public:
     template <class FluidState>
     static void solve(FluidState &fluidState,
                       ParameterCache &paramCache,
-                      int phaseIdx,
+                      unsigned phaseIdx,
                       const ComponentVector &targetFug)
     {
         typedef MathToolbox<Evaluation> Toolbox;
@@ -99,7 +99,7 @@ public:
 
         // save initial composition in case something goes wrong
         Dune::FieldVector<Evaluation, numComponents> xInit;
-        for (int i = 0; i < numComponents; ++i) {
+        for (unsigned i = 0; i < numComponents; ++i) {
             xInit[i] = fluidState.moleFraction(phaseIdx, i);
         }
 
@@ -126,11 +126,11 @@ public:
 
             /*
             std::cout << FluidSystem::phaseName(phaseIdx) << "Phase composition: ";
-            for (int i = 0; i < FluidSystem::numComponents; ++i)
+            for (unsigned i = 0; i < FluidSystem::numComponents; ++i)
                 std::cout << fluidState.moleFraction(phaseIdx, i) << " ";
             std::cout << "\n";
             std::cout << FluidSystem::phaseName(phaseIdx) << "Phase phi: ";
-            for (int i = 0; i < FluidSystem::numComponents; ++i)
+            for (unsigned i = 0; i < FluidSystem::numComponents; ++i)
                 std::cout << fluidState.fugacityCoefficient(phaseIdx, i) << " ";
             std::cout << "\n";
             */
@@ -147,7 +147,7 @@ public:
 
             /*
             std::cout << FluidSystem::phaseName(phaseIdx) << "Phase composition: ";
-            for (int i = 0; i < FluidSystem::numComponents; ++i)
+            for (unsigned i = 0; i < FluidSystem::numComponents; ++i)
                 std::cout << fluidState.moleFraction(phaseIdx, i) << " ";
             std::cout << "\n";
             std::cout << "J: " << J << "\n";
@@ -189,10 +189,10 @@ protected:
     template <class FluidState>
     static void solveIdealMix_(FluidState &fluidState,
                                ParameterCache &paramCache,
-                               int phaseIdx,
+                               unsigned phaseIdx,
                                const ComponentVector &fugacities)
     {
-        for (int i = 0; i < numComponents; ++ i) {
+        for (unsigned i = 0; i < numComponents; ++ i) {
             const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState,
                                                                      paramCache,
                                                                      phaseIdx,
@@ -217,7 +217,7 @@ protected:
                              Dune::FieldVector<Evaluation, numComponents> &defect,
                              FluidState &fluidState,
                              ParameterCache &paramCache,
-                             int phaseIdx,
+                             unsigned phaseIdx,
                              const ComponentVector &targetFug)
     {
         typedef MathToolbox<Evaluation> Toolbox;
@@ -228,7 +228,7 @@ protected:
         Scalar absError = 0;
         // calculate the defect (deviation of the current fugacities
         // from the target fugacities)
-        for (int i = 0; i < numComponents; ++ i) {
+        for (unsigned i = 0; i < numComponents; ++ i) {
             const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState,
                                                           paramCache,
                                                           phaseIdx,
@@ -242,7 +242,7 @@ protected:
 
         // assemble jacobian matrix of the constraints for the composition
         static const Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e6;
-        for (int i = 0; i < numComponents; ++ i) {
+        for (unsigned i = 0; i < numComponents; ++ i) {
             ////////
             // approximately calculate partial derivatives of the
             // fugacity defect of all components in regard to the mole
@@ -256,7 +256,7 @@ protected:
 
             // compute new defect and derivative for all component
             // fugacities
-            for (int j = 0; j < numComponents; ++j) {
+            for (unsigned j = 0; j < numComponents; ++j) {
                 // compute the j-th component's fugacity coefficient ...
                 const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState,
                                                                          paramCache,
@@ -290,8 +290,8 @@ protected:
     static Scalar update_(FluidState &fluidState,
                           ParameterCache &paramCache,
                           Dune::FieldVector<Evaluation, numComponents> &x,
-                          Dune::FieldVector<Evaluation, numComponents> &b,
-                          int phaseIdx,
+                          Dune::FieldVector<Evaluation, numComponents> &/*b*/,
+                          unsigned phaseIdx,
                           const Dune::FieldVector<Evaluation, numComponents> &targetFug)
     {
         typedef MathToolbox<Evaluation> Toolbox;
@@ -301,7 +301,7 @@ protected:
         Scalar relError = 0;
         Evaluation sumDelta = Toolbox::createConstant(0.0);
         Evaluation sumx = Toolbox::createConstant(0.0);
-        for (int i = 0; i < numComponents; ++i) {
+        for (unsigned i = 0; i < numComponents; ++i) {
             origComp[i] = fluidState.moleFraction(phaseIdx, i);
             relError = std::max(relError, std::abs(Toolbox::value(x[i])));
 
@@ -315,7 +315,7 @@ protected:
             x /= (sumDelta/maxDelta);
 
         // change composition
-        for (int i = 0; i < numComponents; ++i) {
+        for (unsigned i = 0; i < numComponents; ++i) {
             Evaluation newx = origComp[i] - x[i];
             // only allow negative mole fractions if the target fugacity is negative
             if (targetFug[i] > 0)
@@ -337,11 +337,11 @@ protected:
 
     template <class FluidState>
     static Scalar calculateDefect_(const FluidState &params,
-                                   int phaseIdx,
+                                   unsigned phaseIdx,
                                    const ComponentVector &targetFug)
     {
         Scalar result = 0.0;
-        for (int i = 0; i < numComponents; ++i) {
+        for (unsigned i = 0; i < numComponents; ++i) {
             // sum of the fugacity defect weighted by the inverse
             // fugacity coefficient
             result += std::abs(

--- a/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
+++ b/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
@@ -106,7 +106,7 @@ public:
     template <class FluidState, class ParameterCache>
     static void solve(FluidState &fluidState,
                       ParameterCache &paramCache,
-                      int refPhaseIdx,
+                      unsigned refPhaseIdx,
                       bool setViscosity,
                       bool setEnthalpy)
     {
@@ -133,7 +133,7 @@ public:
                                                            refPhaseIdx));
 
         // compute the fugacities of all components in the reference phase
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             fluidState.setFugacityCoefficient(refPhaseIdx,
                                               compIdx,
                                               FluidSystem::fugacityCoefficient(fluidState,
@@ -143,12 +143,12 @@ public:
         }
 
         // compute all quantities for the non-reference phases
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             if (phaseIdx == refPhaseIdx)
                 continue; // reference phase is already calculated
 
             ComponentVector fugVec;
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 const auto& fug = fluidState.fugacity(refPhaseIdx, compIdx);
                 fugVec[compIdx] = FsToolbox::template toLhs<Evaluation>(fug);
             }

--- a/opm/material/constraintsolvers/ImmiscibleFlash.hpp
+++ b/opm/material/constraintsolvers/ImmiscibleFlash.hpp
@@ -87,15 +87,15 @@ public:
      */
     template <class FluidState>
     static void guessInitial(FluidState &fluidState,
-                             ParameterCache &paramCache,
+                             ParameterCache &/*paramCache*/,
                              const ComponentVector &globalMolarities)
     {
         // the sum of all molarities
         Scalar sumMoles = 0;
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             sumMoles += globalMolarities[compIdx];
 
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
             // pressure. use atmospheric pressure as initial guess
             fluidState.setPressure(phaseIdx, 2e5);
 
@@ -122,7 +122,7 @@ public:
         // Check if all fluid phases are incompressible
         /////////////////////////
         bool allIncompressible = true;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             if (FluidSystem::isCompressible(phaseIdx)) {
                 allIncompressible = false;
                 break;
@@ -131,7 +131,7 @@ public:
 
         if (allIncompressible) {
             paramCache.updateAll(fluidState);
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 Scalar rho = FluidSystem::density(fluidState, paramCache, phaseIdx);
                 fluidState.setDensity(phaseIdx, rho);
 
@@ -212,7 +212,7 @@ public:
         /*
         printFluidState_(fluidState);
         std::cout << "globalMolarities: ";
-        for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx)
             std::cout << globalMolarities[compIdx] << " ";
         std::cout << "\n";
         */
@@ -229,24 +229,24 @@ protected:
     static void printFluidState_(const FluidState &fs)
     {
         std::cout << "saturations: ";
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             std::cout << fs.saturation(phaseIdx) << " ";
         std::cout << "\n";
 
         std::cout << "pressures: ";
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             std::cout << fs.pressure(phaseIdx) << " ";
         std::cout << "\n";
 
         std::cout << "densities: ";
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             std::cout << fs.density(phaseIdx) << " ";
         std::cout << "\n";
 
         std::cout << "global component molarities: ";
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             Scalar sum = 0;
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 sum += fs.saturation(phaseIdx)*fs.molarity(phaseIdx, compIdx);
             }
             std::cout << sum << " ";
@@ -275,7 +275,7 @@ protected:
         Valgrind::CheckDefined(b);
 
         // assemble jacobian matrix
-        for (int pvIdx = 0; pvIdx < numEq; ++ pvIdx) {
+        for (unsigned pvIdx = 0; pvIdx < numEq; ++ pvIdx) {
             ////////
             // approximately calculate partial derivatives of the
             // fugacity defect of all components in regard to the mole
@@ -294,7 +294,7 @@ protected:
             tmp -= b;
             tmp /= eps;
             // store derivative in jacobian matrix
-            for (int eqIdx = 0; eqIdx < numEq; ++eqIdx)
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx)
                 J[eqIdx][pvIdx] = tmp[eqIdx];
 
             // fluid state and parameter cache to their original values
@@ -308,12 +308,12 @@ protected:
 
     template <class FluidState>
     static void calculateDefect_(Vector &b,
-                                 const FluidState &fluidStateEval,
+                                 const FluidState &/*fluidStateEval*/,
                                  const FluidState &fluidState,
                                  const ComponentVector &globalMolarities)
     {
         // global molarities are given
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             b[phaseIdx] =
                 fluidState.saturation(phaseIdx)
                 * fluidState.molarity(phaseIdx, /*compIdx=*/phaseIdx);
@@ -329,7 +329,7 @@ protected:
                           const Vector &deltaX)
     {
         Scalar relError = 0;
-        for (int pvIdx = 0; pvIdx < numEq; ++ pvIdx) {
+        for (unsigned pvIdx = 0; pvIdx < numEq; ++ pvIdx) {
             Scalar tmp = getQuantity_(fluidState, pvIdx);
             Scalar delta = deltaX[pvIdx];
 
@@ -362,13 +362,13 @@ protected:
         // calculate the saturation of the last phase as a function of
         // the other saturations
         Scalar sumSat = 0.0;
-        for (int phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx)
             sumSat += fluidState.saturation(phaseIdx);
 
         if (sumSat > 1.0) {
             // make sure that the last saturation does not become
             // negative
-            for (int phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx)
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx)
             {
                 Scalar S = fluidState.saturation(phaseIdx);
                 fluidState.setSaturation(phaseIdx, S/sumSat);
@@ -384,7 +384,7 @@ protected:
         // solved for.)
         ComponentVector pC;
         MaterialLaw::capillaryPressures(pC, matParams, fluidState);
-        for (int phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
             fluidState.setPressure(phaseIdx,
                                    fluidState.pressure(0)
                                    + (pC[phaseIdx] - pC[0]));
@@ -393,33 +393,33 @@ protected:
         paramCache.updateAll(fluidState, /*except=*/ParameterCache::Temperature|ParameterCache::Composition);
 
         // update all densities
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
             Scalar rho = FluidSystem::density(fluidState, paramCache, phaseIdx);
             fluidState.setDensity(phaseIdx, rho);
         }
     }
 
-    static bool isPressureIdx_(int pvIdx)
+    static bool isPressureIdx_(unsigned pvIdx)
     { return pvIdx == 0; }
 
-    static bool isSaturationIdx_(int pvIdx)
+    static bool isSaturationIdx_(unsigned pvIdx)
     { return 1 <= pvIdx && pvIdx < numPhases; }
 
     // retrieves a quantity from the fluid state
     template <class FluidState>
-    static Scalar getQuantity_(const FluidState &fs, int pvIdx)
+    static Scalar getQuantity_(const FluidState &fs, unsigned pvIdx)
     {
         assert(pvIdx < numEq);
 
         // first pressure
         if (pvIdx < 1) {
-            int phaseIdx = 0;
+            unsigned phaseIdx = 0;
             return fs.pressure(phaseIdx);
         }
         // saturations
         else {
             assert(pvIdx < numPhases);
-            int phaseIdx = pvIdx - 1;
+            unsigned phaseIdx = pvIdx - 1;
             return fs.saturation(phaseIdx);
         }
     }
@@ -429,7 +429,7 @@ protected:
     static void setQuantity_(FluidState &fs,
                              ParameterCache &paramCache,
                              const typename MaterialLaw::Params &matParams,
-                             int pvIdx,
+                             unsigned pvIdx,
                              Scalar value)
     {
         assert(0 <= pvIdx && pvIdx < numEq);
@@ -440,12 +440,12 @@ protected:
 
             // set all pressures. here we assume that the capillary
             // pressure does not depend on absolute pressure.
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
                 fs.setPressure(phaseIdx, fs.pressure(phaseIdx) + delta);
             paramCache.updateAllPressures(fs);
 
             // update all densities
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 Scalar rho = FluidSystem::density(fs, paramCache, phaseIdx);
                 fs.setDensity(phaseIdx, rho);
             }
@@ -466,14 +466,14 @@ protected:
             // law
             ComponentVector pC;
             MaterialLaw::capillaryPressures(pC, matParams, fs);
-            for (int phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
+            for (unsigned phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
                 fs.setPressure(phaseIdx,
                                fs.pressure(0)
                                + (pC[phaseIdx] - pC[0]));
             paramCache.updateAllPressures(fs);
 
             // update all densities
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 Scalar rho = FluidSystem::density(fs, paramCache, phaseIdx);
                 fs.setDensity(phaseIdx, rho);
             }
@@ -482,19 +482,19 @@ protected:
 
     // set a quantity in the fluid state
     template <class FluidState>
-    static void setQuantityRaw_(FluidState &fs, int pvIdx, Scalar value)
+    static void setQuantityRaw_(FluidState &fs, unsigned pvIdx, Scalar value)
     {
         assert(pvIdx < numEq);
 
         // first pressure
         if (pvIdx < 1) {
-            int phaseIdx = 0;
+            unsigned phaseIdx = 0;
             fs.setPressure(phaseIdx, value);
         }
         // saturations
         else {
             assert(pvIdx < numPhases);
-            int phaseIdx = pvIdx - 1;
+            unsigned phaseIdx = pvIdx - 1;
 
             // make sure that the first M-1 saturations does not get
             // negative
@@ -504,7 +504,7 @@ protected:
     }
 
     template <class FluidState>
-    static Scalar quantityWeight_(const FluidState &fs, int pvIdx)
+    static Scalar quantityWeight_(const FluidState &/*fs*/, unsigned pvIdx)
     {
         // first pressure
         if (pvIdx < 1)

--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -101,12 +101,12 @@ public:
     {
         // the sum of all molarities
         Evaluation sumMoles = 0;
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             sumMoles += globalMolarities[compIdx];
 
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
             // composition
-            for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
+            for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx)
                 fluidState.setMoleFraction(phaseIdx,
                                            compIdx,
                                            globalMolarities[compIdx]/sumMoles);
@@ -120,8 +120,8 @@ public:
 
         // set the fugacity coefficients of all components in all phases
         paramCache.updateAll(fluidState);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
-            for (int compIdx = 0; compIdx < numComponents; ++ compIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
                 const typename FluidState::Scalar phi =
                     FluidSystem::fugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
                 fluidState.setFugacityCoefficient(phaseIdx, compIdx, phi);
@@ -177,7 +177,7 @@ public:
         /*
         std::cout << "--------------------\n";
         std::cout << "globalMolarities: ";
-        for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx)
             std::cout << globalMolarities[compIdx] << " ";
         std::cout << "\n";
         */
@@ -242,7 +242,7 @@ public:
         /*
         printFluidState_(fluidState);
         std::cout << "globalMolarities: ";
-        for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx)
             std::cout << globalMolarities[compIdx] << " ";
         std::cout << "\n";
         */
@@ -282,40 +282,40 @@ protected:
     static void printFluidState_(const FluidState &fluidState)
     {
         std::cout << "saturations: ";
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             std::cout << fluidState.saturation(phaseIdx) << " ";
         std::cout << "\n";
 
         std::cout << "pressures: ";
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             std::cout << fluidState.pressure(phaseIdx) << " ";
         std::cout << "\n";
 
         std::cout << "densities: ";
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             std::cout << fluidState.density(phaseIdx) << " ";
         std::cout << "\n";
 
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             std::cout << "composition " << FluidSystem::phaseName(phaseIdx) << "Phase: ";
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 std::cout << fluidState.moleFraction(phaseIdx, compIdx) << " ";
             }
             std::cout << "\n";
         }
 
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             std::cout << "fugacities " << FluidSystem::phaseName(phaseIdx) << "Phase: ";
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 std::cout << fluidState.fugacity(phaseIdx, compIdx) << " ";
             }
             std::cout << "\n";
         }
 
         std::cout << "global component molarities: ";
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             Scalar sum = 0;
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 sum += fluidState.saturation(phaseIdx)*fluidState.molarity(phaseIdx, compIdx);
             }
             std::cout << sum << " ";
@@ -352,7 +352,7 @@ protected:
         ///////
         // assemble jacobian matrix
         ///////
-        for (int pvIdx = 0; pvIdx < numEq; ++ pvIdx) {
+        for (unsigned pvIdx = 0; pvIdx < numEq; ++ pvIdx) {
             ////////
             // approximately calculate partial derivatives of the
             // fugacity defect of all components in regard to the mole
@@ -368,11 +368,11 @@ protected:
             // compute derivative of the defect
             calculateDefect_(tmp, origFluidState, fluidState, globalMolarities);
             tmp -= b;
-            for (int i = 0; i < numEq; ++ i)
+            for (unsigned i = 0; i < numEq; ++ i)
                 tmp[i] /= eps;
 
             // store derivative in jacobian matrix
-            for (int eqIdx = 0; eqIdx < numEq; ++eqIdx)
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx)
                 J[eqIdx][pvIdx] = tmp[eqIdx];
 
             // fluid state and parameter cache to their original values
@@ -392,11 +392,11 @@ protected:
     {
         typedef typename FluidState::Scalar Evaluation;
 
-        int eqIdx = 0;
+        unsigned eqIdx = 0;
 
         // fugacity of any component must be equal in all phases
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
-            for (int phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx) {
                 b[eqIdx] =
                     fluidState.fugacity(/*phaseIdx=*/0, compIdx)
                     - fluidState.fugacity(phaseIdx, compIdx);
@@ -410,9 +410,9 @@ protected:
         // capillary pressures are treated implicitly!
 
         // global molarities are given
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             b[eqIdx] = 0.0;
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 b[eqIdx] +=
                     fluidState.saturation(phaseIdx)
                     * fluidState.molarity(phaseIdx, compIdx);
@@ -423,9 +423,9 @@ protected:
         }
 
         // model assumptions (-> non-linear complementarity functions) must be adhered
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             Evaluation sumMoleFracEval = 0.0;
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
                 sumMoleFracEval += fluidStateEval.moleFraction(phaseIdx, compIdx);
 
             if (1.0 - sumMoleFracEval > fluidStateEval.saturation(phaseIdx)) {
@@ -433,7 +433,7 @@ protected:
             }
             else {
                 Evaluation sumMoleFrac = 0.0;
-                for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+                for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
                     sumMoleFrac += fluidState.moleFraction(phaseIdx, compIdx);
                 b[eqIdx] = 1.0 - sumMoleFrac;
             }
@@ -454,12 +454,12 @@ protected:
         // make sure we don't swallow non-finite update vectors
 #ifndef NDEBUG
         assert(deltaX.dimension == numEq);
-        for (int i = 0; i < numEq; ++i)
+        for (unsigned i = 0; i < numEq; ++i)
             assert(std::isfinite(Toolbox::value(deltaX[i])));
 #endif
 
         Scalar relError = 0;
-        for (int pvIdx = 0; pvIdx < numEq; ++ pvIdx) {
+        for (unsigned pvIdx = 0; pvIdx < numEq; ++ pvIdx) {
             const Evaluation& tmp = getQuantity_(fluidState, pvIdx);
             Evaluation delta = deltaX[pvIdx];
 
@@ -487,7 +487,7 @@ protected:
         /*
         // make sure all saturations, pressures and mole fractions are non-negative
         Scalar sumSat = 0;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             Scalar value = fluidState.saturation(phaseIdx);
             if (value < -0.05) {
                 value = -0.05;
@@ -499,7 +499,7 @@ protected:
             if (value < 0)
                 fluidState.setPressure(phaseIdx, 0.0);
 
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 value = fluidState.moleFraction(phaseIdx, compIdx);
                 if (value < 0)
                     fluidState.setMoleFraction(phaseIdx, compIdx, 0.0);
@@ -508,7 +508,7 @@ protected:
 
         // last saturation
         if (sumSat > 1.05) {
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 Scalar value = fluidState.saturation(phaseIdx)/(0.95*sumSat);
                 fluidState.setSaturation(phaseIdx, value);
             }
@@ -530,7 +530,7 @@ protected:
         // calculate the saturation of the last phase as a function of
         // the other saturations
         Evaluation sumSat = 0.0;
-        for (int phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx)
             sumSat += fluidState.saturation(phaseIdx);
         fluidState.setSaturation(/*phaseIdx=*/numPhases - 1, 1.0 - sumSat);
 
@@ -539,7 +539,7 @@ protected:
         // solved for.)
         Dune::FieldVector<Scalar, numPhases> pC;
         MaterialLaw::capillaryPressures(pC, matParams, fluidState);
-        for (int phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
             fluidState.setPressure(phaseIdx,
                                    fluidState.pressure(0)
                                    + (pC[phaseIdx] - pC[0]));
@@ -548,47 +548,47 @@ protected:
         paramCache.updateAll(fluidState, /*except=*/ParameterCache::Temperature);
 
         // update all densities and fugacity coefficients
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
             const Evaluation& rho = FluidSystem::density(fluidState, paramCache, phaseIdx);
             fluidState.setDensity(phaseIdx, rho);
 
-            for (int compIdx = 0; compIdx < numComponents; ++ compIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
                 const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
                 fluidState.setFugacityCoefficient(phaseIdx, compIdx, phi);
             }
         }
     }
 
-    static bool isPressureIdx_(int pvIdx)
+    static bool isPressureIdx_(unsigned pvIdx)
     { return pvIdx == 0; }
 
-    static bool isSaturationIdx_(int pvIdx)
+    static bool isSaturationIdx_(unsigned pvIdx)
     { return 1 <= pvIdx && pvIdx < numPhases; }
 
-    static bool isMoleFracIdx_(int pvIdx)
+    static bool isMoleFracIdx_(unsigned pvIdx)
     { return numPhases <= pvIdx && pvIdx < numPhases + numPhases*numComponents; }
 
     // retrieves a quantity from the fluid state
     template <class FluidState>
-    static const typename FluidState::Scalar& getQuantity_(const FluidState &fluidState, int pvIdx)
+    static const typename FluidState::Scalar& getQuantity_(const FluidState &fluidState, unsigned pvIdx)
     {
         assert(pvIdx < numEq);
 
         // first pressure
         if (pvIdx < 1) {
-            int phaseIdx = 0;
+            unsigned phaseIdx = 0;
             return fluidState.pressure(phaseIdx);
         }
         // first M - 1 saturations
         else if (pvIdx < numPhases) {
-            int phaseIdx = pvIdx - 1;
+            unsigned phaseIdx = pvIdx - 1;
             return fluidState.saturation(phaseIdx);
         }
         // mole fractions
         else // if (pvIdx < numPhases + numPhases*numComponents)
         {
-            int phaseIdx = (pvIdx - numPhases)/numComponents;
-            int compIdx = (pvIdx - numPhases)%numComponents;
+            unsigned phaseIdx = (pvIdx - numPhases)/numComponents;
+            unsigned compIdx = (pvIdx - numPhases)%numComponents;
             return fluidState.moleFraction(phaseIdx, compIdx);
         }
     }
@@ -598,7 +598,7 @@ protected:
     static void setQuantity_(FluidState &fluidState,
                              ParameterCache &paramCache,
                              const typename MaterialLaw::Params &matParams,
-                             int pvIdx,
+                             unsigned pvIdx,
                              const typename FluidState::Scalar& value)
     {
         typedef typename FluidState::Scalar Evaluation;
@@ -610,17 +610,17 @@ protected:
 
             // set all pressures. here we assume that the capillary
             // pressure does not depend on absolute pressure.
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
                 fluidState.setPressure(phaseIdx, fluidState.pressure(phaseIdx) + delta);
             paramCache.updateAllPressures(fluidState);
 
             // update all densities and fugacity coefficients
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 const Evaluation& rho = FluidSystem::density(fluidState, paramCache, phaseIdx);
                 Valgrind::CheckDefined(rho);
                 fluidState.setDensity(phaseIdx, rho);
 
-                for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+                for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                     const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
                     Valgrind::CheckDefined(phi);
                     fluidState.setFugacityCoefficient(phaseIdx, compIdx, phi);
@@ -641,19 +641,19 @@ protected:
             Dune::FieldVector<Evaluation, numPhases> pC;
             MaterialLaw::capillaryPressures(pC, matParams, fluidState);
             Valgrind::CheckDefined(pC);
-            for (int phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
+            for (unsigned phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
                 fluidState.setPressure(phaseIdx,
                                        fluidState.pressure(0)
                                        + (pC[phaseIdx] - pC[0]));
             paramCache.updateAllPressures(fluidState);
 
             // update all densities and fugacity coefficients
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 const Evaluation& rho = FluidSystem::density(fluidState, paramCache, phaseIdx);
                 Valgrind::CheckDefined(rho);
                 fluidState.setDensity(phaseIdx, rho);
 
-                for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+                for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                     const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
                     Valgrind::CheckDefined(phi);
                     fluidState.setFugacityCoefficient(phaseIdx, compIdx, phi);
@@ -662,8 +662,8 @@ protected:
         }
         else if (pvIdx < numPhases + numPhases*numComponents) // <- mole fractions
         {
-            int phaseIdx = (pvIdx - numPhases)/numComponents;
-            int compIdx = (pvIdx - numPhases)%numComponents;
+            unsigned phaseIdx = (pvIdx - numPhases)/numComponents;
+            unsigned compIdx = (pvIdx - numPhases)%numComponents;
 
             Valgrind::CheckDefined(value);
             fluidState.setMoleFraction(phaseIdx, compIdx, value);
@@ -677,7 +677,7 @@ protected:
             // if the phase's fugacity coefficients are composition
             // dependent, update them as well.
             if (!FluidSystem::isIdealMixture(phaseIdx)) {
-                for (int fugCompIdx = 0; fugCompIdx < numComponents; ++fugCompIdx) {
+                for (unsigned fugCompIdx = 0; fugCompIdx < numComponents; ++fugCompIdx) {
                     const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState, paramCache, phaseIdx, fugCompIdx);
                     Valgrind::CheckDefined(phi);
                     fluidState.setFugacityCoefficient(phaseIdx, fugCompIdx, phi);
@@ -692,7 +692,7 @@ protected:
     // set a quantity in the fluid state
     template <class FluidState>
     static void setQuantityRaw_(FluidState &fluidState,
-                                int pvIdx,
+                                unsigned pvIdx,
                                 const typename FluidState::Scalar& value)
     {
         assert(pvIdx < numEq);
@@ -700,25 +700,25 @@ protected:
         Valgrind::CheckDefined(value);
         // first pressure
         if (pvIdx < 1) {
-            int phaseIdx = 0;
+            unsigned phaseIdx = 0;
             fluidState.setPressure(phaseIdx, value);
         }
         // first M - 1 saturations
         else if (pvIdx < numPhases) {
-            int phaseIdx = pvIdx - 1;
+            unsigned phaseIdx = pvIdx - 1;
             fluidState.setSaturation(phaseIdx, value);
         }
         // mole fractions
         else // if (pvIdx < numPhases + numPhases*numComponents)
         {
-            int phaseIdx = (pvIdx - numPhases)/numComponents;
-            int compIdx = (pvIdx - numPhases)%numComponents;
+            unsigned phaseIdx = (pvIdx - numPhases)/numComponents;
+            unsigned compIdx = (pvIdx - numPhases)%numComponents;
             fluidState.setMoleFraction(phaseIdx, compIdx, value);
         }
     }
 
     template <class FluidState>
-    static Scalar quantityWeight_(const FluidState &fluidState, int pvIdx)
+    static Scalar quantityWeight_(const FluidState &/*fluidState*/, unsigned pvIdx)
     {
         // first pressure
         if (pvIdx < 1)

--- a/opm/material/eos/PengRobinson.hpp
+++ b/opm/material/eos/PengRobinson.hpp
@@ -60,8 +60,8 @@ class PengRobinson
     { }
 
 public:
-    static void  init(Scalar aMin, Scalar aMax, int na,
-                      Scalar bMin, Scalar bMax, int nb)
+    static void  init(Scalar /*aMin*/, Scalar /*aMax*/, unsigned /*na*/,
+                      Scalar /*bMin*/, Scalar /*bMax*/, unsigned /*nb*/)
     {
 /*
         // resize the tabulation for the critical points
@@ -70,11 +70,11 @@ public:
         criticalMolarVolume_.resize(aMin, aMax, na, bMin, bMax, nb);
 
         Scalar VmCrit, pCrit, TCrit;
-        for (int i = 0; i < na; ++i) {
+        for (unsigned i = 0; i < na; ++i) {
             Scalar a = criticalTemperature_.iToX(i);
             assert(std::abs(criticalTemperature_.xToI(criticalTemperature_.iToX(i)) - i) < 1e-10);
 
-            for (int j = 0; j < nb; ++j) {
+            for (unsigned j = 0; j < nb; ++j) {
                 Scalar b = criticalTemperature_.jToY(j);
                 assert(std::abs(criticalTemperature_.yToJ(criticalTemperature_.jToY(j)) - j) < 1e-10);
 
@@ -112,7 +112,7 @@ public:
         Scalar pVap = ambroseWalton_(params, T);
 
         // Newton-Raphson method
-        for (int i = 0; i < 5; ++i) {
+        for (unsigned i = 0; i < 5; ++i) {
             // calculate the molar densities
             OPM_UNUSED int numSol = molarVolumes(Vm, params, T, pVap);
             assert(numSol == 3);
@@ -141,7 +141,7 @@ public:
     template <class FluidState, class Params>
     static Scalar computeMolarVolume(const FluidState &fs,
                                      Params &params,
-                                     int phaseIdx,
+                                     unsigned phaseIdx,
                                      bool isGasPhase)
     {
         Valgrind::CheckDefined(fs.temperature(phaseIdx));
@@ -156,7 +156,7 @@ public:
         Scalar a = params.a(phaseIdx); // "attractive factor"
         Scalar b = params.b(phaseIdx); // "co-volume"
 
-        if (!std::isfinite(a) || a == 0)
+        if (!std::isfinite(a) || std::abs(a) < 1e-30)
             return std::numeric_limits<Scalar>::quiet_NaN();
         if (!std::isfinite(b) || b <= 0)
             return std::numeric_limits<Scalar>::quiet_NaN();
@@ -274,9 +274,9 @@ public:
 protected:
     template <class FluidState, class Params>
     static void handleCriticalFluid_(Scalar &Vm,
-                                     const FluidState &fs,
+                                     const FluidState &/*fs*/,
                                      const Params &params,
-                                     int phaseIdx,
+                                     unsigned phaseIdx,
                                      bool isGasPhase)
     {
         Scalar Tcrit, pcrit, Vcrit;
@@ -310,7 +310,7 @@ protected:
         // first, we need to find an isotherm where the EOS exhibits
         // a maximum and a minimum
         Scalar Tmin = 250; // [K]
-        for (int i = 0; i < 30; ++i) {
+        for (unsigned i = 0; i < 30; ++i) {
             bool hasExtrema = findExtrema_(minVm, maxVm, minP, maxP, a, b, Tmin);
             if (hasExtrema)
                 break;
@@ -321,8 +321,8 @@ protected:
 
         // Newton's method: Start at minimum temperature and minimize
         // the "gap" between the extrema of the EOS
-        int iMax = 100;
-        for (int i = 0; i < iMax; ++i) {
+        unsigned iMax = 100;
+        for (unsigned i = 0; i < iMax; ++i) {
             // calculate function we would like to minimize
             Scalar f = maxVm - minVm;
 
@@ -363,7 +363,7 @@ protected:
 
             // line search (we have to make sure that both extrema
             // still exist after the update)
-            for (int j = 0; ; ++j) {
+            for (unsigned j = 0; ; ++j) {
                 if (j >= 20) {
                     if (f < 1e-8) {
                         Tcrit = T;
@@ -393,8 +393,8 @@ protected:
     // which are larger than the covolume of the phase
     static bool findExtrema_(Scalar &Vmin,
                              Scalar &Vmax,
-                             Scalar &pMin,
-                             Scalar &pMax,
+                             Scalar &/*pMin*/,
+                             Scalar &/*pMax*/,
                              Scalar a,
                              Scalar b,
                              Scalar T)
@@ -425,7 +425,7 @@ protected:
         // above the covolume
         Scalar V = b*1.1;
         Scalar delta = 1.0;
-        for (int i = 0; std::abs(delta) > 1e-12; ++i) {
+        for (unsigned i = 0; std::abs(delta) > 1e-12; ++i) {
             Scalar f = a5 + V*(a4 + V*(a3 + V*(a2 + V*a1)));
             Scalar fPrime = a4 + V*(2*a3 + V*(3*a2 + V*4*a1));
 
@@ -486,7 +486,7 @@ protected:
      * Appl. Chem., 61, 1395-1403, 1989
      */
     template <class Params>
-    static Scalar ambroseWalton_(const Params &params, Scalar T)
+    static Scalar ambroseWalton_(const Params &/*params*/, Scalar T)
     {
         typedef typename Params::Component Component;
 

--- a/opm/material/eos/PengRobinsonMixture.hpp
+++ b/opm/material/eos/PengRobinsonMixture.hpp
@@ -63,7 +63,7 @@ public:
     template <class MutableParams, class FluidState>
     static int computeMolarVolumes(Scalar *Vm,
                                    const MutableParams &params,
-                                   int phaseIdx,
+                                   unsigned phaseIdx,
                                    const FluidState &fs)
     {
         return PengRobinson::computeMolarVolumes(Vm, params, phaseIdx, fs);
@@ -89,8 +89,8 @@ public:
     template <class FluidState, class Params>
     static Scalar computeFugacityCoefficient(const FluidState &fs,
                                              const Params &params,
-                                             int phaseIdx,
-                                             int compIdx)
+                                             unsigned phaseIdx,
+                                             unsigned compIdx)
     {
         // note that we normalize the component mole fractions, so
         // that their sum is 100%. This increases numerical stability
@@ -111,11 +111,11 @@ public:
 
         // calculate delta_i (see: Reid, p. 145)
         Scalar sumMoleFractions = 0.0;
-        for (int compJIdx = 0; compJIdx < numComponents; ++compJIdx)
+        for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx)
             sumMoleFractions += fs.moleFraction(phaseIdx, compJIdx);
         Scalar deltai = 2*std::sqrt(params.aPure(phaseIdx, compIdx))/params.a(phaseIdx);
         Scalar tmp = 0;
-        for (int compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
+        for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
             tmp +=
                 fs.moleFraction(phaseIdx, compJIdx)
                 / sumMoleFractions

--- a/opm/material/eos/PengRobinsonParamsMixture.hpp
+++ b/opm/material/eos/PengRobinsonParamsMixture.hpp
@@ -50,7 +50,7 @@ namespace Opm
  * Evaluation of Miscible Flood Simulators, Ninth SPE Symposium on
  * Reservoir Simulation, 1987
  */
-template <class Scalar, class FluidSystem, int phaseIdx, bool useSpe5Relations=false>
+template <class Scalar, class FluidSystem, unsigned phaseIdx, bool useSpe5Relations=false>
 class PengRobinsonParamsMixture
     : public PengRobinsonParams<Scalar>
 {
@@ -88,7 +88,7 @@ public:
         //
         // See: R. Reid, et al.: The Properties of Gases and Liquids,
         // 4th edition, McGraw-Hill, 1987, p. 43
-        for (int i = 0; i < numComponents; ++i) {
+        for (unsigned i = 0; i < numComponents; ++i) {
             Scalar pc = FluidSystem::criticalPressure(i);
             Scalar omega = FluidSystem::acentricFactor(i);
             Scalar Tr = temperature/FluidSystem::criticalTemperature(i);
@@ -133,7 +133,7 @@ public:
     void updateMix(const FluidState &fs)
     {
         Scalar sumx = 0.0;
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             sumx += fs.moleFraction(phaseIdx, compIdx);
         sumx = std::max(1e-10, sumx);
 
@@ -143,11 +143,11 @@ public:
         // 4th edition, McGraw-Hill, 1987, p. 82
         Scalar a = 0;
         Scalar b = 0;
-        for (int compIIdx = 0; compIIdx < numComponents; ++compIIdx) {
+        for (unsigned compIIdx = 0; compIIdx < numComponents; ++compIIdx) {
             Scalar xi = std::max(0.0, std::min(1.0, fs.moleFraction(phaseIdx, compIIdx)));
             Valgrind::CheckDefined(xi);
 
-            for (int compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
+            for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
                 Scalar xj = std::max(0.0, std::min(1.0, fs.moleFraction(phaseIdx, compJIdx)));
                 Valgrind::CheckDefined(xj);
 
@@ -181,7 +181,7 @@ public:
      */
     template <class FluidState>
     void updateSingleMoleFraction(const FluidState &fs,
-                                  int compIdx)
+                                  unsigned /*compIdx*/)
     {
         updateMix(fs);
     }
@@ -189,13 +189,13 @@ public:
     /*!
      * \brief Return the Peng-Robinson parameters of a pure substance,
      */
-    const PureParams &pureParams(int compIdx) const
+    const PureParams &pureParams(unsigned compIdx) const
     { return pureParams_[compIdx]; }
 
     /*!
      * \brief Returns the Peng-Robinson parameters for a pure component.
      */
-    const PureParams &operator[](int compIdx) const
+    const PureParams &operator[](unsigned compIdx) const
     {
         assert(0 <= compIdx && compIdx < numComponents);
         return pureParams_[compIdx];
@@ -208,7 +208,7 @@ public:
     void checkDefined() const
     {
 #ifndef NDEBUG
-        for (int i = 0; i < numComponents; ++i)
+        for (unsigned i = 0; i < numComponents; ++i)
             pureParams_[i].checkDefined();
 
         Valgrind::CheckDefined(this->a());
@@ -222,8 +222,8 @@ protected:
 private:
     void updateACache_()
     {
-        for (int compIIdx = 0; compIIdx < numComponents; ++ compIIdx) {
-            for (int compJIdx = 0; compJIdx < numComponents; ++ compJIdx) {
+        for (unsigned compIIdx = 0; compIIdx < numComponents; ++ compIIdx) {
+            for (unsigned compJIdx = 0; compJIdx < numComponents; ++ compJIdx) {
                 // interaction coefficient as given in SPE5
                 Scalar Psi = FluidSystem::interactionCoefficient(compIIdx, compJIdx);
 
@@ -238,7 +238,7 @@ private:
     Scalar aCache_[numComponents][numComponents];
 };
 
-template <class Scalar, class FluidSystem, int phaseIdx, bool useSpe5Relations>
+template <class Scalar, class FluidSystem, unsigned phaseIdx, bool useSpe5Relations>
 const Scalar PengRobinsonParamsMixture<Scalar, FluidSystem, phaseIdx, useSpe5Relations>::R = Opm::Constants<Scalar>::R;
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -188,13 +188,10 @@ public:
      * \brief The inverse of the capillary pressure
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &values,
-                            const Params &params,
-                            const FluidState &fs)
+    static void saturations(ContainerT& /*values*/,
+                            const Params& /*params*/,
+                            const FluidState& /*fluidState*/)
     {
-        static_cast<void>(values);
-        static_cast<void>(params);
-        static_cast<void>(fs);
         OPM_THROW(std::logic_error, "Not implemented: saturations()");
     }
 
@@ -202,11 +199,9 @@ public:
      * \brief The saturation of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sg(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sg(const Params& /*params*/,
+                         const FluidState& /*fluidState*/)
     {
-        static_cast<void>(params);
-        static_cast<void>(fluidState);
         OPM_THROW(std::logic_error, "Not implemented: Sg()");
     }
 
@@ -214,11 +209,9 @@ public:
      * \brief The saturation of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sn(const Params& /*params*/,
+                         const FluidState& /*fluidState*/)
     {
-        static_cast<void>(params);
-        static_cast<void>(fluidState);
         OPM_THROW(std::logic_error, "Not implemented: Sn()");
     }
 
@@ -226,11 +219,9 @@ public:
      * \brief The saturation of the wetting (i.e., water) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params,
-                         const FluidState &fluidState)
+    static Evaluation Sw(const Params& /*params*/,
+                         const FluidState& /*fluidState*/)
     {
-        static_cast<void>(params);
-        static_cast<void>(fluidState);
         OPM_THROW(std::logic_error, "Not implemented: Sw()");
     }
 

--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -68,63 +68,63 @@ public:
      * \brief Specify whether saturation scaling is enabled.
      */
     void setEnableSatScaling(bool yesno)
-    { enableSatScaling_ = yesno; };
+    { enableSatScaling_ = yesno; }
 
     /*!
      * \brief Returns whether saturation scaling is enabled.
      */
     bool enableSatScaling() const
-    { return enableSatScaling_; };
+    { return enableSatScaling_; }
 
     /*!
      * \brief Specify whether three point saturation scaling is enabled for the relative
      *        permeabilities.
      */
     void setEnableThreePointKrSatScaling(bool yesno)
-    { enableThreePointKrSatScaling_ = yesno; };
+    { enableThreePointKrSatScaling_ = yesno; }
 
     /*!
      * \brief Returns whether three point saturation scaling is enabled for the relative
      *        permeabilities.
      */
     bool enableThreePointKrSatScaling() const
-    { return enableThreePointKrSatScaling_; };
+    { return enableThreePointKrSatScaling_; }
 
     /*!
      * \brief Specify whether relative permeability scaling is enabled for the wetting phase.
      */
     void setEnableKrwScaling(bool yesno)
-    { enableKrwScaling_ = yesno; };
+    { enableKrwScaling_ = yesno; }
 
     /*!
      * \brief Returns whether relative permeability scaling is enabled for the wetting phase.
      */
     bool enableKrwScaling() const
-    { return enableKrwScaling_; };
+    { return enableKrwScaling_; }
 
     /*!
      * \brief Specify whether relative permeability scaling is enabled for the non-wetting phase.
      */
     void setEnableKrnScaling(bool yesno)
-    { enableKrnScaling_ = yesno; };
+    { enableKrnScaling_ = yesno; }
 
     /*!
      * \brief Returns whether relative permeability scaling is enabled for the non-wetting phase.
      */
     bool enableKrnScaling() const
-    { return enableKrnScaling_; };
+    { return enableKrnScaling_; }
 
     /*!
      * \brief Specify whether capillary pressure scaling is enabled.
      */
     void setEnablePcScaling(bool yesno)
-    { enablePcScaling_ = yesno; };
+    { enablePcScaling_ = yesno; }
 
     /*!
      * \brief Returns whether capillary pressure scaling is enabled.
      */
     bool enablePcScaling() const
-    { return enablePcScaling_; };
+    { return enablePcScaling_; }
 
 #if HAVE_OPM_PARSER
     /*!

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -179,7 +179,7 @@ struct EclEpsScalingPointsInfo
      */
     void extractUnscaled(Opm::DeckConstPtr deck,
                          Opm::EclipseStateConstPtr eclState,
-                         int satRegionIdx)
+                         unsigned satRegionIdx)
     {
         // TODO: support for the SOF2/SOF3 keyword family
         auto tables = eclState->getTableManager();
@@ -243,8 +243,8 @@ struct EclEpsScalingPointsInfo
             extractUnscaledSof3_(sof3Tables[satRegionIdx]);
 
             // some safety checks mandated by the ECL documentation
-            assert(Sowu == 1 - swfnTables[satRegionIdx].getSwColumn().front());
-            assert(maxKrw == maxKrg);
+            assert(std::abs(Sowu - (1 - swfnTables[satRegionIdx].getSwColumn().front())) < 1e-30);
+            assert(std::abs(maxKrw - maxKrg) < 1e-30);
 
         }
         else {
@@ -259,7 +259,7 @@ struct EclEpsScalingPointsInfo
      *
      * I.e., the values which are "seen" by the physical model.
      */
-    void extractScaled(const EclEpsGridProperties& epsProperties, int cartesianCellIdx)
+    void extractScaled(const EclEpsGridProperties& epsProperties, unsigned cartesianCellIdx)
     {
         // overwrite the unscaled values with the values for the cell if it is
         // explicitly specified by the corresponding keyword.
@@ -304,10 +304,10 @@ private:
         }
 
         // critical oil saturation of gas-oil system
-        for (int rowIdx = sgofTable.numRows() - 1; rowIdx >= 0; -- rowIdx) {
-            if (sgofTable.getKrogColumn()[rowIdx] > 0) {
-                assert(rowIdx < (int) sgofTable.numRows() - 1);
-                Sogcr = 1.0 - sgofTable.getSgColumn()[rowIdx + 1];
+        for (int rowIdx = static_cast<int>(sgofTable.numRows()) - 1; rowIdx >= 0; -- rowIdx) {
+            if (sgofTable.getKrogColumn()[static_cast<size_t>(rowIdx)] > 0) {
+                assert(rowIdx < static_cast<int>(sgofTable.numRows()) - 1);
+                Sogcr = 1.0 - sgofTable.getSgColumn()[static_cast<unsigned>(rowIdx) + 1];
                 break;
             };
         }
@@ -333,16 +333,16 @@ private:
         Sogu = slgofTable.getSlColumn().back();
 
         // critical gas saturation
-        for (int rowIdx = slgofTable.numRows() - 1; rowIdx >= 0; -- rowIdx) {
-            if (slgofTable.getKrgColumn()[rowIdx] > 0) {
-                assert(rowIdx < (int) slgofTable.numRows() - 1);
-                Sgcr = 1 - slgofTable.getSlColumn()[rowIdx + 1];
+        for (int rowIdx = static_cast<int>(slgofTable.numRows()) - 1; rowIdx >= 0; -- rowIdx) {
+            if (slgofTable.getKrgColumn()[static_cast<size_t>(rowIdx)] > 0) {
+                assert(rowIdx < static_cast<int>(slgofTable.numRows()) - 1);
+                Sgcr = 1 - slgofTable.getSlColumn()[static_cast<unsigned>(rowIdx) + 1];
                 break;
             };
         }
 
         // critical oil saturation of gas-oil system
-        for (unsigned rowIdx = 0; rowIdx < slgofTable.numRows(); ++ rowIdx) {
+        for (size_t rowIdx = 0; rowIdx < slgofTable.numRows(); ++ rowIdx) {
             if (slgofTable.getKrogColumn()[rowIdx] > 0) {
                 assert(rowIdx > 0);
                 Sogcr = slgofTable.getSlColumn()[rowIdx - 1];
@@ -369,7 +369,7 @@ private:
         Sowu = 1.0 - swofTable.getSwColumn().front();
 
         // critical water saturation
-        for (unsigned rowIdx = 0; rowIdx < swofTable.numRows(); ++ rowIdx) {
+        for (size_t rowIdx = 0; rowIdx < swofTable.numRows(); ++ rowIdx) {
             if (swofTable.getKrwColumn()[rowIdx] > 0) {
                 assert(rowIdx > 0);
                 Swcr = swofTable.getSwColumn()[rowIdx - 1];
@@ -378,10 +378,10 @@ private:
         }
 
         // critical oil saturation of oil-water system
-        for (int rowIdx = swofTable.numRows() - 1; rowIdx >= 0; -- rowIdx) {
-            if (swofTable.getKrowColumn()[rowIdx] > 0) {
-                assert(rowIdx < (int) swofTable.numRows() - 1);
-                Sowcr = 1.0 - swofTable.getSwColumn()[rowIdx + 1];
+        for (int rowIdx = static_cast<int>(swofTable.numRows()) - 1; rowIdx >= 0; -- rowIdx) {
+            if (swofTable.getKrowColumn()[static_cast<size_t>(rowIdx)] > 0) {
+                assert(rowIdx < static_cast<int>(swofTable.numRows()) - 1);
+                Sowcr = 1.0 - swofTable.getSwColumn()[static_cast<unsigned>(rowIdx) + 1];
                 break;
             };
         }
@@ -477,7 +477,7 @@ private:
 
     void extractGridPropertyValue_(Scalar& targetValue,
                                    const std::vector<double>* propData,
-                                   int cartesianCellIdx)
+                                   unsigned cartesianCellIdx)
     {
         if (!propData)
             return;
@@ -578,7 +578,7 @@ public:
     /*!
      * \brief Sets an saturation value for capillary pressure saturation scaling
      */
-    void setSaturationPcPoint(int pointIdx, Scalar value)
+    void setSaturationPcPoint(unsigned pointIdx, Scalar value)
     { saturationPcPoints_[pointIdx] = value; }
 
     /*!
@@ -590,7 +590,7 @@ public:
     /*!
      * \brief Sets an saturation value for wetting-phase relperm saturation scaling
      */
-    void setSaturationKrwPoint(int pointIdx, Scalar value)
+    void setSaturationKrwPoint(unsigned pointIdx, Scalar value)
     { saturationKrwPoints_[pointIdx] = value; }
 
     /*!
@@ -602,7 +602,7 @@ public:
     /*!
      * \brief Sets an saturation value for non-wetting phase relperm saturation scaling
      */
-    void setSaturationKrnPoint(int pointIdx, Scalar value)
+    void setSaturationKrnPoint(unsigned pointIdx, Scalar value)
     { saturationKrnPoints_[pointIdx] = value; }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -106,11 +106,8 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container &values, const Params &params, const FluidState &fs)
+    static void capillaryPressures(Container& /*values*/, const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        static_cast<void>(values);
-        static_cast<void>(params);
-        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The capillaryPressures(fs) method is not yet implemented");
     }
@@ -126,11 +123,8 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container &values, const Params &params, const FluidState &fs)
+    static void relativePermeabilities(Container& /*values*/, const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        static_cast<void>(values);
-        static_cast<void>(params);
-        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The pcnw(fs) method is not yet implemented");
     }
@@ -147,10 +141,8 @@ public:
      *         Genuchten, linear...)
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fs)
+    static Evaluation pcnw(const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        static_cast<void>(params);
-        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The pcnw(fs) method is not yet implemented");
     }
@@ -175,11 +167,8 @@ public:
      * \brief The saturation-capillary pressure curves.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &values, const Params &params, const FluidState &fs)
+    static void saturations(Container& /*values*/, const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        static_cast<void>(values);
-        static_cast<void>(params);
-        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The saturations(fs) method is not yet implemented");
     }
@@ -189,19 +178,15 @@ public:
      *        the rest of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fs)
+    static Evaluation Sw(const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        static_cast<void>(params);
-        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The Sw(fs) method is not yet implemented");
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &params, const Evaluation& pc)
+    static Evaluation twoPhaseSatSw(const Params& /*params*/, const Evaluation& /*pc*/)
     {
-        static_cast<void>(params);
-        static_cast<void>(pc);
         OPM_THROW(NotAvailable,
                   "The twoPhaseSatSw(pc) method is not yet implemented");
     }
@@ -211,19 +196,15 @@ public:
      *        the rest of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fs)
+    static Evaluation Sn(const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        static_cast<void>(params);
-        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The Sn(pc) method is not yet implemented");
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params &params, const Evaluation& pc)
+    static Evaluation twoPhaseSatSn(const Params& /*params*/, const Evaluation& /*pc*/)
     {
-        static_cast<void>(params);
-        static_cast<void>(pc);
         OPM_THROW(NotAvailable,
                   "The twoPhaseSatSn(pc) method is not yet implemented");
     }
@@ -238,10 +219,8 @@ public:
      *
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fs)
+    static Evaluation krw(const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        static_cast<void>(params);
-        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The krw(fs) method is not yet implemented");
     }
@@ -266,10 +245,8 @@ public:
      * \brief The relative permeability of the non-wetting phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fs)
+    static Evaluation krn(const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        static_cast<void>(params);
-        static_cast<void>(fs);
         OPM_THROW(NotAvailable,
                   "The krn(fs) method is not yet implemented");
     }

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -56,13 +56,13 @@ public:
      * \brief Specify whether hysteresis is enabled or not.
      */
     void setEnableHysteresis(bool yesno)
-    { enableHysteresis_ = yesno; };
+    { enableHysteresis_ = yesno; }
 
     /*!
      * \brief Returns whether hysteresis is enabled.
      */
     bool enableHysteresis() const
-    { return enableHysteresis_; };
+    { return enableHysteresis_; }
 
     /*!
      * \brief Set the type of the hysteresis model which is used for capillary pressure.
@@ -71,7 +71,7 @@ public:
      * 0: use the Killough model for capillary pressure hysteresis
      */
     void setPcHysteresisModel(int value)
-    { pcHysteresisModel_ = value; };
+    { pcHysteresisModel_ = value; }
 
     /*!
      * \brief Return the type of the hysteresis model which is used for capillary pressure.
@@ -80,7 +80,7 @@ public:
      * 0: use the Killough model for capillary pressure hysteresis
      */
     int pcHysteresisModel() const
-    { return pcHysteresisModel_; };
+    { return pcHysteresisModel_; }
 
     /*!
      * \brief Set the type of the hysteresis model which is used for relative permeability.
@@ -89,7 +89,7 @@ public:
      * 0: use the Carlson model for relative permeability hysteresis
      */
     void setKrHysteresisModel(int value)
-    { krHysteresisModel_ = value; };
+    { krHysteresisModel_ = value; }
 
     /*!
      * \brief Return the type of the hysteresis model which is used for relative permeability.
@@ -98,7 +98,7 @@ public:
      * 0: use the Carlson model for relative permeability hysteresis
      */
     int krHysteresisModel() const
-    { return krHysteresisModel_; };
+    { return krHysteresisModel_; }
 
 #if HAVE_OPM_PARSER
     /*!

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -151,14 +151,14 @@ public:
      *        drainage curve (MDC) to imbibition happend on the capillary pressure curve.
      */
     void setPcSwMdc(Scalar value)
-    { pcSwMdc_ = value; };
+    { pcSwMdc_ = value; }
 
     /*!
      * \brief Set the saturation of the wetting phase where the last switch from the main
      *        drainage curve to imbibition happend on the capillary pressure curve.
      */
     Scalar pcSwMdc() const
-    { return pcSwMdc_; };
+    { return pcSwMdc_; }
 
     /*!
      * \brief Set the saturation of the wetting phase where the last switch from the main
@@ -184,7 +184,7 @@ public:
      *        non-wetting phase.
      */
     void setKrnSwMdc(Scalar value)
-    { krnSwMdc_ = value; };
+    { krnSwMdc_ = value; }
 
     /*!
      * \brief Set the saturation of the wetting phase where the last switch from the main
@@ -192,7 +192,7 @@ public:
      *        non-wetting phase.
      */
     Scalar krnSwMdc() const
-    { return krnSwMdc_; };
+    { return krnSwMdc_; }
 
     /*!
      * \brief Sets the saturation value which must be added if krw is calculated using

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -117,16 +117,16 @@ public:
     {
         compressedToCartesianElemIdx_ = compressedToCartesianElemIdx;
         // get the number of saturation regions and the number of cells in the deck
-        int numSatRegions = deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0);
-        int numCompressedElems = compressedToCartesianElemIdx.size();
+        unsigned numSatRegions = static_cast<unsigned>(deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0));
+        size_t numCompressedElems = compressedToCartesianElemIdx.size();
 
         // copy the SATNUM grid property. in some cases this is not necessary, but it
         // should not require much memory anyway...
         satnumRegionIdx_.resize(numCompressedElems);
         if (eclState->hasIntGridProperty("SATNUM")) {
             const auto& satnumRawData = eclState->getIntGridProperty("SATNUM")->getData();
-            for (int elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
-                int cartesianElemIdx = compressedToCartesianElemIdx_[elemIdx];
+            for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
+                unsigned cartesianElemIdx = static_cast<unsigned>(compressedToCartesianElemIdx_[elemIdx]);
                 satnumRegionIdx_[elemIdx] = satnumRawData[cartesianElemIdx] - 1;
             }
         }
@@ -138,7 +138,7 @@ public:
         readGlobalThreePhaseOptions_(deck);
 
         unscaledEpsInfo_.resize(numSatRegions);
-        for (int satnumRegionIdx = 0; satnumRegionIdx < numSatRegions; ++satnumRegionIdx)
+        for (unsigned satnumRegionIdx = 0; satnumRegionIdx < numSatRegions; ++satnumRegionIdx)
             unscaledEpsInfo_[satnumRegionIdx].extractUnscaled(deck, eclState, satnumRegionIdx);
 
         if (!hasElementSpecificParameters())
@@ -155,7 +155,7 @@ public:
      * that the capillary pressure given depends on the particuars of how the simulator
      * calculates its initial condition.
      */
-    Scalar applySwatinit(int elemIdx,
+    Scalar applySwatinit(unsigned elemIdx,
                          Scalar pcow,
                          Scalar Sw)
     {
@@ -207,7 +207,7 @@ public:
     bool hasElementSpecificParameters() const
     { return enableEndPointScaling() || enableHysteresis(); }
 
-    MaterialLawParams& materialLawParams(int elemIdx)
+    MaterialLawParams& materialLawParams(unsigned elemIdx)
     {
         if (hasElementSpecificParameters()) {
             assert(0 <= elemIdx && elemIdx < (int) materialLawParams_.size());
@@ -217,7 +217,7 @@ public:
             return *materialLawParams_[satnumRegionIdx_[elemIdx]];
     }
 
-    const MaterialLawParams& materialLawParams(int elemIdx) const
+    const MaterialLawParams& materialLawParams(unsigned elemIdx) const
     {
         if (hasElementSpecificParameters()) {
             assert(0 <= elemIdx && elemIdx < (int) materialLawParams_.size());
@@ -228,7 +228,7 @@ public:
     }
 
     template <class FluidState>
-    void updateHysteresis(const FluidState& fluidState, int elemIdx)
+    void updateHysteresis(const FluidState& fluidState, unsigned elemIdx)
     {
         if (!enableHysteresis())
             return;
@@ -237,7 +237,7 @@ public:
         MaterialLaw::updateHysteresis(*threePhaseParams, fluidState);
     }
 
-    const Opm::EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(int elemIdx) const
+    const Opm::EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(unsigned elemIdx) const
     {
         if (hasElementSpecificParameters())
             return *oilWaterScaledEpsInfoDrainage_[elemIdx];
@@ -323,8 +323,8 @@ private:
 
     void initNonElemSpecific_(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
-        unsigned numSatRegions = deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0);
-        unsigned numCompressedElems = compressedToCartesianElemIdx_.size();;
+        unsigned numSatRegions = static_cast<unsigned>(deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0));
+        unsigned numCompressedElems = static_cast<unsigned>(compressedToCartesianElemIdx_.size());
 
         GasOilEffectiveParamVector gasOilEffectiveParamVector(numSatRegions);
         OilWaterEffectiveParamVector oilWaterEffectiveParamVector(numSatRegions);
@@ -332,7 +332,7 @@ private:
         OilWaterParamVector oilWaterParams(numSatRegions);
         MaterialLawParamsVector satRegionParams(numSatRegions);
         EclEpsScalingPointsInfo<Scalar> dummyInfo;
-        for (size_t satnumRegionIdx = 0; satnumRegionIdx < numSatRegions; ++satnumRegionIdx) {
+        for (unsigned satnumRegionIdx = 0; satnumRegionIdx < numSatRegions; ++satnumRegionIdx) {
             // the parameters for the effective two-phase matererial laws
             readGasOilEffectiveParameters_(gasOilEffectiveParamVector, deck, eclState, satnumRegionIdx);
             readOilWaterEffectiveParameters_(oilWaterEffectiveParamVector, deck, eclState, satnumRegionIdx);
@@ -381,15 +381,15 @@ private:
 
         materialLawParams_.resize(numCompressedElems);
         for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
-            int satnumRegionIdx = satnumRegionIdx_[elemIdx];
+            unsigned satnumRegionIdx = static_cast<unsigned>(satnumRegionIdx_[elemIdx]);
             materialLawParams_[elemIdx] = satRegionParams[satnumRegionIdx];
         }
     }
 
     void initElemSpecific_(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
-        unsigned numSatRegions = deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0);
-        unsigned numCompressedElems = compressedToCartesianElemIdx_.size();;
+        unsigned numSatRegions = static_cast<unsigned>(deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0));
+        unsigned numCompressedElems = static_cast<unsigned>(compressedToCartesianElemIdx_.size());
 
         // read the end point scaling configuration. this needs to be done only once per
         // deck.
@@ -480,7 +480,7 @@ private:
         const auto& imbnumData = eclState->getIntGridProperty("IMBNUM")->getData();
         assert(numCompressedElems == satnumRegionIdx_.size());
         for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
-            int satnumRegionIdx = satnumRegionIdx_[elemIdx];
+            unsigned satnumRegionIdx = static_cast<unsigned>(satnumRegionIdx_[elemIdx]);
 
             gasOilParams[elemIdx] = std::make_shared<GasOilTwoPhaseHystParams>();
             oilWaterParams[elemIdx] = std::make_shared<OilWaterTwoPhaseHystParams>();
@@ -510,7 +510,7 @@ private:
                                                            EclOilWaterSystem);
 
             if (enableHysteresis()) {
-                int imbRegionIdx = imbnumData[elemIdx] - 1;
+                unsigned imbRegionIdx = static_cast<unsigned>(imbnumData[elemIdx]) - 1;
 
                 auto gasOilImbParamsHyst = std::make_shared<GasOilEpsTwoPhaseParams>();
                 gasOilImbParamsHyst->setConfig(gasOilConfig);
@@ -542,7 +542,7 @@ private:
         materialLawParams_.resize(numCompressedElems);
         for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
             materialLawParams_[elemIdx] = std::make_shared<MaterialLawParams>();
-            int satnumRegionIdx = satnumRegionIdx_[elemIdx];
+            unsigned satnumRegionIdx = static_cast<unsigned>(satnumRegionIdx_[elemIdx]);
 
             initThreePhaseParams_(deck,
                                   eclState,
@@ -601,7 +601,7 @@ private:
     void readGasOilEffectiveParameters_(Container& dest,
                                         Opm::DeckConstPtr deck,
                                         Opm::EclipseStateConstPtr eclState,
-                                        int satnumRegionIdx)
+                                        unsigned satnumRegionIdx)
     {
         dest[satnumRegionIdx] = std::make_shared<GasOilEffectiveTwoPhaseParams>();
 
@@ -664,7 +664,9 @@ private:
                                                   tableManager->getSgfnTables()[satnumRegionIdx]);
             break;
         }
-        default:
+
+        //default:
+        case noFamily:
             throw std::domain_error("No valid saturation keyword family specified");
 
         }
@@ -728,7 +730,7 @@ private:
     void readOilWaterEffectiveParameters_(Container& dest,
                                           Opm::DeckConstPtr deck,
                                           Opm::EclipseStateConstPtr eclState,
-                                          int satnumRegionIdx)
+                                          unsigned satnumRegionIdx)
     {
         dest[satnumRegionIdx] = std::make_shared<OilWaterEffectiveTwoPhaseParams>();
 
@@ -789,7 +791,9 @@ private:
             effParams.finalize();
             break;
         }
-        default:
+
+        case noFamily:
+        //default:
             throw std::domain_error("No valid saturation keyword family specified");
 
         }
@@ -801,7 +805,7 @@ private:
                                    std::shared_ptr<EclEpsConfig> config,
                                    Opm::DeckConstPtr /* deck */,
                                    Opm::EclipseStateConstPtr /* eclState */,
-                                   int satnumRegionIdx)
+                                   unsigned satnumRegionIdx)
     {
         dest[satnumRegionIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
         dest[satnumRegionIdx]->init(unscaledEpsInfo_[satnumRegionIdx], *config, EclGasOilSystem);
@@ -812,7 +816,7 @@ private:
                                      std::shared_ptr<EclEpsConfig> config,
                                      Opm::DeckConstPtr /* deck */,
                                      Opm::EclipseStateConstPtr /* eclState */,
-                                     int satnumRegionIdx)
+                                     unsigned satnumRegionIdx)
     {
         dest[satnumRegionIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
         dest[satnumRegionIdx]->init(unscaledEpsInfo_[satnumRegionIdx], *config, EclOilWaterSystem);
@@ -823,10 +827,10 @@ private:
                                  PointsContainer& destPoints,
                                  std::shared_ptr<EclEpsConfig> config,
                                  const EclEpsGridProperties& epsGridProperties,
-                                 int elemIdx)
+                                 unsigned elemIdx)
     {
-        int cartElemIdx = compressedToCartesianElemIdx_[elemIdx];
-        int satnumRegionIdx = (*epsGridProperties.satnum)[cartElemIdx] - 1; // ECL uses Fortran indices!
+        unsigned cartElemIdx = static_cast<unsigned>(compressedToCartesianElemIdx_[elemIdx]);
+        unsigned satnumRegionIdx = (*epsGridProperties.satnum)[cartElemIdx] - 1; // ECL uses Fortran indices!
 
         destInfo[elemIdx] = std::make_shared<EclEpsScalingPointsInfo<Scalar> >(unscaledEpsInfo_[satnumRegionIdx]);
         destInfo[elemIdx]->extractScaled(epsGridProperties, cartElemIdx);
@@ -840,10 +844,10 @@ private:
                                    PointsContainer& destPoints,
                                    std::shared_ptr<EclEpsConfig> config,
                                    const EclEpsGridProperties& epsGridProperties,
-                                   int elemIdx)
+                                   unsigned elemIdx)
     {
-        int cartElemIdx = compressedToCartesianElemIdx_[elemIdx];
-        int satnumRegionIdx = (*epsGridProperties.satnum)[cartElemIdx] - 1; // ECL uses Fortran indices!
+        unsigned cartElemIdx = static_cast<unsigned>(compressedToCartesianElemIdx_[elemIdx]);
+        unsigned satnumRegionIdx = (*epsGridProperties.satnum)[cartElemIdx] - 1; // ECL uses Fortran indices!
 
         destInfo[elemIdx] = std::make_shared<EclEpsScalingPointsInfo<Scalar> >(unscaledEpsInfo_[satnumRegionIdx]);;
         destInfo[elemIdx]->extractScaled(epsGridProperties, cartElemIdx);
@@ -855,7 +859,7 @@ private:
     void initThreePhaseParams_(Opm::DeckConstPtr deck,
                                Opm::EclipseStateConstPtr /* eclState */,
                                MaterialLawParams& materialParams,
-                               int satnumIdx,
+                               unsigned satnumIdx,
                                const EclEpsScalingPointsInfo<Scalar>& epsInfo,
                                std::shared_ptr<OilWaterTwoPhaseHystParams> oilWaterParams,
                                std::shared_ptr<GasOilTwoPhaseHystParams> gasOilParams)
@@ -910,7 +914,7 @@ private:
         }
     }
 
-    EclEpsScalingPoints<Scalar>& getOilWaterScaledEpsPointsDrainage_(int elemIdx)
+    EclEpsScalingPoints<Scalar>& getOilWaterScaledEpsPointsDrainage_(unsigned elemIdx)
     {
         auto& materialParams = *materialLawParams_[elemIdx];
         switch (materialParams.approach()) {

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -79,6 +79,15 @@ public:
 #endif
     }
 
+    EclMultiplexerMaterialParams(const EclMultiplexerMaterialParams& /*other*/)
+    {
+        realParams_ = 0;
+
+#ifndef NDEBUG
+        finalized_ = false;
+#endif
+    }
+
     ~EclMultiplexerMaterialParams()
     {
         switch (approach()) {

--- a/opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp
@@ -117,7 +117,7 @@ public:
         typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
         OverlayFluidState overlayFs(fs);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
             overlayFs.setSaturation(phaseIdx,
                                     effectiveSaturation(params,
                                                         fs.saturation(phaseIdx),
@@ -143,7 +143,7 @@ public:
         typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
         OverlayFluidState overlayFs(fs);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
             overlayFs.setSaturation(phaseIdx,
                                     effectiveSaturation(params,
                                                         fs.saturation(phaseIdx),
@@ -174,7 +174,7 @@ public:
                       "number of phases!");
 
         OverlayFluidState overlayFs(fs);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
             overlayFs.setSaturation(phaseIdx,
                                     effectiveSaturation(params,
                                                         fs.saturation(phaseIdx),
@@ -200,7 +200,7 @@ public:
     static void saturations(Container &values, const Params &params, const FluidState &fs)
     {
         EffLaw::template saturations<Container, FluidState>(values, params, fs);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             values[phaseIdx] = absoluteSaturation(params, values[phaseIdx], phaseIdx);
         }
     }
@@ -279,7 +279,7 @@ public:
                       "number of phases!");
 
         OverlayFluidState overlayFs(fs);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
             overlayFs.setSaturation(phaseIdx,
                                     effectiveSaturation(params,
                                                         fs.saturation(phaseIdx),
@@ -307,7 +307,7 @@ public:
                       "number of phases!");
 
         OverlayFluidState overlayFs(fs);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
             overlayFs.setSaturation(phaseIdx,
                                     effectiveSaturation(params,
                                                         fs.saturation(phaseIdx),
@@ -338,7 +338,7 @@ public:
                       "number of phases!");
 
         OverlayFluidState overlayFs(fs);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
             overlayFs.setSaturation(phaseIdx,
                                     effectiveSaturation(params,
                                                         fs.saturation(phaseIdx),
@@ -352,14 +352,14 @@ public:
      * \brief Convert an absolute saturation to an effective one.
      */
     template <class Evaluation>
-    static Evaluation effectiveSaturation(const Params &params, const Evaluation& S, int phaseIdx)
+    static Evaluation effectiveSaturation(const Params &params, const Evaluation& S, unsigned phaseIdx)
     { return (S - params.residualSaturation(phaseIdx))/(1.0 - params.sumResidualSaturations()); }
 
     /*!
      * \brief Convert an effective saturation to an absolute one.
      */
     template <class Evaluation>
-    static Evaluation absoluteSaturation(const Params &params, const Evaluation& S, int phaseIdx)
+    static Evaluation absoluteSaturation(const Params &params, const Evaluation& S, unsigned phaseIdx)
     { return S*(1.0 - params.sumResidualSaturations()) + params.residualSaturation(phaseIdx); }
 
 private:
@@ -371,7 +371,7 @@ private:
      *                  is constructed accordingly. Afterwards the values are set there, too.
      * \return          Derivative of the effective saturation w.r.t. the absolute saturation.
      */
-    static Scalar dSeff_dSabs_(const Params &params, int phaseIdx)
+    static Scalar dSeff_dSabs_(const Params &params, int /*phaseIdx*/)
     { return 1.0/(1 - params.sumResidualSaturations()); }
 
     /*!
@@ -382,7 +382,7 @@ private:
      *                  is constructed accordingly. Afterwards the values are set there, too.
      * \return          Derivative of the absolute saturation w.r.t. the effective saturation.
      */
-    static Scalar dSabs_dSeff_(const Params &params, int phaseIdx)
+    static Scalar dSabs_dSeff_(const Params &params, int /*phaseIdx*/)
     { return 1 - params.sumResidualSaturations(); }
 };
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EffToAbsLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EffToAbsLawParams.hpp
@@ -48,7 +48,7 @@ public:
     EffToAbsLawParams()
         : EffLawParams()
     {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             residualSaturation_[phaseIdx] = 0.0;
 
 #ifndef NDEBUG
@@ -63,7 +63,7 @@ public:
     void finalize()
     {
         sumResidualSaturations_ = 0.0;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             sumResidualSaturations_ += residualSaturation_[phaseIdx];
 
         EffLawParams::finalize();
@@ -76,7 +76,7 @@ public:
     /*!
      * \brief Return the residual saturation of a phase.
      */
-    Scalar residualSaturation(int phaseIdx) const
+    Scalar residualSaturation(unsigned phaseIdx) const
     { assertFinalized_(); return residualSaturation_[phaseIdx]; }
 
     /*!
@@ -88,7 +88,7 @@ public:
     /*!
      * \brief Set the residual saturation of a phase.
      */
-    void setResidualSaturation(int phaseIdx, Scalar value)
+    void setResidualSaturation(unsigned phaseIdx, Scalar value)
     { residualSaturation_[phaseIdx] = value; }
 
 private:

--- a/opm/material/fluidmatrixinteractions/LinearMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/LinearMaterial.hpp
@@ -102,7 +102,7 @@ public:
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        for (int phaseIdx = 0; phaseIdx < Traits::numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < Traits::numPhases; ++phaseIdx) {
             const Evaluation& S =
                 FsToolbox::template toLhs<Evaluation>(state.saturation(phaseIdx));
             Valgrind::CheckDefined(S);
@@ -117,9 +117,9 @@ public:
      * \brief The inverse of the capillary pressure
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &values,
-                            const Params &params,
-                            const FluidState &state)
+    static void saturations(ContainerT &/*values*/,
+                            const Params &/*params*/,
+                            const FluidState &/*state*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: LinearMaterial::saturations()");
     }
@@ -129,14 +129,14 @@ public:
      */
     template <class ContainerT, class FluidState>
     static void relativePermeabilities(ContainerT &values,
-                                       const Params &params,
+                                       const Params &/*params*/,
                                        const FluidState &state)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         typedef MathToolbox<Evaluation> Toolbox;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        for (int phaseIdx = 0; phaseIdx < Traits::numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < Traits::numPhases; ++phaseIdx) {
             const Evaluation& S =
                 FsToolbox::template toLhs<Evaluation>(state.saturation(phaseIdx));
             Valgrind::CheckDefined(S);
@@ -192,12 +192,12 @@ public:
      *        of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fs)
+    static Evaluation Sw(const Params &/*params*/, const FluidState &/*fs*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Sw()"); }
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
-    twoPhaseSatSw(const Params &params, const Evaluation& Sw)
+    twoPhaseSatSw(const Params &/*params*/, const Evaluation& /*Sw*/)
     { OPM_THROW(std::runtime_error, "Not implemented: twoPhaseSatSw()"); }
 
     /*!
@@ -205,12 +205,12 @@ public:
      *        the rest of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fs)
+    static Evaluation Sn(const Params &/*params*/, const FluidState &/*fs*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Sn()"); }
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
-    twoPhaseSatSn(const Params &params, const Evaluation& Sw)
+    twoPhaseSatSn(const Params &/*params*/, const Evaluation& /*Sw*/)
     { OPM_THROW(std::runtime_error, "Not implemented: twoPhaseSatSn()"); }
 
     /*!
@@ -221,14 +221,14 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if<Traits::numPhases == 3, Evaluation>::type
-    Sg(const Params &params, const FluidState &fs)
+    Sg(const Params &/*params*/, const FluidState &/*fs*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Sg()"); }
 
     /*!
      * \brief The relative permability of the wetting phase
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fs)
+    static Evaluation krw(const Params &/*params*/, const FluidState &fs)
     {
         typedef MathToolbox<Evaluation> Toolbox;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -240,7 +240,7 @@ public:
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
-    twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    twoPhaseSatKrw(const Params &/*params*/, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -251,7 +251,7 @@ public:
      * \brief The relative permability of the liquid non-wetting phase
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fs)
+    static Evaluation krn(const Params &/*params*/, const FluidState &fs)
     {
         typedef MathToolbox<Evaluation> Toolbox;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -263,7 +263,7 @@ public:
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
-    twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
+    twoPhaseSatKrn(const Params &/*params*/, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -277,7 +277,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if<Traits::numPhases == 3, Evaluation>::type
-    krg(const Params &params, const FluidState &fs)
+    krg(const Params &/*params*/, const FluidState &fs)
     {
         typedef MathToolbox<Evaluation> Toolbox;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidmatrixinteractions/LinearMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/LinearMaterialParams.hpp
@@ -50,7 +50,7 @@ public:
      */
     LinearMaterialParams()
     {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             setPcMinSat(phaseIdx, 0.0);
             setPcMaxSat(phaseIdx, 0.0);
         }
@@ -76,7 +76,7 @@ public:
      *
      * This means \f$p_{c\alpha}\f$ at \f$S_\alpha=0\f$.
      */
-    Scalar pcMinSat(int phaseIdx) const
+    Scalar pcMinSat(unsigned phaseIdx) const
     { assertFinalized_();return pcMinSat_[phaseIdx]; }
 
     /*!
@@ -84,7 +84,7 @@ public:
      *
      * This means \f$p_{c\alpha}\f$ at \f$S_\alpha=0\f$.
      */
-    void setPcMinSat(int phaseIdx, Scalar val)
+    void setPcMinSat(unsigned phaseIdx, Scalar val)
     { pcMinSat_[phaseIdx] = val; }
 
     /*!
@@ -92,7 +92,7 @@ public:
      *
      * This means \f$p_{c\alpha}\f$ at \f$S_\alpha=1\f$.
      */
-    Scalar pcMaxSat(int phaseIdx) const
+    Scalar pcMaxSat(unsigned phaseIdx) const
     { assertFinalized_(); return pcMaxSat_[phaseIdx]; }
 
     /*!
@@ -100,7 +100,7 @@ public:
      *
      * This means \f$p_{c\alpha}\f$ at \f$S_\alpha=1\f$.
      */
-    void setPcMaxSat(int phaseIdx, Scalar val)
+    void setPcMaxSat(unsigned phaseIdx, Scalar val)
     { pcMaxSat_[phaseIdx] = val; }
 
 private:

--- a/opm/material/fluidmatrixinteractions/NullMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/NullMaterial.hpp
@@ -88,8 +88,8 @@ public:
      */
     template <class ContainerT, class FluidState>
     static void capillaryPressures(ContainerT &values,
-                                   const Params &params,
-                                   const FluidState &state)
+                                   const Params &/*params*/,
+                                   const FluidState &/*fluidState*/)
     {
         for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             values[phaseIdx] = 0.0;
@@ -99,9 +99,9 @@ public:
      * \brief The inverse of the capillary pressure
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &values,
-                            const Params &params,
-                            const FluidState &state)
+    static void saturations(ContainerT &/*values*/,
+                            const Params &/*params*/,
+                            const FluidState &/*fluidState*/)
     { OPM_THROW(std::logic_error, "Not defined: NullMaterial::saturations()"); }
 
     /*!
@@ -109,14 +109,14 @@ public:
      */
     template <class ContainerT, class FluidState>
     static void relativePermeabilities(ContainerT &values,
-                                       const Params &params,
+                                       const Params &/*params*/,
                                        const FluidState &fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
 
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             const Evaluation& S =
                 FsToolbox::template toLhs<Evaluation>(fluidState.saturation(phaseIdx));
             values[phaseIdx] = Toolbox::max(Toolbox::min(S, 1.0), 0.0);
@@ -128,12 +128,12 @@ public:
      */
     template <class FluidState, class Evaluation  = typename FluidState::Scalar>
     static typename std::enable_if<(numPhases > 1), Evaluation>::type
-    pcnw(const Params &params, const FluidState &fluidState)
+    pcnw(const Params &/*params*/, const FluidState &/*fluidState*/)
     { return 0; }
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
-    twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
+    twoPhaseSatPcnw(const Params &/*params*/, const Evaluation& /*Sw*/)
     { return 0; }
 
     /*!
@@ -141,12 +141,12 @@ public:
      *        of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Scalar Sw(const Params &params, const FluidState &fluidState)
+    static Scalar Sw(const Params &/*params*/, const FluidState &/*fluidState*/)
     { OPM_THROW(std::logic_error, "Not defined: Sw()"); }
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
-    twoPhaseSatSw(const Params &params, const Evaluation& pcnw)
+    twoPhaseSatSw(const Params &/*params*/, const Evaluation& /*pcnw*/)
     { OPM_THROW(std::logic_error, "Not defined: twoPhaseSatSw()"); }
 
     /*!
@@ -154,12 +154,12 @@ public:
      *        rest of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Scalar Sn(const Params &params, const FluidState &fluidState)
+    static Scalar Sn(const Params &/*params*/, const FluidState &/*fluidState*/)
     { OPM_THROW(std::logic_error, "Not defined: Sn()"); }
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
-    twoPhaseSatSn(const Params &params, const Evaluation& pcnw)
+    twoPhaseSatSn(const Params &/*params*/, const Evaluation& /*pcnw*/)
     { OPM_THROW(std::logic_error, "Not defined: twoPhaseSatSn()"); }
 
     /*!
@@ -170,7 +170,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if< (numPhases > 2), Evaluation>::type
-    Sg(const Params &params, const FluidState &fluidState)
+    Sg(const Params &/*params*/, const FluidState &/*fluidState*/)
     { OPM_THROW(std::logic_error, "Not defined: Sg()"); }
 
     /*!
@@ -178,7 +178,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if<(numPhases > 1), Evaluation>::type
-    krw(const Params &params, const FluidState &fluidState)
+    krw(const Params &/*params*/, const FluidState &fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -191,7 +191,7 @@ public:
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
-    twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    twoPhaseSatKrw(const Params &/*params*/, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -203,7 +203,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if<(numPhases > 1), Evaluation>::type
-    krn(const Params &params, const FluidState &fluidState)
+    krn(const Params &/*params*/, const FluidState &fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -216,7 +216,7 @@ public:
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
-    twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
+    twoPhaseSatKrn(const Params &/*params*/, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -230,7 +230,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if< (numPhases > 2), Evaluation>::type
-    krg(const Params &params, const FluidState &fluidState)
+    krg(const Params &/*params*/, const FluidState &fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -248,7 +248,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if< (Traits::numPhases > 2), Evaluation>::type
-    pcgn(const Params &params, const FluidState &fluidState)
+    pcgn(const Params &/*params*/, const FluidState &/*fluidState*/)
     { return 0; }
 };
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
+++ b/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
@@ -354,7 +354,7 @@ public:
      *        the phase saturations.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &values, const Params &params, const FluidState &fs)
+    static void saturations(Container &/*values*/, const Params &/*params*/, const FluidState &/*fs*/)
     { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::saturations()"); }
 
     /*!
@@ -426,11 +426,11 @@ public:
      *        the phase pressures.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fs)
+    static Evaluation Sw(const Params &/*params*/, const FluidState &/*fs*/)
     { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::Sw()"); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &params, const Evaluation& pc)
+    static Evaluation twoPhaseSatSw(const Params &/*params*/, const Evaluation& /*pc*/)
     { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::twoPhaseSatSw()"); }
 
     /*!
@@ -442,7 +442,7 @@ public:
     { return 1 - Sw<FluidState, Evaluation>(params, fs); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params &params, const Evaluation& pc)
+    static Evaluation twoPhaseSatSn(const Params &/*params*/, const Evaluation& /*pc*/)
     { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::twoPhaseSatSn()"); }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -238,7 +238,7 @@ private:
         if (x >= xValues.back())
             return yValues.back();
 
-        int segIdx = findSegmentIndex_(xValues, Toolbox::value(x));
+        size_t segIdx = findSegmentIndex_(xValues, Toolbox::value(x));
 
         Scalar x0 = xValues[segIdx];
         Scalar x1 = xValues[segIdx + 1];
@@ -263,7 +263,7 @@ private:
         if (x <= xValues.back())
             return yValues.back();
 
-        int segIdx = findSegmentIndexDescending_(xValues, Toolbox::value(x));
+        size_t segIdx = findSegmentIndexDescending_(xValues, Toolbox::value(x));
 
         Scalar x0 = xValues[segIdx];
         Scalar x1 = xValues[segIdx + 1];
@@ -283,12 +283,12 @@ private:
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
-        if (Toolbox::value(x) < xValues.front())
+        if (Toolbox::value(x) <= xValues.front())
             return Toolbox::createConstant(0.0);
-        if (Toolbox::value(x) > xValues.back())
+        if (Toolbox::value(x) >= xValues.back())
             return Toolbox::createConstant(0.0);
 
-        int segIdx = findSegmentIndex_(xValues, Toolbox::value(x));
+        size_t segIdx = findSegmentIndex_(xValues, Toolbox::value(x));
 
         Scalar x0 = xValues[segIdx];
         Scalar x1 = xValues[segIdx + 1];
@@ -299,19 +299,19 @@ private:
         return Toolbox::createConstant((y1 - y0)/(x1 - x0));
     }
 
-    static int findSegmentIndex_(const ValueVector &xValues, Scalar x)
+    static size_t findSegmentIndex_(const ValueVector &xValues, Scalar x)
     {
-        int n = xValues.size() - 1;
-        assert(n >= 1); // we need at least two sampling points!
-        if (xValues[n] < x)
+        assert(xValues.size() > 1); // we need at least two sampling points!
+        size_t n = xValues.size() - 1;
+        if (xValues.back() <= x)
             return n - 1;
-        else if (xValues[0] > x)
+        else if (x <= xValues.front())
             return 0;
 
         // bisection
-        int lowIdx = 0, highIdx = n;
+        size_t lowIdx = 0, highIdx = n;
         while (lowIdx + 1 < highIdx) {
-            int curIdx = (lowIdx + highIdx)/2;
+            size_t curIdx = (lowIdx + highIdx)/2;
             if (xValues[curIdx] < x)
                 lowIdx = curIdx;
             else
@@ -321,19 +321,19 @@ private:
         return lowIdx;
     }
 
-    static int findSegmentIndexDescending_(const ValueVector &xValues, Scalar x)
+    static size_t findSegmentIndexDescending_(const ValueVector &xValues, Scalar x)
     {
-        int n = xValues.size() - 1;
-        assert(n >= 1); // we need at least two sampling points!
-        if (xValues[n] >= x)
-            return n - 1;
-        else if (xValues[0] <= x)
+        assert(xValues.size() > 1); // we need at least two sampling points!
+        size_t n = xValues.size() - 1;
+        if (x <= xValues.back())
+            return n;
+        else if (xValues.front() <= x)
             return 0;
 
         // bisection
-        int lowIdx = 0, highIdx = n;
+        size_t lowIdx = 0, highIdx = n;
         while (lowIdx + 1 < highIdx) {
-            int curIdx = (lowIdx + highIdx)/2;
+            size_t curIdx = (lowIdx + highIdx)/2;
             if (xValues[curIdx] >= x)
                 lowIdx = curIdx;
             else

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -26,8 +26,8 @@
 #define OPM_PIECEWISE_LINEAR_TWO_PHASE_MATERIAL_PARAMS_HPP
 
 #include <vector>
-
 #include <cassert>
+#include <cstddef>
 
 namespace Opm {
 /*!
@@ -113,7 +113,7 @@ public:
     {
         assert(SwValues.size() == values.size());
 
-        int n = SwValues.size();
+        size_t n = SwValues.size();
         SwPcwnSamples_.resize(n);
         pcwnSamples_.resize(n);
 
@@ -141,7 +141,7 @@ public:
     {
         assert(SwValues.size() == values.size());
 
-        int n = SwValues.size();
+        size_t n = SwValues.size();
         SwKrwSamples_.resize(n);
         krwSamples_.resize(n);
 
@@ -169,7 +169,7 @@ public:
     {
         assert(SwValues.size() == values.size());
 
-        int n = SwValues.size();
+        size_t n = SwValues.size();
         SwKrnSamples_.resize(n);
         krnSamples_.resize(n);
 
@@ -195,7 +195,7 @@ private:
                  origSampleIdx < swValues.size() / 2;
                  ++ origSampleIdx)
             {
-                unsigned newSampleIdx = swValues.size() - origSampleIdx - 1;
+                size_t newSampleIdx = swValues.size() - origSampleIdx - 1;
 
                 std::swap(swValues[origSampleIdx], swValues[newSampleIdx]);
                 std::swap(values[origSampleIdx], values[newSampleIdx]);

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
@@ -150,7 +150,6 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatPcnwInv(const Params &params, const Evaluation& pcnw)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
         static const Evaluation nil(0.0);
 
         // this assumes that the capillary pressure is monotonically decreasing
@@ -205,8 +204,6 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-
         if (Sw <= params.krnSpline().xMin())
             return Evaluation(params.krwSpline().yFirst());
         if (Sw >= params.krnSpline().xMax())
@@ -218,7 +215,6 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatKrwInv(const Params &params, const Evaluation& krw)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
         static const Evaluation nil(0.0);
 
         if (krw <= params.krwSpline().yFirst())
@@ -247,8 +243,6 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
-
         if (Sw <= params.krnSpline().xMin())
             return Evaluation(params.krnSpline().yFirst());
         if (Sw >= params.krnSpline().xMax())
@@ -260,7 +254,6 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatKrnInv(const Params &params, const Evaluation& krn)
     {
-        typedef MathToolbox<Evaluation> Toolbox;
         static const Evaluation nil(0.0);
 
         if (krn >= params.krnSpline().yFirst())

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
@@ -103,7 +103,7 @@ public:
      *        pressure differences.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &values, const Params &params, const FluidState &fluidState)
+    static void saturations(Container &/*values*/, const Params &/*params*/, const FluidState &/*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: saturations()"); }
 
     /*!
@@ -167,11 +167,11 @@ public:
      * \brief The saturation-capillary pressure curve
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fluidState)
+    static Evaluation Sw(const Params &/*params*/, const FluidState &/*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: Sw()"); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &params, const Evaluation& pC)
+    static Evaluation twoPhaseSatSw(const Params &/*params*/, const Evaluation& /*pC*/)
     { OPM_THROW(std::logic_error, "Not implemented: twoPhaseSatSw()"); }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
@@ -225,30 +225,30 @@ public:
      *
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &values,
-                            const Params &params,
-                            const FluidState &fluidState)
+    static void saturations(ContainerT &/*values*/,
+                            const Params &/*params*/,
+                            const FluidState &/*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: inverse capillary pressures"); }
 
     /*!
      * \brief The saturation of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sg(const Params &params, const FluidState &fluidState)
+    static Evaluation Sg(const Params &/*params*/, const FluidState &/*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: Sg()"); }
 
     /*!
      * \brief The saturation of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fluidState)
+    static Evaluation Sn(const Params &/*params*/, const FluidState &/*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: Sn()"); }
 
     /*!
      * \brief The saturation of the wetting (i.e., water) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fluidState)
+    static Evaluation Sw(const Params &/*params*/, const FluidState &/*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: Sw()"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStateCompositionModules.hpp
+++ b/opm/material/fluidstates/FluidStateCompositionModules.hpp
@@ -60,13 +60,13 @@ public:
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    const Scalar&  moleFraction(int phaseIdx, int compIdx) const
+    const Scalar&  moleFraction(unsigned phaseIdx, unsigned compIdx) const
     { return moleFraction_[phaseIdx][compIdx]; }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
-    Scalar massFraction(int phaseIdx, int compIdx) const
+    Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
     {
         typedef Opm::MathToolbox<Scalar> Toolbox;
 
@@ -85,7 +85,7 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    const Scalar&  averageMolarMass(int phaseIdx) const
+    const Scalar&  averageMolarMass(unsigned phaseIdx) const
     { return averageMolarMass_[phaseIdx]; }
 
     /*!
@@ -97,7 +97,7 @@ public:
      *
      * http://en.wikipedia.org/wiki/Concentration
      */
-    Scalar molarity(int phaseIdx, int compIdx) const
+    Scalar molarity(unsigned phaseIdx, unsigned compIdx) const
     { return asImp_().molarDensity(phaseIdx)*moleFraction(phaseIdx, compIdx); }
 
     /*!
@@ -105,7 +105,7 @@ public:
      *        and update the average molar mass [kg/mol] according
      *        to the current composition of the phase
      */
-    void setMoleFraction(int phaseIdx, int compIdx, const Scalar&  value)
+    void setMoleFraction(unsigned phaseIdx, unsigned compIdx, const Scalar&  value)
     {
         Valgrind::CheckDefined(value);
         Valgrind::SetUndefined(sumMoleFractions_[phaseIdx]);
@@ -117,7 +117,7 @@ public:
         // re-calculate the mean molar mass
         sumMoleFractions_[phaseIdx] = 0.0;
         averageMolarMass_[phaseIdx] = 0.0;
-        for (int compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
+        for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
             sumMoleFractions_[phaseIdx] += moleFraction_[phaseIdx][compJIdx];
             averageMolarMass_[phaseIdx] += moleFraction_[phaseIdx][compJIdx]*FluidSystem::molarMass(compJIdx);
         }
@@ -133,10 +133,10 @@ public:
         typedef typename FluidState::Scalar FsScalar;
         typedef Opm::MathToolbox<FsScalar> FsToolbox;
 
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             averageMolarMass_[phaseIdx] = 0;
             sumMoleFractions_[phaseIdx] = 0;
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 moleFraction_[phaseIdx][compIdx] =
                     FsToolbox::template toLhs<Scalar>(fs.moleFraction(phaseIdx, compIdx));
 
@@ -192,13 +192,13 @@ public:
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    Scalar moleFraction(int phaseIdx, int compIdx) const
+    Scalar moleFraction(unsigned phaseIdx, unsigned compIdx) const
     { return (phaseIdx == compIdx)?1.0:0.0; }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
-    Scalar massFraction(int phaseIdx, int compIdx) const
+    Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
     { return (phaseIdx == compIdx)?1.0:0.0; }
 
     /*!
@@ -209,7 +209,7 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    Scalar averageMolarMass(int phaseIdx) const
+    Scalar averageMolarMass(unsigned phaseIdx) const
     { return FluidSystem::molarMass(/*compIdx=*/phaseIdx); }
 
     /*!
@@ -221,7 +221,7 @@ public:
      *
      * http://en.wikipedia.org/wiki/Concentration
      */
-    Scalar molarity(int phaseIdx, int compIdx) const
+    Scalar molarity(unsigned phaseIdx, unsigned compIdx) const
     { return asImp_().molarDensity(phaseIdx)*moleFraction(phaseIdx, compIdx); }
 
     /*!

--- a/opm/material/fluidstates/FluidStateDensityModules.hpp
+++ b/opm/material/fluidstates/FluidStateDensityModules.hpp
@@ -52,25 +52,25 @@ public:
     /*!
      * \brief The density of a fluid phase [kg/m^3]
      */
-    const Scalar& density(int phaseIdx) const
+    const Scalar& density(unsigned phaseIdx) const
     { return density_[phaseIdx]; }
 
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
-    Scalar molarDensity(int phaseIdx) const
+    Scalar molarDensity(unsigned phaseIdx) const
     { return density_[phaseIdx]/asImp_().averageMolarMass(phaseIdx); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
-    Scalar molarVolume(int phaseIdx) const
+    Scalar molarVolume(unsigned phaseIdx) const
     { return 1/molarDensity(phaseIdx); }
 
     /*!
      * \brief Set the density of a phase [kg/m^3]
      */
-    void setDensity(int phaseIdx, const Scalar&  value)
+    void setDensity(unsigned phaseIdx, const Scalar&  value)
     { density_[phaseIdx] = value; }
 
     /*!
@@ -82,7 +82,7 @@ public:
     {
         typedef typename FluidState::Scalar FsScalar;
         typedef Opm::MathToolbox<FsScalar> FsToolbox;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             density_[phaseIdx] = FsToolbox::template toLhs<Scalar>(fs.density(phaseIdx));
         }
     }

--- a/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
+++ b/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
@@ -51,19 +51,19 @@ public:
     /*!
      * \brief The specific enthalpy of a fluid phase [J/kg]
      */
-    const Scalar& enthalpy(int phaseIdx) const
+    const Scalar& enthalpy(unsigned phaseIdx) const
     { return enthalpy_[phaseIdx]; }
 
     /*!
      * \brief The specific internal energy of a fluid phase [J/kg]
      */
-    Scalar internalEnergy(int phaseIdx) const
+    Scalar internalEnergy(unsigned phaseIdx) const
     { return enthalpy_[phaseIdx] - asImp_().pressure(phaseIdx)/asImp_().density(phaseIdx); }
 
     /*!
      * \brief Set the specific enthalpy of a phase [J/kg]
      */
-    void setEnthalpy(int phaseIdx, const Scalar& value)
+    void setEnthalpy(unsigned phaseIdx, const Scalar& value)
     { enthalpy_[phaseIdx] = value; }
 
     /*!
@@ -75,7 +75,7 @@ public:
     {
         typedef typename FluidState::Scalar FsScalar;
         typedef Opm::MathToolbox<FsScalar> FsToolbox;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             enthalpy_[phaseIdx] = FsToolbox::template toLhs<Scalar>(fs.enthalpy(phaseIdx));
         }
     }

--- a/opm/material/fluidstates/FluidStateFugacityModules.hpp
+++ b/opm/material/fluidstates/FluidStateFugacityModules.hpp
@@ -55,19 +55,19 @@ public:
     /*!
      * \brief The fugacity coefficient of a component in a phase []
      */
-    const Scalar& fugacityCoefficient(int phaseIdx, int compIdx) const
+    const Scalar& fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
     { return fugacityCoefficient_[phaseIdx][compIdx]; }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
-    Scalar fugacity(int phaseIdx, int compIdx) const
+    Scalar fugacity(unsigned phaseIdx, unsigned compIdx) const
     { return asImp_().pressure(phaseIdx)*fugacityCoefficient_[phaseIdx][compIdx]*asImp_().moleFraction(phaseIdx, compIdx); }
 
     /*!
      * \brief Set the fugacity of a component in a phase []
      */
-    void setFugacityCoefficient(int phaseIdx, int compIdx, const Scalar& value)
+    void setFugacityCoefficient(unsigned phaseIdx, unsigned compIdx, const Scalar& value)
     { fugacityCoefficient_[phaseIdx][compIdx] = value; }
 
     /*!
@@ -77,8 +77,8 @@ public:
     template <class FluidState>
     void assign(const FluidState& fs)
     {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 fugacityCoefficient_[phaseIdx][compIdx] = fs.fugacityCoefficient(phaseIdx, compIdx);
             }
         }
@@ -124,19 +124,19 @@ public:
     /*!
      * \brief The fugacity coefficient of a component in a phase []
      */
-    Scalar fugacityCoefficient(int phaseIdx, int compIdx) const
+    Scalar fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
     { return (phaseIdx == compIdx)?fugacityCoefficient_[phaseIdx]:std::numeric_limits<Scalar>::infinity(); }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
-    Scalar fugacity(int phaseIdx, int compIdx) const
+    Scalar fugacity(unsigned phaseIdx, unsigned compIdx) const
     { return asImp_().pressure(phaseIdx)*fugacityCoefficient(phaseIdx, compIdx)*asImp_().moleFraction(phaseIdx, compIdx); }
 
     /*!
      * \brief Set the fugacity of a component in a phase []
      */
-    void setFugacityCoefficient(int phaseIdx, const Scalar& value)
+    void setFugacityCoefficient(unsigned phaseIdx, const Scalar& value)
     { fugacityCoefficient_[phaseIdx] = value; }
 
     /*!
@@ -146,7 +146,7 @@ public:
     template <class FluidState>
     void assign(const FluidState& fs)
     {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             fugacityCoefficient_[phaseIdx] = fs.fugacityCoefficient(phaseIdx, /*compIdx=*/phaseIdx);
         }
     }

--- a/opm/material/fluidstates/FluidStatePressureModules.hpp
+++ b/opm/material/fluidstates/FluidStatePressureModules.hpp
@@ -51,14 +51,14 @@ public:
     /*!
      * \brief The pressure of a fluid phase [Pa]
      */
-    const Scalar& pressure(int phaseIdx) const
+    const Scalar& pressure(unsigned phaseIdx) const
     { return pressure_[phaseIdx]; }
 
 
     /*!
      * \brief Set the pressure of a phase [Pa]
      */
-    void setPressure(int phaseIdx, const Scalar& value)
+    void setPressure(unsigned phaseIdx, const Scalar& value)
     { pressure_[phaseIdx] = value; }
 
     /*!
@@ -70,7 +70,7 @@ public:
     {
         typedef typename FluidState::Scalar FsScalar;
         typedef Opm::MathToolbox<FsScalar> FsToolbox;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             pressure_[phaseIdx] = FsToolbox::template toLhs<Scalar>(fs.pressure(phaseIdx));
         }
     }

--- a/opm/material/fluidstates/FluidStateSaturationModules.hpp
+++ b/opm/material/fluidstates/FluidStateSaturationModules.hpp
@@ -52,13 +52,13 @@ public:
     /*!
      * \brief The saturation of a fluid phase [-]
      */
-    const Scalar& saturation(int phaseIdx) const
+    const Scalar& saturation(unsigned phaseIdx) const
     { return saturation_[phaseIdx]; }
 
     /*!
      * \brief Set the saturation of a phase [-]
      */
-    void setSaturation(int phaseIdx, const Scalar& value)
+    void setSaturation(unsigned phaseIdx, const Scalar& value)
     { saturation_[phaseIdx] = value; }
 
     /*!
@@ -70,7 +70,7 @@ public:
     {
         typedef typename FluidState::Scalar FsScalar;
         typedef Opm::MathToolbox<FsScalar> FsToolbox;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             saturation_[phaseIdx] = FsToolbox::template toLhs<Scalar>(fs.saturation(phaseIdx));
         }
     }

--- a/opm/material/fluidstates/FluidStateTemperatureModules.hpp
+++ b/opm/material/fluidstates/FluidStateTemperatureModules.hpp
@@ -54,13 +54,13 @@ public:
     /*!
      * \brief The temperature of a fluid phase [-]
      */
-    Scalar temperature(int phaseIdx) const
+    Scalar temperature(unsigned phaseIdx) const
     { return temperature_[phaseIdx]; }
 
     /*!
      * \brief Set the temperature of a phase [-]
      */
-    void setTemperature(int phaseIdx, Scalar value)
+    void setTemperature(unsigned phaseIdx, Scalar value)
     { temperature_[phaseIdx] = value; }
 
     /*!
@@ -70,7 +70,7 @@ public:
     template <class FluidState>
     void assign(const FluidState& fs)
     {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             temperature_[phaseIdx] = fs.temperature(phaseIdx);
         }
     }
@@ -108,7 +108,7 @@ public:
     /*!
      * \brief The temperature of a fluid phase [-]
      */
-    Scalar temperature(int /* phaseIdx */) const
+    Scalar temperature(unsigned /*phaseIdx*/) const
     { return temperature_; }
 
     /*!
@@ -130,7 +130,7 @@ public:
 
 #ifndef NDEBUG
         typedef Opm::MathToolbox<Scalar> Toolbox;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             assert(std::abs(FsToolbox::value(fs.temperature(phaseIdx))
                             - Toolbox::value(temperature_)) < 1e-30);
         }
@@ -168,7 +168,7 @@ public:
     /*!
      * \brief The temperature of a fluid phase [-]
      */
-    Scalar temperature(int /* phaseIdx */) const
+    Scalar temperature(unsigned /* phaseIdx */) const
     { OPM_THROW(std::runtime_error, "Temperature is not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStateViscosityModules.hpp
+++ b/opm/material/fluidstates/FluidStateViscosityModules.hpp
@@ -52,13 +52,13 @@ public:
     /*!
      * \brief The viscosity of a fluid phase [-]
      */
-    Scalar viscosity(int phaseIdx) const
+    Scalar viscosity(unsigned phaseIdx) const
     { return viscosity_[phaseIdx]; }
 
     /*!
      * \brief Set the dynamic viscosity of a phase [Pa s]
      */
-    void setViscosity(int phaseIdx, Scalar value)
+    void setViscosity(unsigned phaseIdx, Scalar value)
     { viscosity_[phaseIdx] = value; }
 
     /*!
@@ -70,7 +70,7 @@ public:
     {
         typedef typename FluidState::Scalar FsScalar;
         typedef Opm::MathToolbox<FsScalar> FsToolbox;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             viscosity_[phaseIdx] = FsToolbox::template toLhs<Scalar>(fs.viscosity(phaseIdx));
         }
     }

--- a/opm/material/fluidstates/ImmiscibleFluidState.hpp
+++ b/opm/material/fluidstates/ImmiscibleFluidState.hpp
@@ -64,9 +64,6 @@ class ImmiscibleFluidState<Scalar, FluidSystem, true>
 public:
     ImmiscibleFluidState()
     {}
-
-    ImmiscibleFluidState(const ImmiscibleFluidState &fs)
-    { memcpy(this, &fs, sizeof(fs)); }
 };
 
 // specialization for the enthalpy disabled case
@@ -87,9 +84,6 @@ class ImmiscibleFluidState<Scalar, FluidSystem, false>
 public:
     ImmiscibleFluidState()
     {}
-
-    ImmiscibleFluidState(const ImmiscibleFluidState &fs)
-    { memcpy(this, &fs, sizeof(fs)); }
 };
 } // namespace Opm
 

--- a/opm/material/fluidstates/PressureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/PressureOverlayFluidState.hpp
@@ -55,7 +55,7 @@ public:
     PressureOverlayFluidState(const FluidState &fs)
         : fs_(&fs)
     {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             pressure_[phaseIdx] = fs.pressure(phaseIdx);
     }
 
@@ -81,19 +81,19 @@ public:
     /*!
      * \brief Returns the saturation of a phase []
      */
-    Scalar saturation(int phaseIdx) const
+    Scalar saturation(unsigned phaseIdx) const
     { return fs_->saturation(phaseIdx); }
 
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    Scalar moleFraction(int phaseIdx, int compIdx) const
+    Scalar moleFraction(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->moleFraction(phaseIdx, compIdx); }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
-    Scalar massFraction(int phaseIdx, int compIdx) const
+    Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->massFraction(phaseIdx, compIdx); }
 
     /*!
@@ -104,7 +104,7 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    Scalar averageMolarMass(int phaseIdx) const
+    Scalar averageMolarMass(unsigned phaseIdx) const
     { return fs_->averageMolarMass(phaseIdx); }
 
     /*!
@@ -116,67 +116,67 @@ public:
      *
      * http://en.wikipedia.org/wiki/Concentration
      */
-    Scalar molarity(int phaseIdx, int compIdx) const
+    Scalar molarity(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->molarity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
-    Scalar fugacity(int phaseIdx, int compIdx) const
+    Scalar fugacity(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->fugacity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity coefficient of a component in a phase [-]
      */
-    Scalar fugacityCoefficient(int phaseIdx, int compIdx) const
+    Scalar fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->fugacityCoefficient(phaseIdx, compIdx); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
-    Scalar molarVolume(int phaseIdx) const
+    Scalar molarVolume(unsigned phaseIdx) const
     { return fs_->molarVolume(phaseIdx); }
 
     /*!
      * \brief The mass density of a fluid phase [kg/m^3]
      */
-    Scalar density(int phaseIdx) const
+    Scalar density(unsigned phaseIdx) const
     { return fs_->density(phaseIdx); }
 
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
-    Scalar molarDensity(int phaseIdx) const
+    Scalar molarDensity(unsigned phaseIdx) const
     { return fs_->molarDensity(phaseIdx); }
 
     /*!
      * \brief The temperature of a fluid phase [K]
      */
-    Scalar temperature(int phaseIdx) const
+    Scalar temperature(unsigned phaseIdx) const
     { return fs_->temperature(phaseIdx); }
 
     /*!
      * \brief The pressure of a fluid phase [Pa]
      */
-    Scalar pressure(int phaseIdx) const
+    Scalar pressure(unsigned phaseIdx) const
     { return pressure_[phaseIdx]; }
 
     /*!
      * \brief The specific enthalpy of a fluid phase [J/kg]
      */
-    Scalar enthalpy(int phaseIdx) const
+    Scalar enthalpy(unsigned phaseIdx) const
     { return fs_->enthalpy(phaseIdx); }
 
     /*!
      * \brief The specific internal energy of a fluid phase [J/kg]
      */
-    Scalar internalEnergy(int phaseIdx) const
+    Scalar internalEnergy(unsigned phaseIdx) const
     { return fs_->internalEnergy(phaseIdx); }
 
     /*!
      * \brief The dynamic viscosity of a fluid phase [Pa s]
      */
-    Scalar viscosity(int phaseIdx) const
+    Scalar viscosity(unsigned phaseIdx) const
     { return fs_->viscosity(phaseIdx); }
 
 
@@ -188,7 +188,7 @@ public:
     /*!
      * \brief Set the pressure [Pa] of a fluid phase
      */
-    void setPressure(int phaseIdx, Scalar value)
+    void setPressure(unsigned phaseIdx, Scalar value)
     { pressure_[phaseIdx] = value; }
 
     /*!

--- a/opm/material/fluidstates/SaturationOverlayFluidState.hpp
+++ b/opm/material/fluidstates/SaturationOverlayFluidState.hpp
@@ -55,7 +55,7 @@ public:
     SaturationOverlayFluidState(const FluidState &fs)
         : fs_(&fs)
     {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             saturation_[phaseIdx] = fs.saturation(phaseIdx);
     }
 
@@ -80,19 +80,19 @@ public:
     /*!
      * \brief Returns the saturation of a phase []
      */
-    Scalar saturation(int phaseIdx) const
+    Scalar saturation(unsigned phaseIdx) const
     { return saturation_[phaseIdx]; }
 
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    Scalar moleFraction(int phaseIdx, int compIdx) const
+    Scalar moleFraction(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->moleFraction(phaseIdx, compIdx); }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
-    Scalar massFraction(int phaseIdx, int compIdx) const
+    Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->massFraction(phaseIdx, compIdx); }
 
     /*!
@@ -103,7 +103,7 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    Scalar averageMolarMass(int phaseIdx) const
+    Scalar averageMolarMass(unsigned phaseIdx) const
     { return fs_->averageMolarMass(phaseIdx); }
 
     /*!
@@ -115,67 +115,67 @@ public:
      *
      * http://en.wikipedia.org/wiki/Concentration
      */
-    Scalar molarity(int phaseIdx, int compIdx) const
+    Scalar molarity(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->molarity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
-    Scalar fugacity(int phaseIdx, int compIdx) const
+    Scalar fugacity(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->fugacity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity coefficient of a component in a phase [-]
      */
-    Scalar fugacityCoefficient(int phaseIdx, int compIdx) const
+    Scalar fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->fugacityCoefficient(phaseIdx, compIdx); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
-    Scalar molarVolume(int phaseIdx) const
+    Scalar molarVolume(unsigned phaseIdx) const
     { return fs_->molarVolume(phaseIdx); }
 
     /*!
      * \brief The mass density of a fluid phase [kg/m^3]
      */
-    Scalar density(int phaseIdx) const
+    Scalar density(unsigned phaseIdx) const
     { return fs_->density(phaseIdx); }
 
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
-    Scalar molarDensity(int phaseIdx) const
+    Scalar molarDensity(unsigned phaseIdx) const
     { return fs_->molarDensity(phaseIdx); }
 
     /*!
      * \brief The temperature of a fluid phase [K]
      */
-    Scalar temperature(int phaseIdx) const
+    Scalar temperature(unsigned phaseIdx) const
     { return fs_->temperature(phaseIdx); }
 
     /*!
      * \brief The pressure of a fluid phase [Pa]
      */
-    Scalar pressure(int phaseIdx) const
+    Scalar pressure(unsigned phaseIdx) const
     { return fs_->pressure(phaseIdx); }
 
     /*!
      * \brief The specific enthalpy of a fluid phase [J/kg]
      */
-    Scalar enthalpy(int phaseIdx) const
+    Scalar enthalpy(unsigned phaseIdx) const
     { return fs_->enthalpy(phaseIdx); }
 
     /*!
      * \brief The specific internal energy of a fluid phase [J/kg]
      */
-    Scalar internalEnergy(int phaseIdx) const
+    Scalar internalEnergy(unsigned phaseIdx) const
     { return fs_->internalEnergy(phaseIdx); }
 
     /*!
      * \brief The dynamic viscosity of a fluid phase [Pa s]
      */
-    Scalar viscosity(int phaseIdx) const
+    Scalar viscosity(unsigned phaseIdx) const
     { return fs_->viscosity(phaseIdx); }
 
 
@@ -187,7 +187,7 @@ public:
     /*!
      * \brief Set the saturation [-] of a fluid phase
      */
-    void setSaturation(int phaseIdx, Scalar value)
+    void setSaturation(unsigned phaseIdx, Scalar value)
     { saturation_[phaseIdx] = value; }
 
     /*!

--- a/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
@@ -82,19 +82,19 @@ public:
     /*!
      * \brief Returns the saturation of a phase []
      */
-    Scalar saturation(int phaseIdx) const
+    Scalar saturation(unsigned phaseIdx) const
     { return fs_->saturation(phaseIdx); }
 
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    Scalar moleFraction(int phaseIdx, int compIdx) const
+    Scalar moleFraction(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->moleFraction(phaseIdx, compIdx); }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
-    Scalar massFraction(int phaseIdx, int compIdx) const
+    Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->massFraction(phaseIdx, compIdx); }
 
     /*!
@@ -105,7 +105,7 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    Scalar averageMolarMass(int phaseIdx) const
+    Scalar averageMolarMass(unsigned phaseIdx) const
     { return fs_->averageMolarMass(phaseIdx); }
 
     /*!
@@ -117,67 +117,67 @@ public:
      *
      * http://en.wikipedia.org/wiki/Concentration
      */
-    Scalar molarity(int phaseIdx, int compIdx) const
+    Scalar molarity(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->molarity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
-    Scalar fugacity(int phaseIdx, int compIdx) const
+    Scalar fugacity(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->fugacity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity coefficient of a component in a phase []
      */
-    Scalar fugacityCoefficient(int phaseIdx, int compIdx) const
+    Scalar fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
     { return fs_->fugacityCoefficient(phaseIdx, compIdx); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
-    Scalar molarVolume(int phaseIdx) const
+    Scalar molarVolume(unsigned phaseIdx) const
     { return fs_->molarVolume(phaseIdx); }
 
     /*!
      * \brief The mass density of a fluid phase [kg/m^3]
      */
-    Scalar density(int phaseIdx) const
+    Scalar density(unsigned phaseIdx) const
     { return fs_->density(phaseIdx); }
 
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
-    Scalar molarDensity(int phaseIdx) const
+    Scalar molarDensity(unsigned phaseIdx) const
     { return fs_->molarDensity(phaseIdx); }
 
     /*!
      * \brief The temperature of a fluid phase [K]
      */
-    Scalar temperature(int phaseIdx) const
+    Scalar temperature(int /*phaseIdx*/) const
     { return temperature_; }
 
     /*!
      * \brief The pressure of a fluid phase [Pa]
      */
-    Scalar pressure(int phaseIdx) const
+    Scalar pressure(unsigned phaseIdx) const
     { return fs_->pressure(phaseIdx); }
 
     /*!
      * \brief The specific enthalpy of a fluid phase [J/kg]
      */
-    Scalar enthalpy(int phaseIdx) const
+    Scalar enthalpy(unsigned phaseIdx) const
     { return fs_->enthalpy(phaseIdx); }
 
     /*!
      * \brief The specific internal energy of a fluid phase [J/kg]
      */
-    Scalar internalEnergy(int phaseIdx) const
+    Scalar internalEnergy(unsigned phaseIdx) const
     { return fs_->internalEnergy(phaseIdx); }
 
     /*!
      * \brief The dynamic viscosity of a fluid phase [Pa s]
      */
-    Scalar viscosity(int phaseIdx) const
+    Scalar viscosity(unsigned phaseIdx) const
     { return fs_->viscosity(phaseIdx); }
 
 

--- a/opm/material/fluidsystems/BaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/BaseFluidSystem.hpp
@@ -64,7 +64,7 @@ public:
      *
      * \copydoc Doxygen::phaseIdxParam
      */
-    static char *phaseName(int phaseIdx)
+    static char *phaseName(unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error,
                   "Not implemented: The fluid system '" << Opm::className<Implementation>() << "' does not provide a phaseName() method!");
@@ -75,7 +75,7 @@ public:
      *
      * \copydoc Doxygen::phaseIdxParam
      */
-    static bool isLiquid(int phaseIdx)
+    static bool isLiquid(unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error,
                   "Not implemented: The fluid system '" << Opm::className<Implementation>() << "' does not provide a isLiquid() method!");
@@ -95,7 +95,7 @@ public:
      *
      * \copydoc Doxygen::phaseIdxParam
      */
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error,
                   "Not implemented: The fluid system '" << Opm::className<Implementation>() << "' does not provide a isIdealMixture() method!");
@@ -110,7 +110,7 @@ public:
      *
      * \copydoc Doxygen::phaseIdxParam
      */
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error,
                   "Not implemented: The fluid system '" << Opm::className<Implementation>() << "' does not provide a isCompressible() method!");
@@ -122,7 +122,7 @@ public:
      *
      * \copydoc Doxygen::phaseIdxParam
      */
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error,
                   "Not implemented: The fluid system '" << Opm::className<Implementation>() << "' does not provide a isIdealGas() method!");
@@ -133,7 +133,7 @@ public:
      *
      * \copydoc Doxygen::compIdxParam
      */
-    static const char *componentName(int compIdx)
+    static const char *componentName(unsigned /*compIdx*/)
     {
         OPM_THROW(std::runtime_error,
                   "Not implemented: The fluid system '" << Opm::className<Implementation>() << "' does not provide a componentName() method!");
@@ -144,7 +144,7 @@ public:
      *
      * \copydoc Doxygen::compIdxParam
      */
-    static Scalar molarMass(int compIdx)
+    static Scalar molarMass(unsigned /*compIdx*/)
     {
         OPM_THROW(std::runtime_error,
                   "Not implemented: The fluid system '" << Opm::className<Implementation>() << "' does not provide a molarMass() method!");
@@ -163,9 +163,9 @@ public:
      * \copydoc Doxygen::phaseIdxParam
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &paramCache,
-                           int phaseIdx)
+    static LhsEval density(const FluidState &/*fluidState*/,
+                           const ParameterCache &/*paramCache*/,
+                           unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error,
                   "Not implemented: The fluid system '" << Opm::className<Implementation>() << "' does not provide a density() method!");
@@ -186,10 +186,10 @@ public:
      * \copydoc Doxygen::compIdxParam
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx,
-                                       int compIdx)
+    static LhsEval fugacityCoefficient(const FluidState &/*fluidState*/,
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned /*phaseIdx*/,
+                                       unsigned /*compIdx*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Opm::className<Implementation>() << "'  does not provide a fugacityCoefficient() method!");
     }
@@ -201,9 +201,9 @@ public:
      * \copydoc Doxygen::phaseIdxParam
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &paramCache,
-                             int phaseIdx)
+    static LhsEval viscosity(const FluidState &/*fluidState*/,
+                             const ParameterCache &/*paramCache*/,
+                             unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Opm::className<Implementation>() << "'  does not provide a viscosity() method!");
     }
@@ -226,10 +226,10 @@ public:
      * \copydoc Doxygen::compIdxParam
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache &paramCache,
-                                        int phaseIdx,
-                                        int compIdx)
+    static LhsEval diffusionCoefficient(const FluidState &/*fluidState*/,
+                                        const ParameterCache &/*paramCache*/,
+                                        unsigned /*phaseIdx*/,
+                                        unsigned /*compIdx*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Opm::className<Implementation>() << "'  does not provide a diffusionCoefficient() method!");
     }
@@ -242,9 +242,9 @@ public:
      * \copydoc Doxygen::phaseIdxParam
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &paramCache,
-                            int phaseIdx)
+    static LhsEval enthalpy(const FluidState &/*fluidState*/,
+                            const ParameterCache &/*paramCache*/,
+                            unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Opm::className<Implementation>() << "'  does not provide an enthalpy() method!");
     }
@@ -256,9 +256,9 @@ public:
      * \copydoc Doxygen::phaseIdxParam
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx)
+    static LhsEval thermalConductivity(const FluidState &/*fluidState*/,
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Opm::className<Implementation>() << "'  does not provide a thermalConductivity() method!");
     }
@@ -270,9 +270,9 @@ public:
      * \copydoc Doxygen::phaseIdxParam
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &paramCache,
-                                int phaseIdx)
+    static LhsEval heatCapacity(const FluidState &/*fluidState*/,
+                                const ParameterCache &/*paramCache*/,
+                                unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Opm::className<Implementation>() << "'  does not provide a heatCapacity() method!");
     }

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -59,25 +59,25 @@ public:
     class ParameterCache : public Opm::NullParameterCache
     {
     public:
-        ParameterCache(int regionIdx=0)
+        ParameterCache(int /*regionIdx*/=0)
         { regionIdx_ = 0; }
 
         /*!
          * \brief Return the index of the region which should be used to determine the
          *        thermodynamic properties
          */
-        int regionIndex() const
+        unsigned regionIndex() const
         { return regionIdx_; }
 
         /*!
          * \brief Set the index of the region which should be used to determine the
          *        thermodynamic properties
          */
-        void setRegionIndex(int val)
+        void setRegionIndex(unsigned val)
         { regionIdx_ = val; }
 
     private:
-        int regionIdx_;
+        unsigned regionIdx_;
     };
 
     /****************************************
@@ -185,7 +185,7 @@ public:
     static void setReferenceDensities(Scalar rhoOil,
                                       Scalar rhoWater,
                                       Scalar rhoGas,
-                                      int regionIdx)
+                                      unsigned regionIdx)
     {
         referenceDensity_[regionIdx][oilPhaseIdx] = rhoOil;
         referenceDensity_[regionIdx][waterPhaseIdx] = rhoWater;
@@ -198,8 +198,8 @@ public:
     static void initEnd()
     {
         // calculate the final 2D functions which are used for interpolation.
-        int numRegions = molarMass_.size();
-        for (int regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
+        unsigned numRegions = molarMass_.size();
+        for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
             // calculate molar masses
 
             // water is simple: 18 g/mol
@@ -218,7 +218,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(const int phaseIdx)
+    static const char *phaseName(const unsigned phaseIdx)
     {
         static const char *name[] = { "water", "oil", "gas" };
 
@@ -227,7 +227,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isLiquid
-    static bool isLiquid(const int phaseIdx)
+    static bool isLiquid(const unsigned phaseIdx)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
         return phaseIdx != gasPhaseIdx;
@@ -248,7 +248,7 @@ public:
     static const int gasCompIdx = 2;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(int compIdx)
+    static const char *componentName(unsigned compIdx)
     {
         static const char *name[] = { "Oil", "Water", "Gas" };
 
@@ -257,11 +257,11 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::molarMass
-    static Scalar molarMass(int compIdx, int regionIdx = 0)
+    static Scalar molarMass(unsigned compIdx, unsigned regionIdx = 0)
     { return molarMass_[regionIdx][compIdx]; }
 
     //! \copydoc BaseFluidSystem::isIdealMixture
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(unsigned /*phaseIdx*/)
     {
         // fugacity coefficients are only pressure dependent -> we
         // have an ideal mixture
@@ -269,11 +269,11 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isCompressible
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(unsigned /*phaseIdx*/)
     { return true; /* all phases are compressible */ }
 
     //! \copydoc BaseFluidSystem::isIdealGas
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned /*phaseIdx*/)
     { return false; }
 
     /****************************************
@@ -283,7 +283,7 @@ public:
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval density(const FluidState &fluidState,
                            ParameterCache &paramCache,
-                           const int phaseIdx)
+                           const unsigned phaseIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx <= numPhases);
 
@@ -292,7 +292,7 @@ public:
 
         const auto& p = FsToolbox::template toLhs<LhsEval>(fluidState.pressure(phaseIdx));
         const auto& T = FsToolbox::template toLhs<LhsEval>(fluidState.temperature(phaseIdx));
-        int regionIdx = paramCache.regionIndex();
+        unsigned regionIdx = paramCache.regionIndex();
 
         switch (phaseIdx) {
         case waterPhaseIdx: return waterDensity<LhsEval>(T, p, regionIdx);
@@ -313,8 +313,8 @@ public:
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
                                        const ParameterCache &paramCache,
-                                       int phaseIdx,
-                                       int compIdx)
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx <= numPhases);
         assert(0 <= compIdx  && compIdx <= numComponents);
@@ -323,7 +323,7 @@ public:
 
         const auto& p = FsToolbox::template toLhs<LhsEval>(fluidState.pressure(phaseIdx));
         const auto& T = FsToolbox::template toLhs<LhsEval>(fluidState.temperature(phaseIdx));
-        int regionIdx = paramCache.regionIndex();
+        unsigned regionIdx = paramCache.regionIndex();
 
         switch (phaseIdx) {
         case waterPhaseIdx: return fugCoefficientInWater<LhsEval>(compIdx, T, p, regionIdx);
@@ -338,7 +338,7 @@ public:
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval viscosity(const FluidState &fluidState,
                              const ParameterCache &paramCache,
-                             int phaseIdx)
+                             unsigned phaseIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx <= numPhases);
 
@@ -346,7 +346,7 @@ public:
 
         const auto& p = FsToolbox::template toLhs<LhsEval>(fluidState.pressure(phaseIdx));
         const auto& T = FsToolbox::template toLhs<LhsEval>(fluidState.temperature(phaseIdx));
-        int regionIdx = paramCache.regionIndex();
+        unsigned regionIdx = paramCache.regionIndex();
 
         switch (phaseIdx) {
         case oilPhaseIdx: {
@@ -387,7 +387,7 @@ public:
      *
      * \copydoc Doxygen::phaseIdxParam
      */
-    static Scalar referenceDensity(int phaseIdx, int regionIdx)
+    static Scalar referenceDensity(unsigned phaseIdx, unsigned regionIdx)
     { return referenceDensity_[regionIdx][phaseIdx]; }
 
     /*!
@@ -398,7 +398,7 @@ public:
     template <class LhsEval>
     static LhsEval saturatedOilFormationVolumeFactor(const LhsEval& temperature,
                                                      const LhsEval& pressure,
-                                                     int regionIdx)
+                                                     unsigned regionIdx)
     {
         Valgrind::CheckDefined(pressure);
 
@@ -414,7 +414,7 @@ public:
     template <class LhsEval>
     static LhsEval waterFormationVolumeFactor(const LhsEval& temperature,
                                               const LhsEval& pressure,
-                                              int regionIdx)
+                                              unsigned regionIdx)
     { return waterPvt_->formationVolumeFactor(regionIdx, temperature, pressure); }
 
     /*!
@@ -425,7 +425,7 @@ public:
     template <class LhsEval>
     static LhsEval gasDissolutionFactor(const LhsEval& temperature,
                                         const LhsEval& pressure,
-                                        int regionIdx)
+                                        unsigned regionIdx)
     { return oilPvt_->gasDissolutionFactor(regionIdx, temperature, pressure); }
 
     /*!
@@ -436,7 +436,7 @@ public:
     template <class LhsEval>
     static LhsEval oilVaporizationFactor(const LhsEval& temperature,
                                          const LhsEval& pressure,
-                                         int regionIdx)
+                                         unsigned regionIdx)
     { return gasPvt_->oilVaporizationFactor(regionIdx, temperature, pressure); }
 
     /*!
@@ -446,10 +446,10 @@ public:
      * \param pressure The pressure of interest [Pa]
      */
     template <class LhsEval>
-    static LhsEval fugCoefficientInWater(int compIdx,
+    static LhsEval fugCoefficientInWater(unsigned compIdx,
                                          const LhsEval& temperature,
                                          const LhsEval& pressure,
-                                         int regionIdx)
+                                         unsigned regionIdx)
     { return waterPvt_->fugacityCoefficient(regionIdx, temperature, pressure, compIdx); }
 
     /*!
@@ -459,10 +459,10 @@ public:
      * \param pressure The pressure of interest [Pa]
      */
     template <class LhsEval>
-    static LhsEval fugCoefficientInGas(int compIdx,
+    static LhsEval fugCoefficientInGas(unsigned compIdx,
                                        const LhsEval& temperature,
                                        const LhsEval& pressure,
-                                       int regionIdx)
+                                       unsigned regionIdx)
     { return gasPvt_->fugacityCoefficient(regionIdx, temperature, pressure, compIdx); }
 
     /*!
@@ -472,10 +472,10 @@ public:
      * \param pressure The pressure of interest [Pa]
      */
     template <class LhsEval>
-    static LhsEval fugCoefficientInOil(int compIdx,
+    static LhsEval fugCoefficientInOil(unsigned compIdx,
                                        const LhsEval& temperature,
                                        const LhsEval& pressure,
-                                       int regionIdx)
+                                       unsigned regionIdx)
     { return oilPvt_->fugacityCoefficient(regionIdx, temperature, pressure, compIdx); }
 
     /*!
@@ -487,7 +487,7 @@ public:
     template <class LhsEval>
     static LhsEval oilSaturationPressure(const LhsEval& temperature,
                                          const LhsEval& XoG,
-                                         int regionIdx)
+                                         unsigned regionIdx)
     { return oilPvt_->oilSaturationPressure(regionIdx, temperature, XoG); }
 
     /*!
@@ -496,7 +496,7 @@ public:
     template <class LhsEval>
     static LhsEval saturatedOilGasMassFraction(const LhsEval& temperature,
                                                const LhsEval& pressure,
-                                               int regionIdx)
+                                               unsigned regionIdx)
     { return oilPvt_->saturatedOilGasMassFraction(regionIdx, temperature, pressure); }
 
     /*!
@@ -505,7 +505,7 @@ public:
     template <class LhsEval>
     static LhsEval saturatedOilGasMoleFraction(const LhsEval& temperature,
                                                const LhsEval& pressure,
-                                               int regionIdx)
+                                               unsigned regionIdx)
     { return oilPvt_->saturatedOilGasMoleFraction(regionIdx, temperature, pressure); }
 
     /*!
@@ -514,7 +514,7 @@ public:
     template <class LhsEval>
     static LhsEval saturatedGasOilMassFraction(const LhsEval& temperature,
                                                const LhsEval& pressure,
-                                               int regionIdx)
+                                               unsigned regionIdx)
     { return gasPvt_->saturatedGasOilMassFraction(regionIdx, temperature, pressure); }
 
     /*!
@@ -523,7 +523,7 @@ public:
     template <class LhsEval>
     static LhsEval saturatedGasOilMoleFraction(const LhsEval& temperature,
                                                const LhsEval& pressure,
-                                               int regionIdx)
+                                               unsigned regionIdx)
     { return gasPvt_->saturatedGasOilMoleFraction(regionIdx, temperature, pressure); }
 
     /*!
@@ -534,7 +534,7 @@ public:
     static LhsEval oilFormationVolumeFactor(const LhsEval& temperature,
                                             const LhsEval& pressure,
                                             const LhsEval& XoG,
-                                            int regionIdx)
+                                            unsigned regionIdx)
     { return oilPvt_->formationVolumeFactor(regionIdx, temperature, pressure, XoG); }
 
     /*!
@@ -544,7 +544,7 @@ public:
     static LhsEval oilDensity(const LhsEval& temperature,
                               const LhsEval& pressure,
                               const LhsEval& XoG,
-                              int regionIdx)
+                              unsigned regionIdx)
     { return oilPvt_->density(regionIdx, temperature, pressure, XoG); }
 
     /*!
@@ -553,7 +553,7 @@ public:
     template <class LhsEval>
     static LhsEval saturatedOilDensity(const LhsEval& temperature,
                                        const LhsEval& pressure,
-                                       int regionIdx)
+                                       unsigned regionIdx)
     {
         // mass fraction of gas-saturated oil
         const LhsEval& XoG = saturatedOilGasMassFraction(temperature, pressure, regionIdx);
@@ -567,7 +567,7 @@ public:
     static LhsEval gasFormationVolumeFactor(const LhsEval& temperature,
                                             const LhsEval& pressure,
                                             const LhsEval& XgO,
-                                            int regionIdx)
+                                            unsigned regionIdx)
     { return gasPvt_->formationVolumeFactor(regionIdx, temperature, pressure, XgO); }
 
     /*!
@@ -577,7 +577,7 @@ public:
     static LhsEval gasDensity(const LhsEval& temperature,
                               const LhsEval& pressure,
                               const LhsEval& XgO,
-                              int regionIdx)
+                              unsigned regionIdx)
     { return gasPvt_->density(regionIdx, temperature, pressure, XgO); }
 
     /*!
@@ -586,7 +586,7 @@ public:
     template <class LhsEval>
     static LhsEval waterDensity(const LhsEval& temperature,
                                 const LhsEval& pressure,
-                                int regionIdx)
+                                unsigned regionIdx)
     { return waterPvt_->density(regionIdx, temperature, pressure); }
 
 private:

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -41,9 +41,7 @@
 #include <opm/material/binarycoefficients/Brine_CO2.hpp>
 #include <opm/material/binarycoefficients/H2O_N2.hpp>
 
-#if HAVE_MPI
-#include <mpi.h>
-#endif
+#include <opm/material/common/Unused.hpp>
 
 #include <iostream>
 
@@ -90,7 +88,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::phaseName
      */
-    static const char *phaseName(int phaseIdx)
+    static const char *phaseName(unsigned phaseIdx)
     {
         static const char *name[] = {
             "liquid",
@@ -104,7 +102,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::isLiquid
      */
-    static bool isLiquid(int phaseIdx)
+    static bool isLiquid(unsigned phaseIdx)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -114,7 +112,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::isIdealGas
      */
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned phaseIdx)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -126,7 +124,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::isIdealMixture
      */
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(OPM_UNUSED unsigned phaseIdx)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -136,7 +134,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::isCompressible
      */
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(OPM_UNUSED unsigned phaseIdx)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -162,7 +160,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::componentName
      */
-    static const char *componentName(int compIdx)
+    static const char *componentName(unsigned compIdx)
     {
         static const char *name[] = {
             Brine::name(),
@@ -176,7 +174,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::molarMass
      */
-    static Scalar molarMass(int compIdx)
+    static Scalar molarMass(unsigned compIdx)
     {
         assert(0 <= compIdx && compIdx < numComponents);
         return (compIdx==BrineIdx)
@@ -208,8 +206,8 @@ public:
      * \param pressMax The maximum pressure used for tabulation of water [Pa]
      * \param nPress The number of ticks on the pressure axis of the  table of water
      */
-    static void init(Scalar tempMin, Scalar tempMax, int nTemp,
-                     Scalar pressMin, Scalar pressMax, int nPress)
+    static void init(Scalar tempMin, Scalar tempMax, unsigned nTemp,
+                     Scalar pressMin, Scalar pressMax, unsigned nPress)
     {
         if (H2O::isTabulated) {
             H2O_Tabulated::init(tempMin, tempMax, nTemp,
@@ -230,8 +228,8 @@ public:
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &paramCache,
-                           int phaseIdx)
+                           const ParameterCache &/*paramCache*/,
+                           unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<LhsEval> LhsToolbox;
@@ -284,8 +282,8 @@ public:
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &paramCache,
-                             int phaseIdx)
+                             const ParameterCache &/*paramCache*/,
+                             unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -313,9 +311,9 @@ public:
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx,
-                                       int compIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<LhsEval> LhsToolbox;
@@ -370,9 +368,9 @@ public:
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache &paramCache,
-                                        int phaseIdx,
-                                        int compIdx)
+                                        const ParameterCache &/*paramCache*/,
+                                        unsigned phaseIdx,
+                                        unsigned /*compIdx*/)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -390,8 +388,8 @@ public:
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &paramCache,
-                            int phaseIdx)
+                            const ParameterCache &/*paramCache*/,
+                            unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<LhsEval> LhsToolbox;
@@ -426,9 +424,9 @@ public:
      * \copydoc BaseFluidSystem::thermalConductivity
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx)
+    static LhsEval thermalConductivity(const FluidState &/*fluidState*/,
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx)
     {
         typedef MathToolbox<LhsEval> LhsToolbox;
 
@@ -454,8 +452,8 @@ public:
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &paramCache,
-                                int phaseIdx)
+                                const ParameterCache &/*paramCache*/,
+                                unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidsystems/H2OAirFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirFluidSystem.hpp
@@ -82,7 +82,7 @@ public:
     static const int gasPhaseIdx = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(int phaseIdx)
+    static const char *phaseName(unsigned phaseIdx)
     {
         switch (phaseIdx) {
         case liquidPhaseIdx: return "liquid";
@@ -92,14 +92,14 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isLiquid
-    static bool isLiquid(int phaseIdx)
+    static bool isLiquid(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         return phaseIdx != gasPhaseIdx;
     }
 
     //! \copydoc BaseFluidSystem::isCompressible
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         return (phaseIdx == gasPhaseIdx)
@@ -111,7 +111,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isIdealGas
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned phaseIdx)
     {
         return
             (phaseIdx == gasPhaseIdx)
@@ -120,7 +120,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isIdealMixture
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         // we assume Henry's and Rault's laws for the water phase and
@@ -142,7 +142,7 @@ public:
     static const int AirIdx = 1;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(int compIdx)
+    static const char *componentName(unsigned compIdx)
     {
         switch (compIdx)
         {
@@ -153,7 +153,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::molarMass
-    static Scalar molarMass(int compIdx)
+    static Scalar molarMass(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -161,7 +161,7 @@ public:
             : (compIdx == AirIdx)
             ? Air::molarMass()
             : 1e100;
-   }
+    }
 
 
     /*!
@@ -169,7 +169,7 @@ public:
      *
      * \param compIdx The index of the component to consider
      */
-    static Scalar criticalTemperature(int compIdx)
+    static Scalar criticalTemperature(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -184,7 +184,7 @@ public:
      *
      * \param compIdx The index of the component to consider
      */
-    static Scalar criticalPressure(int compIdx)
+    static Scalar criticalPressure(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -199,7 +199,7 @@ public:
      *
      * \param compIdx The index of the component to consider
      */
-    static Scalar acentricFactor(int compIdx)
+    static Scalar acentricFactor(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -246,15 +246,15 @@ public:
     {
         if (H2O::isTabulated) {
             H2O::init(tempMin, tempMax, nTemp,
-                               pressMin, pressMax, nPress);
+                      pressMin, pressMax, nPress);
         }
     }
 
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &paramCache,
-                           int phaseIdx)
+                           const ParameterCache &/*paramCache*/,
+                           unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef Opm::MathToolbox<LhsEval> LhsToolbox;
@@ -274,7 +274,7 @@ public:
 
 
         LhsEval sumMoleFrac = 0;
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             sumMoleFrac += FsToolbox::template toLhs<LhsEval>(fluidState.moleFraction(phaseIdx, compIdx));
 
         if (phaseIdx == liquidPhaseIdx)
@@ -319,8 +319,8 @@ public:
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval viscosity(const FluidState &fluidState,
-                            const ParameterCache &paramCache,
-                            int phaseIdx)
+                             const ParameterCache &/*paramCache*/,
+                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<LhsEval> LhsToolbox;
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -364,11 +364,9 @@ public:
                     Air::molarMass()
                 };
 
-                for (int i = 0; i < numComponents; ++i)
-                {
+                for (unsigned i = 0; i < numComponents; ++i) {
                     LhsEval divisor = 0;
-                    for (int j = 0; j < numComponents; ++j)
-                    {
+                    for (unsigned j = 0; j < numComponents; ++j) {
                         LhsEval phiIJ =
                             1 +
                             LhsToolbox::sqrt(mu[i]/mu[j]) * // 1 + (mu[i]/mu[j]^1/2
@@ -390,9 +388,9 @@ public:
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                      const ParameterCache &paramCache,
-                                      int phaseIdx,
-                                      int compIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -416,9 +414,9 @@ public:
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval binaryDiffusionCoefficient(const FluidState &fluidState,
-                                             const ParameterCache &paramCache,
-                                             int phaseIdx,
-                                             int compIdx)
+                                              const ParameterCache &/*paramCache*/,
+                                              unsigned phaseIdx,
+                                              unsigned /*compIdx*/)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -435,8 +433,8 @@ public:
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval enthalpy(const FluidState &fluidState,
-                           const ParameterCache &paramCache,
-                           int phaseIdx)
+                            const ParameterCache &/*paramCache*/,
+                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -469,8 +467,8 @@ public:
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                          const ParameterCache &paramCache,
-                                          int phaseIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
@@ -127,18 +127,18 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isLiquid
-    static bool isLiquid(int phaseIdx)
+    static bool isLiquid(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         return phaseIdx != gasPhaseIdx;
     }
 
     //! \copydoc BaseFluidSystem::isIdealGas
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned phaseIdx)
     { return phaseIdx == gasPhaseIdx && H2O::gasIsIdeal() && Air::gasIsIdeal() && NAPL::gasIsIdeal(); }
 
     //! \copydoc BaseFluidSystem::isCompressible
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         // gases are always compressible
@@ -150,7 +150,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isIdealMixture
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         // we assume Henry's and Rault's laws for the water phase and
@@ -160,7 +160,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(int phaseIdx)
+    static const char *phaseName(unsigned phaseIdx)
     {
         switch (phaseIdx) {
         case waterPhaseIdx: return "water";
@@ -171,7 +171,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(int compIdx)
+    static const char *componentName(unsigned compIdx)
     {
         switch (compIdx) {
         case H2OIdx: return H2O::name();
@@ -182,7 +182,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::molarMass
-    static Scalar molarMass(int compIdx)
+    static Scalar molarMass(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -198,8 +198,8 @@ public:
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &paramCache,
-                           int phaseIdx)
+                           const ParameterCache &/*paramCache*/,
+                           unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -245,8 +245,8 @@ public:
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &paramCache,
-                             int phaseIdx)
+                             const ParameterCache &/*paramCache*/,
+                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -308,10 +308,10 @@ public:
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache &paramCache,
-                                        int phaseIdx,
-                                        int compIdx)
+    static LhsEval diffusionCoefficient(const FluidState &/*fluidState*/,
+                                        const ParameterCache &/*paramCache*/,
+                                        unsigned /*phaseIdx*/,
+                                        unsigned /*compIdx*/)
     {
         return 0;
 #if 0
@@ -370,9 +370,9 @@ public:
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx,
-                                       int compIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -419,8 +419,8 @@ public:
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &paramCache,
-                            int phaseIdx)
+                            const ParameterCache &/*paramCache*/,
+                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -448,8 +448,8 @@ public:
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
@@ -89,18 +89,18 @@ public:
     { }
 
     //! \copydoc BaseFluidSystem::isLiquid
-    static bool isLiquid(int phaseIdx)
+    static bool isLiquid(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         return phaseIdx != gasPhaseIdx;
     }
 
     //! \copydoc BaseFluidSystem::isIdealGas
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned phaseIdx)
     { return phaseIdx == gasPhaseIdx && H2O::gasIsIdeal() && Air::gasIsIdeal() && NAPL::gasIsIdeal(); }
 
     //! \copydoc BaseFluidSystem::isIdealMixture
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -111,7 +111,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isCompressible
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(unsigned phaseIdx)
     {
         return
             (phaseIdx == gasPhaseIdx)
@@ -125,7 +125,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(int phaseIdx)
+    static const char *phaseName(unsigned phaseIdx)
     {
         switch (phaseIdx) {
         case waterPhaseIdx: return "water";
@@ -136,7 +136,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(int compIdx)
+    static const char *componentName(unsigned compIdx)
     {
         switch (compIdx) {
         case H2OIdx: return H2O::name();
@@ -147,7 +147,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::molarMass
-    static Scalar molarMass(int compIdx)
+    static Scalar molarMass(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -165,8 +165,8 @@ public:
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval density(const FluidState &fluidState,
-                          const ParameterCache &paramCache,
-                          int phaseIdx)
+                           const ParameterCache &/*paramCache*/,
+                           unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -208,8 +208,8 @@ public:
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval viscosity(const FluidState &fluidState,
-                            const ParameterCache &paramCache,
-                            int phaseIdx)
+                             const ParameterCache &/*paramCache*/,
+                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -272,9 +272,9 @@ public:
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx,
-                                       int compIdx)
+                                        const ParameterCache &/*paramCache*/,
+                                        unsigned phaseIdx,
+                                        unsigned compIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -293,8 +293,8 @@ public:
             if (compIdx==NAPLIdx) return (1.- xgw)/(xga/diffAW + xgc/diffWC);
             else if (compIdx==H2OIdx) return (1.- xgc)/(xgw/diffWC + xga/diffAC);
             else if (compIdx==airIdx) OPM_THROW(std::logic_error,
-                                                 "Diffusivity of air in the gas phase "
-                                                 "is constraint by sum of diffusive fluxes = 0 !\n");
+                                                "Diffusivity of air in the gas phase "
+                                                "is constraint by sum of diffusive fluxes = 0 !\n");
         } else if (phaseIdx==waterPhaseIdx){
             Scalar diffACl = 1.e-9; // BinaryCoeff::Air_Xylene::liquidDiffCoeff(temperature, pressure);
             Scalar diffWCl = 1.e-9; // BinaryCoeff::H2O_Xylene::liquidDiffCoeff(temperature, pressure);
@@ -311,14 +311,14 @@ public:
                 return (1.- xwc)/(xww/diffWCl + xwa/diffACl);
             case H2OIdx:
                 OPM_THROW(std::logic_error,
-                           "Diffusivity of water in the water phase "
-                           "is constraint by sum of diffusive fluxes = 0 !\n");
+                          "Diffusivity of water in the water phase "
+                          "is constraint by sum of diffusive fluxes = 0 !\n");
             };
         } else if (phaseIdx==naplPhaseIdx) {
 
             OPM_THROW(std::logic_error,
-                       "Diffusion coefficients of "
-                       "substances in liquid phase are undefined!\n");
+                      "Diffusion coefficients of "
+                      "substances in liquid phase are undefined!\n");
         }
         return 0;
     }
@@ -326,9 +326,9 @@ public:
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                      const ParameterCache &paramCache,
-                                      int phaseIdx,
-                                      int compIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -371,8 +371,8 @@ public:
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval enthalpy(const FluidState &fluidState,
-                           const ParameterCache &paramCache,
-                           int phaseIdx)
+                            const ParameterCache &/*paramCache*/,
+                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidsystems/H2ON2FluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2FluidSystem.hpp
@@ -80,7 +80,7 @@ public:
     static const int gasPhaseIdx = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(int phaseIdx)
+    static const char *phaseName(unsigned phaseIdx)
     {
         static const char *name[] = {
             "liquid",
@@ -92,14 +92,14 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isLiquid
-    static bool isLiquid(int phaseIdx)
+    static bool isLiquid(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         return phaseIdx != gasPhaseIdx;
     }
 
     //! \copydoc BaseFluidSystem::isCompressible
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         // gases are always compressible
@@ -110,7 +110,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isIdealGas
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -121,7 +121,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isIdealMixture
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         // we assume Henry's and Rault's laws for the water phase and
@@ -151,7 +151,7 @@ public:
     typedef SimpleN2 N2;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(int compIdx)
+    static const char *componentName(unsigned compIdx)
     {
         static const char *name[] = {
             H2O::name(),
@@ -163,7 +163,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::molarMass
-    static Scalar molarMass(int compIdx)
+    static Scalar molarMass(unsigned compIdx)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
         return (compIdx == H2OIdx)
@@ -178,7 +178,7 @@ public:
      *
      * \copydetails Doxygen::compIdxParam
      */
-    static Scalar criticalTemperature(int compIdx)
+    static Scalar criticalTemperature(unsigned compIdx)
     {
         return (compIdx == H2OIdx)
             ? H2O::criticalTemperature()
@@ -192,7 +192,7 @@ public:
      *
      * \copydetails Doxygen::compIdxParam
      */
-    static Scalar criticalPressure(int compIdx)
+    static Scalar criticalPressure(unsigned compIdx)
     {
         return (compIdx == H2OIdx)
             ? H2O::criticalPressure()
@@ -206,7 +206,7 @@ public:
      *
      * \copydetails Doxygen::compIdxParam
      */
-    static Scalar acentricFactor(int compIdx)
+    static Scalar acentricFactor(unsigned compIdx)
     {
         return (compIdx == H2OIdx)
             ? H2O::acentricFactor()
@@ -264,8 +264,8 @@ public:
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &paramCache,
-                           int phaseIdx)
+                           const ParameterCache &/*paramCache*/,
+                           unsigned phaseIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx < numPhases);
 
@@ -276,7 +276,7 @@ public:
         const auto& p = FsToolbox::template toLhs<LhsEval>(fluidState.pressure(phaseIdx));
 
         LhsEval sumMoleFrac = 0;
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             sumMoleFrac += FsToolbox::template toLhs<LhsEval>(fluidState.moleFraction(phaseIdx, compIdx));
 
         // liquid phase
@@ -321,8 +321,8 @@ public:
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &paramCache,
-                             int phaseIdx)
+                             const ParameterCache &/*paramCache*/,
+                             unsigned phaseIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx < numPhases);
 
@@ -357,13 +357,13 @@ public:
             };
 
             LhsEval sumx = 0.0;
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
                 sumx += FsToolbox::template toLhs<LhsEval>(fluidState.moleFraction(phaseIdx, compIdx));
             sumx = LhsToolbox::max(1e-10, sumx);
 
-            for (int i = 0; i < numComponents; ++i) {
+            for (unsigned i = 0; i < numComponents; ++i) {
                 LhsEval divisor = 0;
-                for (int j = 0; j < numComponents; ++j) {
+                for (unsigned j = 0; j < numComponents; ++j) {
                     LhsEval phiIJ = 1 + LhsToolbox::sqrt(mu[i]/mu[j]) * std::pow(molarMass(j)/molarMass(i), 1/4.0);
                     phiIJ *= phiIJ;
                     phiIJ /= std::sqrt(8*(1 + molarMass(i)/molarMass(j)));
@@ -382,9 +382,9 @@ public:
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx,
-                                       int compIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx < numPhases);
         assert(0 <= compIdx  && compIdx < numComponents);
@@ -411,9 +411,9 @@ public:
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache &paramCache,
-                                        int phaseIdx,
-                                        int compIdx)
+                                        const ParameterCache &/*paramCache*/,
+                                        unsigned phaseIdx,
+                                        unsigned /*compIdx*/)
 
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -433,8 +433,8 @@ public:
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &paramCache,
-                            int phaseIdx)
+                            const ParameterCache &/*paramCache*/,
+                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -467,8 +467,8 @@ public:
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx < numPhases);
 
@@ -502,8 +502,8 @@ public:
     //! \copydoc BaseFluidSystem::heatCapacity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &paramCache,
-                                int phaseIdx)
+                                const ParameterCache &/*paramCache*/,
+                                unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -79,7 +79,7 @@ public:
     static const int liquidPhaseIdx = 0;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(int phaseIdx)
+    static const char *phaseName(OPM_UNUSED unsigned phaseIdx)
     {
         assert(phaseIdx == liquidPhaseIdx);
 
@@ -87,14 +87,14 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isLiquid
-    static bool isLiquid(int phaseIdx)
+    static bool isLiquid(unsigned /*phaseIdx*/)
     {
         //assert(phaseIdx == liquidPhaseIdx);
         return true; //only water phase present
     }
 
     //! \copydoc BaseFluidSystem::isCompressible
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         // the water component decides for the liquid phase...
@@ -102,14 +102,14 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isIdealGas
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         return false; // not a gas (only liquid phase present)
     }
 
     //! \copydoc BaseFluidSystem::isIdealMixture
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         // we assume Henry's and Rault's laws for the water phase and
@@ -139,7 +139,7 @@ public:
     typedef SimpleN2 N2;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(int compIdx)
+    static const char *componentName(unsigned compIdx)
     {
         static const char *name[] = {
             H2O::name(),
@@ -151,7 +151,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::molarMass
-    static Scalar molarMass(int compIdx)
+    static Scalar molarMass(unsigned compIdx)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
         return (compIdx == H2OIdx)
@@ -166,7 +166,7 @@ public:
      *
      * \param compIdx The index of the component to consider
      */
-    static Scalar criticalTemperature(int compIdx)
+    static Scalar criticalTemperature(unsigned compIdx)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
         return (compIdx == H2OIdx)
@@ -181,7 +181,7 @@ public:
      *
      * \param compIdx The index of the component to consider
      */
-    static Scalar criticalPressure(int compIdx)
+    static Scalar criticalPressure(unsigned compIdx)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
         return (compIdx == H2OIdx)
@@ -196,7 +196,7 @@ public:
      *
      * \param compIdx The index of the component to consider
      */
-    static Scalar acentricFactor(int compIdx)
+    static Scalar acentricFactor(unsigned compIdx)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
         return (compIdx == H2OIdx)
@@ -249,8 +249,8 @@ public:
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &paramCache,
-                           int phaseIdx)
+                           const ParameterCache &/*paramCache*/,
+                           unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -260,7 +260,7 @@ public:
         const auto& p = FsToolbox::template toLhs<LhsEval>(fluidState.pressure(phaseIdx));
 
         LhsEval sumMoleFrac = 0;
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             sumMoleFrac += FsToolbox::template toLhs<LhsEval>(fluidState.moleFraction(phaseIdx, compIdx));
 
         assert(phaseIdx == liquidPhaseIdx);
@@ -286,8 +286,8 @@ public:
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &paramCache,
-                             int phaseIdx)
+                             const ParameterCache &/*paramCache*/,
+                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -303,9 +303,9 @@ public:
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx,
-                                       int compIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -323,9 +323,9 @@ public:
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache &paramCache,
-                                        int phaseIdx,
-                                        int compIdx)
+                                        const ParameterCache &/*paramCache*/,
+                                        unsigned phaseIdx,
+                                        unsigned /*compIdx*/)
 
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -341,8 +341,8 @@ public:
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &paramCache,
-                            int phaseIdx)
+                            const ParameterCache &/*paramCache*/,
+                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -360,8 +360,8 @@ public:
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       const int phaseIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       const unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -379,8 +379,8 @@ public:
     //! \copydoc BaseFluidSystem::heatCapacity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &paramCache,
-                                int phaseIdx)
+                                const ParameterCache &/*paramCache*/,
+                                unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidsystems/ParameterCacheBase.hpp
+++ b/opm/material/fluidsystems/ParameterCacheBase.hpp
@@ -63,9 +63,9 @@ public:
      * \param exceptQuantities The quantities of the fluid state that have not changed since the last update.
      */
     template <class FluidState>
-    void updateAll(const FluidState &fluidState, int exceptQuantities = None)
+    void updateAll(const FluidState &fluidState, int /*exceptQuantities*/ = None)
     {
-        for (int phaseIdx = 0; phaseIdx < FluidState::numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < FluidState::numPhases; ++phaseIdx)
             asImp_().updatePhase(fluidState, phaseIdx);
     }
 
@@ -94,7 +94,7 @@ public:
     template <class FluidState>
     void updateAllTemperatures(const FluidState &fluidState)
     {
-        for (int phaseIdx = 0; phaseIdx < FluidState::numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < FluidState::numPhases; ++phaseIdx)
             asImp_().updatePhase(fluidState, phaseIdx);
     }
 
@@ -107,7 +107,7 @@ public:
      * \param exceptQuantities The quantities of the fluid state that have not changed since the last update.
      */
     template <class FluidState>
-    void updatePhase(const FluidState &fluidState, int phaseIdx, int exceptQuantities = None)
+    void updatePhase(const FluidState& /*fluidState*/, unsigned /*phaseIdx*/, int /*exceptQuantities*/ = None)
     {}
 
     /*!
@@ -122,7 +122,7 @@ public:
      * \param phaseIdx The index of the fluid phase of interest.
      */
     template <class FluidState>
-    void updateTemperature(const FluidState &fluidState, int phaseIdx)
+    void updateTemperature(const FluidState &fluidState, unsigned phaseIdx)
     {
         asImp_().updatePhase(fluidState, phaseIdx);
     }
@@ -139,7 +139,7 @@ public:
      * \param phaseIdx The index of the fluid phase of interest.
      */
     template <class FluidState>
-    void updatePressure(const FluidState &fluidState, int phaseIdx)
+    void updatePressure(const FluidState &fluidState, unsigned phaseIdx)
     {
         asImp_().updatePhase(fluidState, phaseIdx);
     }
@@ -156,7 +156,7 @@ public:
      * \param phaseIdx The index of the fluid phase of interest.
      */
     template <class FluidState>
-    void updateComposition(const FluidState &fluidState, int phaseIdx)
+    void updateComposition(const FluidState &fluidState, unsigned phaseIdx)
     {
         asImp_().updatePhase(fluidState, phaseIdx, /*except=*/Temperature | Pressure);
     }
@@ -176,8 +176,8 @@ public:
      */
     template <class FluidState>
     void updateSingleMoleFraction(const FluidState &fluidState,
-                                  int phaseIdx,
-                                  int compIdx)
+                                  unsigned phaseIdx,
+                                  unsigned /*compIdx*/)
     {
         asImp_().updateComposition(fluidState, phaseIdx);
     }

--- a/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
@@ -36,6 +36,8 @@
 #include <opm/material/components/N2.hpp>
 #include <opm/material/components/TabulatedComponent.hpp>
 
+#include <opm/material/common/Unused.hpp>
+
 #include <limits>
 #include <cassert>
 
@@ -70,7 +72,7 @@ public:
     static const int numPhases = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(int phaseIdx)
+    static const char *phaseName(OPM_UNUSED unsigned phaseIdx)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -78,7 +80,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isLiquid
-    static bool isLiquid(int phaseIdx)
+    static bool isLiquid(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -86,7 +88,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isCompressible
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -95,7 +97,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isIdealGas
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -104,7 +106,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isIdealMixture
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -120,7 +122,7 @@ public:
     static const int numComponents = 1;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(int compIdx)
+    static const char *componentName(OPM_UNUSED unsigned compIdx)
     {
         assert(0 <= compIdx && compIdx < numComponents);
 
@@ -128,7 +130,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::molarMass
-    static Scalar molarMass(int compIdx)
+    static Scalar molarMass(unsigned /*compIdx*/)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
 
@@ -140,7 +142,7 @@ public:
      *
      * \param compIdx The index of the component to consider
      */
-    static Scalar criticalTemperature(int compIdx)
+    static Scalar criticalTemperature(unsigned /*compIdx*/)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
 
@@ -152,7 +154,7 @@ public:
      *
      * \param compIdx The index of the component to consider
      */
-    static Scalar criticalPressure(int compIdx)
+    static Scalar criticalPressure(unsigned /*compIdx*/)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
 
@@ -164,7 +166,7 @@ public:
      *
      * \param compIdx The index of the component to consider
      */
-    static Scalar acentricFactor(int compIdx)
+    static Scalar acentricFactor(unsigned /*compIdx*/)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
 
@@ -182,8 +184,8 @@ public:
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &paramCache,
-                           int phaseIdx)
+                           const ParameterCache &/*paramCache*/,
+                           unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -197,8 +199,8 @@ public:
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &paramCache,
-                             int phaseIdx)
+                             const ParameterCache &/*paramCache*/,
+                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -211,10 +213,10 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx,
-                                       int compIdx)
+    static LhsEval fugacityCoefficient(const FluidState &/*fluidState*/,
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx < numPhases);
         assert(0 <= compIdx  && compIdx < numComponents);
@@ -231,8 +233,8 @@ public:
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &paramCache,
-                            int phaseIdx)
+                            const ParameterCache &/*paramCache*/,
+                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -246,8 +248,8 @@ public:
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -261,8 +263,8 @@ public:
     //! \copydoc BaseFluidSystem::heatCapacity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &paramCache,
-                                int phaseIdx)
+                                const ParameterCache &/*paramCache*/,
+                                unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidsystems/Spe5FluidSystem.hpp
+++ b/opm/material/fluidsystems/Spe5FluidSystem.hpp
@@ -82,7 +82,7 @@ public:
     typedef Opm::H2O<Scalar> H2O;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(int phaseIdx)
+    static const char *phaseName(unsigned phaseIdx)
     {
         static const char *name[] = {
             "gas",
@@ -95,7 +95,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isLiquid
-    static bool isLiquid(int phaseIdx)
+    static bool isLiquid(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         return phaseIdx != gasPhaseIdx;
@@ -106,21 +106,21 @@ public:
      *
      * In the SPE-5 problems all fluids are compressible...
      */
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         return true;
     }
 
     //! \copydoc BaseFluidSystem::isIdealGas
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         return false; // gas is not ideal here!
     }
 
     //! \copydoc BaseFluidSystem::isIdealMixture
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(unsigned phaseIdx)
     {
         // always use the reference oil for the fugacity coefficents,
         // so they cannot be dependent on composition and they the
@@ -144,7 +144,7 @@ public:
     static const int C20Idx = 6; //!< Index of the C20 component
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(int compIdx)
+    static const char *componentName(unsigned compIdx)
     {
         static const char *name[] = {
             H2O::name(),
@@ -161,7 +161,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::molarMass
-    static Scalar molarMass(int compIdx)
+    static Scalar molarMass(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -184,7 +184,7 @@ public:
     /*!
      * \brief Critical temperature of a component [K].
      */
-    static Scalar criticalTemperature(int compIdx)
+    static Scalar criticalTemperature(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -207,7 +207,7 @@ public:
     /*!
      * \brief Critical pressure of a component [Pa].
      */
-    static Scalar criticalPressure(int compIdx)
+    static Scalar criticalPressure(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -230,7 +230,7 @@ public:
     /*!
      * \brief Molar volume of a component at the critical point [m^3/mol].
      */
-    static Scalar criticalMolarVolume(int compIdx)
+    static Scalar criticalMolarVolume(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -253,7 +253,7 @@ public:
     /*!
      * \brief The acentric factor of a component [].
      */
-    static Scalar acentricFactor(int compIdx)
+    static Scalar acentricFactor(unsigned compIdx)
     {
         return
             (compIdx == H2OIdx)
@@ -278,10 +278,10 @@ public:
      *
      * The values are given by the SPE5 paper.
      */
-    static Scalar interactionCoefficient(int comp1Idx, int comp2Idx)
+    static Scalar interactionCoefficient(unsigned comp1Idx, unsigned comp2Idx)
     {
-        int i = std::min(comp1Idx, comp2Idx);
-        int j = std::max(comp1Idx, comp2Idx);
+        unsigned i = std::min(comp1Idx, comp2Idx);
+        unsigned j = std::max(comp1Idx, comp2Idx);
         if (i == C1Idx && (j == C15Idx || j == C20Idx))
             return 0.05;
         else if (i == C3Idx && (j == C15Idx || j == C20Idx))
@@ -318,7 +318,7 @@ public:
         Scalar minB = 1e100, maxB = -1e100;
 
         prParams.updatePure(minT, minP);
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             minA = std::min(prParams.pureParams(compIdx).a(), minA);
             maxA = std::max(prParams.pureParams(compIdx).a(), maxA);
             minB = std::min(prParams.pureParams(compIdx).b(), minB);
@@ -326,7 +326,7 @@ public:
         };
 
         prParams.updatePure(maxT, minP);
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             minA = std::min(prParams.pureParams(compIdx).a(), minA);
             maxA = std::max(prParams.pureParams(compIdx).a(), maxA);
             minB = std::min(prParams.pureParams(compIdx).b(), minB);
@@ -334,7 +334,7 @@ public:
         };
 
         prParams.updatePure(minT, maxP);
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             minA = std::min(prParams.pureParams(compIdx).a(), minA);
             maxA = std::max(prParams.pureParams(compIdx).a(), maxA);
             minB = std::min(prParams.pureParams(compIdx).b(), minB);
@@ -342,7 +342,7 @@ public:
         };
 
         prParams.updatePure(maxT, maxP);
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             minA = std::min(prParams.pureParams(compIdx).a(), minA);
             maxA = std::max(prParams.pureParams(compIdx).a(), maxA);
             minB = std::min(prParams.pureParams(compIdx).b(), minB);
@@ -357,7 +357,7 @@ public:
     template <class FluidState, class Evaluation = Scalar>
     static Scalar density(const FluidState &fluidState,
                           const ParameterCache &paramCache,
-                          int phaseIdx)
+                          unsigned phaseIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx < numPhases);
         static_assert(std::is_same<Evaluation, Scalar>::value,
@@ -368,9 +368,9 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class Evaluation = Scalar>
-    static Scalar viscosity(const FluidState &fluidState,
-                            const ParameterCache &paramCache,
-                            int phaseIdx)
+    static Scalar viscosity(const FluidState &/*fluidState*/,
+                            const ParameterCache &/*paramCache*/,
+                            unsigned phaseIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx <= numPhases);
         static_assert(std::is_same<Evaluation, Scalar>::value,
@@ -396,8 +396,8 @@ public:
     template <class FluidState, class Evaluation = Scalar>
     static Scalar fugacityCoefficient(const FluidState &fluidState,
                                       const ParameterCache &paramCache,
-                                      int phaseIdx,
-                                      int compIdx)
+                                      unsigned phaseIdx,
+                                      unsigned compIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx <= numPhases);
         assert(0 <= compIdx  && compIdx <= numComponents);
@@ -418,7 +418,7 @@ public:
     }
 
 protected:
-    static Scalar henryCoeffWater_(int compIdx, Scalar temperature)
+    static Scalar henryCoeffWater_(unsigned compIdx, Scalar temperature)
     {
         // use henry's law for the solutes and the vapor pressure for
         // the solvent.

--- a/opm/material/fluidsystems/Spe5ParameterCache.hpp
+++ b/opm/material/fluidsystems/Spe5ParameterCache.hpp
@@ -62,7 +62,7 @@ public:
 
     Spe5ParameterCache()
     {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             VmUpToDate_[phaseIdx] = false;
             Valgrind::SetUndefined(Vm_[phaseIdx]);
         }
@@ -71,7 +71,7 @@ public:
     //! \copydoc ParameterCacheBase::updatePhase
     template <class FluidState>
     void updatePhase(const FluidState &fluidState,
-                     int phaseIdx,
+                     unsigned phaseIdx,
                      int exceptQuantities = ParentType::None)
     {
         updateEosParams(fluidState, phaseIdx, exceptQuantities);
@@ -88,8 +88,8 @@ public:
     //! \copydoc ParameterCacheBase::updateSingleMoleFraction
     template <class FluidState>
     void updateSingleMoleFraction(const FluidState &fluidState,
-                                  int phaseIdx,
-                                  int compIdx)
+                                  unsigned phaseIdx,
+                                  unsigned compIdx)
     {
         if (phaseIdx == oilPhaseIdx)
             oilPhaseParams_.updateSingleMoleFraction(fluidState, compIdx);
@@ -105,7 +105,7 @@ public:
      *
      * \param phaseIdx The fluid phase of interest
      */
-    Scalar a(int phaseIdx) const
+    Scalar a(unsigned phaseIdx) const
     {
         switch (phaseIdx)
         {
@@ -123,7 +123,7 @@ public:
      *
      * \param phaseIdx The fluid phase of interest
      */
-    Scalar b(int phaseIdx) const
+    Scalar b(unsigned phaseIdx) const
     {
         switch (phaseIdx)
         {
@@ -144,7 +144,7 @@ public:
      * \param phaseIdx The fluid phase of interest
      * \param compIdx The component phase of interest
      */
-    Scalar aPure(int phaseIdx, int compIdx) const
+    Scalar aPure(unsigned phaseIdx, unsigned compIdx) const
     {
         switch (phaseIdx)
         {
@@ -164,7 +164,7 @@ public:
      * \param phaseIdx The fluid phase of interest
      * \param compIdx The component phase of interest
      */
-    Scalar bPure(int phaseIdx, int compIdx) const
+    Scalar bPure(unsigned phaseIdx, unsigned compIdx) const
     {
         switch (phaseIdx)
         {
@@ -182,7 +182,7 @@ public:
      *
      * \param phaseIdx The fluid phase of interest
      */
-    Scalar molarVolume(int phaseIdx) const
+    Scalar molarVolume(unsigned phaseIdx) const
     { assert(VmUpToDate_[phaseIdx]); return Vm_[phaseIdx]; }
 
 
@@ -210,7 +210,7 @@ public:
      */
     template <class FluidState>
     void updateEosParams(const FluidState &fluidState,
-                         int phaseIdx,
+                         unsigned phaseIdx,
                          int exceptQuantities = ParentType::None)
     {
         if (!(exceptQuantities & ParentType::Temperature))
@@ -237,7 +237,7 @@ protected:
      * This usually means the parameters for the pure components.
      */
     template <class FluidState>
-    void updatePure_(const FluidState &fluidState, int phaseIdx)
+    void updatePure_(const FluidState &fluidState, unsigned phaseIdx)
     {
         Scalar T = fluidState.temperature(phaseIdx);
         Scalar p = fluidState.pressure(phaseIdx);
@@ -258,7 +258,7 @@ protected:
      * Here, the mixing rule kicks in.
      */
     template <class FluidState>
-    void updateMix_(const FluidState &fluidState, int phaseIdx)
+    void updateMix_(const FluidState &fluidState, unsigned phaseIdx)
     {
         Valgrind::CheckDefined(fluidState.averageMolarMass(phaseIdx));
         switch (phaseIdx)
@@ -276,7 +276,7 @@ protected:
 
     template <class FluidState>
     void updateMolarVolume_(const FluidState &fluidState,
-                            int phaseIdx)
+                            unsigned phaseIdx)
     {
         VmUpToDate_[phaseIdx] = true;
 
@@ -294,6 +294,7 @@ protected:
                                                  *this,
                                                  phaseIdx,
                                                  /*isGasPhase=*/true);
+            break;
         }
         case oilPhaseIdx: {
             // calculate molar volumes for the given composition. although
@@ -307,6 +308,7 @@ protected:
                                                  phaseIdx,
                                                  /*isGasPhase=*/false);
 
+            break;
         }
         case waterPhaseIdx: {
             // Density of water in the stock tank (i.e. atmospheric
@@ -321,6 +323,7 @@ protected:
 
             // convert water density [kg/m^3] to molar volume [m^3/mol]
             Vm_[waterPhaseIdx] = fluidState.averageMolarMass(waterPhaseIdx)/waterDensity;
+            break;
         };
         };
     }

--- a/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
+++ b/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
@@ -79,7 +79,7 @@ public:
     static const int nonWettingPhaseIdx = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(int phaseIdx)
+    static const char *phaseName(unsigned phaseIdx)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -91,7 +91,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isLiquid
-    static bool isLiquid(int phaseIdx)
+    static bool isLiquid(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
         return
@@ -101,7 +101,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isCompressible
-    static bool isCompressible(int phaseIdx)
+    static bool isCompressible(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -112,7 +112,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isIdealGas
-    static bool isIdealGas(int phaseIdx)
+    static bool isIdealGas(unsigned phaseIdx)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -124,7 +124,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isIdealMixture
-    static bool isIdealMixture(int phaseIdx)
+    static bool isIdealMixture(unsigned /*phaseIdx*/)
     {
         //assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -145,7 +145,7 @@ public:
     static const int nonWettingCompIdx = 1;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(int compIdx)
+    static const char *componentName(unsigned compIdx)
     {
         assert(0 <= compIdx && compIdx < numComponents);
 
@@ -155,7 +155,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::molarMass
-    static Scalar molarMass(int compIdx)
+    static Scalar molarMass(unsigned compIdx)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
 
@@ -169,7 +169,7 @@ public:
     /*!
      * \brief Critical temperature of a component [K].
      */
-    static Scalar criticalTemperature(int compIdx)
+    static Scalar criticalTemperature(unsigned compIdx)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
         // let the fluids decide
@@ -182,7 +182,7 @@ public:
     /*!
      * \brief Critical pressure of a component [Pa].
      */
-    static Scalar criticalPressure(int compIdx)
+    static Scalar criticalPressure(unsigned compIdx)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
         // let the fluids decide
@@ -195,7 +195,7 @@ public:
     /*!
      * \brief The acentric factor of a component [].
      */
-    static Scalar acentricFactor(int compIdx)
+    static Scalar acentricFactor(unsigned compIdx)
     {
         //assert(0 <= compIdx && compIdx < numComponents);
         // let the fluids decide
@@ -220,8 +220,8 @@ public:
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &paramCache,
-                           int phaseIdx)
+                           const ParameterCache &/*paramCache*/,
+                           unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -237,8 +237,8 @@ public:
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &paramCache,
-                             int phaseIdx)
+                             const ParameterCache &/*paramCache*/,
+                             unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -253,10 +253,10 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx,
-                                       int compIdx)
+    static LhsEval fugacityCoefficient(const FluidState &/*fluidState*/,
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
     {
         typedef MathToolbox<LhsEval> LhsToolbox;
 
@@ -275,8 +275,8 @@ public:
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &paramCache,
-                            int phaseIdx)
+                            const ParameterCache &/*paramCache*/,
+                            unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -292,8 +292,8 @@ public:
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
-                                       int phaseIdx)
+                                       const ParameterCache &/*paramCache*/,
+                                       unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -309,8 +309,8 @@ public:
     //! \copydoc BaseFluidSystem::heatCapacity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &paramCache,
-                                int phaseIdx)
+                                const ParameterCache &/*paramCache*/,
+                                unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtInterface.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtInterface.hpp
@@ -44,14 +44,16 @@ template <class Scalar, class Evaluation = Scalar>
 class GasPvtInterface
 {
 public:
+    virtual ~GasPvtInterface() {}
+
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
-    virtual Evaluation viscosity(int regionIdx,
+    virtual Evaluation viscosity(unsigned regionIdx,
                                  const Evaluation& temperature,
                                  const Evaluation& pressure,
                                  const Evaluation& XgO) const = 0;
-    virtual Scalar viscosity(int regionIdx,
+    virtual Scalar viscosity(unsigned regionIdx,
                              Scalar temperature,
                              Scalar pressure,
                              Scalar XgO) const = 0;
@@ -59,11 +61,11 @@ public:
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */
-    virtual Evaluation formationVolumeFactor(int regionIdx,
+    virtual Evaluation formationVolumeFactor(unsigned regionIdx,
                                              const Evaluation& temperature,
                                              const Evaluation& pressure,
                                              const Evaluation& XgO) const = 0;
-    virtual Scalar formationVolumeFactor(int regionIdx,
+    virtual Scalar formationVolumeFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure,
                                          Scalar XgO) const = 0;
@@ -71,11 +73,11 @@ public:
     /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
      */
-    virtual Evaluation density(int regionIdx,
+    virtual Evaluation density(unsigned regionIdx,
                                const Evaluation& temperature,
                                const Evaluation& pressure,
                                const Evaluation& XgO) const = 0;
-    virtual Scalar density(int regionIdx,
+    virtual Scalar density(unsigned regionIdx,
                            Scalar temperature,
                            Scalar pressure,
                            Scalar XgO) const = 0;
@@ -84,22 +86,22 @@ public:
      * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
      *        a set of parameters.
      */
-    virtual Evaluation fugacityCoefficient(int regionIdx,
+    virtual Evaluation fugacityCoefficient(unsigned regionIdx,
                                            const Evaluation& temperature,
                                            const Evaluation& pressure,
-                                           int compIdx) const = 0;
-    virtual Scalar fugacityCoefficient(int regionIdx,
+                                           unsigned compIdx) const = 0;
+    virtual Scalar fugacityCoefficient(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure,
-                                       int compIdx) const = 0;
+                                       unsigned compIdx) const = 0;
 
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of oil saturated gas.
      */
-    virtual Evaluation oilVaporizationFactor(int regionIdx,
+    virtual Evaluation oilVaporizationFactor(unsigned regionIdx,
                                              const Evaluation& temperature,
                                              const Evaluation& pressure) const = 0;
-    virtual Scalar oilVaporizationFactor(int regionIdx,
+    virtual Scalar oilVaporizationFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure) const = 0;
 
@@ -109,10 +111,10 @@ public:
      *
      * \param XgO The mass fraction of the oil component in the gas phase [-]
      */
-    virtual Evaluation gasSaturationPressure(int regionIdx,
+    virtual Evaluation gasSaturationPressure(unsigned regionIdx,
                                              const Evaluation& temperature,
                                              const Evaluation& XgO) const = 0;
-    virtual Scalar gasSaturationPressure(int regionIdx,
+    virtual Scalar gasSaturationPressure(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar XgO) const = 0;
 
@@ -120,10 +122,10 @@ public:
      * \brief Returns the gas mass fraction of oil-saturated gas at a given temperatire
      *        and pressure [-].
      */
-    virtual Evaluation saturatedGasOilMassFraction(int regionIdx,
+    virtual Evaluation saturatedGasOilMassFraction(unsigned regionIdx,
                                                    const Evaluation& temperature,
                                                    const Evaluation& pressure) const = 0;
-    virtual Scalar saturatedGasOilMassFraction(int regionIdx,
+    virtual Scalar saturatedGasOilMassFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const = 0;
 
@@ -131,10 +133,10 @@ public:
      * \brief Returns the gas mole fraction of oil-saturated gas at a given temperatire
      *        and pressure [-].
      */
-    virtual Evaluation saturatedGasOilMoleFraction(int regionIdx,
+    virtual Evaluation saturatedGasOilMoleFraction(unsigned regionIdx,
                                                    const Evaluation& temperature,
                                                    const Evaluation& pressure) const = 0;
-    virtual Scalar saturatedGasOilMoleFraction(int regionIdx,
+    virtual Scalar saturatedGasOilMoleFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const = 0;
 };
@@ -143,32 +145,32 @@ template <class Scalar>
 class GasPvtInterface<Scalar, Scalar>
 {
 public:
-    virtual Scalar viscosity(int regionIdx,
+    virtual Scalar viscosity(unsigned regionIdx,
                              Scalar temperature,
                              Scalar pressure,
                              Scalar XgO) const = 0;
-    virtual Scalar formationVolumeFactor(int regionIdx,
+    virtual Scalar formationVolumeFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure,
                                          Scalar XgO) const = 0;
-    virtual Scalar density(int regionIdx,
+    virtual Scalar density(unsigned regionIdx,
                            Scalar temperature,
                            Scalar pressure,
                            Scalar XgO) const = 0;
-    virtual Scalar fugacityCoefficient(int regionIdx,
+    virtual Scalar fugacityCoefficient(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure,
-                                       int compIdx) const = 0;
-    virtual Scalar oilVaporizationFactor(int regionIdx,
+                                       unsigned compIdx) const = 0;
+    virtual Scalar oilVaporizationFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure) const = 0;
-    virtual Scalar gasSaturationPressure(int regionIdx,
+    virtual Scalar gasSaturationPressure(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar XgO) const = 0;
-    virtual Scalar saturatedGasOilMassFraction(int regionIdx,
+    virtual Scalar saturatedGasOilMassFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const = 0;
-    virtual Scalar saturatedGasOilMoleFraction(int regionIdx,
+    virtual Scalar saturatedGasOilMoleFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const = 0;
 };
@@ -180,85 +182,85 @@ class GasPvtInterfaceTemplateWrapper : public GasPvtInterface<Scalar, Evaluation
     { return *static_cast<const Implementation*>(this); }
 
 public:
-    virtual Evaluation viscosity(int regionIdx,
+    virtual Evaluation viscosity(unsigned regionIdx,
                                  const Evaluation& temperature,
                                  const Evaluation& pressure,
                                  const Evaluation& XgO) const OPM_FINAL
-    { return asImp_().viscosity_(regionIdx, temperature, pressure, XgO); };
-    virtual Scalar viscosity(int regionIdx,
+    { return asImp_().viscosity_(regionIdx, temperature, pressure, XgO); }
+    virtual Scalar viscosity(unsigned regionIdx,
                              Scalar temperature,
                              Scalar pressure,
                              Scalar XgO) const OPM_FINAL
-    { return asImp_().viscosity_(regionIdx, temperature, pressure, XgO); };
+    { return asImp_().viscosity_(regionIdx, temperature, pressure, XgO); }
 
-    virtual Evaluation formationVolumeFactor(int regionIdx,
+    virtual Evaluation formationVolumeFactor(unsigned regionIdx,
                                              const Evaluation& temperature,
                                              const Evaluation& pressure,
                                              const Evaluation& XgO) const OPM_FINAL
-    { return asImp_().formationVolumeFactor_(regionIdx, temperature, pressure, XgO); };
-    virtual Scalar formationVolumeFactor(int regionIdx,
+    { return asImp_().formationVolumeFactor_(regionIdx, temperature, pressure, XgO); }
+    virtual Scalar formationVolumeFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure,
                                          Scalar XgO) const OPM_FINAL
-    { return asImp_().formationVolumeFactor_(regionIdx, temperature, pressure, XgO); };
+    { return asImp_().formationVolumeFactor_(regionIdx, temperature, pressure, XgO); }
 
-    virtual Evaluation density(int regionIdx,
+    virtual Evaluation density(unsigned regionIdx,
                                const Evaluation& temperature,
                                const Evaluation& pressure,
                                const Evaluation& XgO) const OPM_FINAL
-    { return asImp_().density_(regionIdx, temperature, pressure, XgO); };
-    virtual Scalar density(int regionIdx,
+    { return asImp_().density_(regionIdx, temperature, pressure, XgO); }
+    virtual Scalar density(unsigned regionIdx,
                            Scalar temperature,
                            Scalar pressure,
                            Scalar XgO) const OPM_FINAL
-    { return asImp_().density_(regionIdx, temperature, pressure, XgO); };
+    { return asImp_().density_(regionIdx, temperature, pressure, XgO); }
 
-    virtual Evaluation fugacityCoefficient(int regionIdx,
+    virtual Evaluation fugacityCoefficient(unsigned regionIdx,
                                            const Evaluation& temperature,
                                            const Evaluation& pressure,
-                                           int compIdx) const OPM_FINAL
-    { return asImp_().fugacityCoefficient_(regionIdx, temperature, pressure, compIdx); };
-    virtual Scalar fugacityCoefficient(int regionIdx,
+                                           unsigned compIdx) const OPM_FINAL
+    { return asImp_().fugacityCoefficient_(regionIdx, temperature, pressure, compIdx); }
+    virtual Scalar fugacityCoefficient(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure,
-                                       int compIdx) const OPM_FINAL
-    { return asImp_().fugacityCoefficient_(regionIdx, temperature, pressure, compIdx); };
+                                       unsigned compIdx) const OPM_FINAL
+    { return asImp_().fugacityCoefficient_(regionIdx, temperature, pressure, compIdx); }
 
-    virtual Evaluation oilVaporizationFactor(int regionIdx,
+    virtual Evaluation oilVaporizationFactor(unsigned regionIdx,
                                              const Evaluation& temperature,
                                              const Evaluation& pressure) const OPM_FINAL
-    { return asImp_().oilVaporizationFactor_(regionIdx, temperature, pressure); };
-    virtual Scalar oilVaporizationFactor(int regionIdx,
+    { return asImp_().oilVaporizationFactor_(regionIdx, temperature, pressure); }
+    virtual Scalar oilVaporizationFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure) const OPM_FINAL
-    { return asImp_().oilVaporizationFactor_(regionIdx, temperature, pressure); };
+    { return asImp_().oilVaporizationFactor_(regionIdx, temperature, pressure); }
 
-    virtual Evaluation gasSaturationPressure(int regionIdx,
+    virtual Evaluation gasSaturationPressure(unsigned regionIdx,
                                              const Evaluation& temperature,
                                              const Evaluation& XgO) const OPM_FINAL
-    { return asImp_().gasSaturationPressure_(regionIdx, temperature, XgO); };
-    virtual Scalar gasSaturationPressure(int regionIdx,
+    { return asImp_().gasSaturationPressure_(regionIdx, temperature, XgO); }
+    virtual Scalar gasSaturationPressure(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar XgO) const OPM_FINAL
-    { return asImp_().gasSaturationPressure_(regionIdx, temperature, XgO); };
+    { return asImp_().gasSaturationPressure_(regionIdx, temperature, XgO); }
 
-    virtual Evaluation saturatedGasOilMassFraction(int regionIdx,
+    virtual Evaluation saturatedGasOilMassFraction(unsigned regionIdx,
                                                    const Evaluation& temperature,
                                                    const Evaluation& pressure) const OPM_FINAL
-    { return asImp_().saturatedGasOilMassFraction_(regionIdx, temperature, pressure); };
-    virtual Scalar saturatedGasOilMassFraction(int regionIdx,
+    { return asImp_().saturatedGasOilMassFraction_(regionIdx, temperature, pressure); }
+    virtual Scalar saturatedGasOilMassFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const OPM_FINAL
-    { return asImp_().saturatedGasOilMassFraction_(regionIdx, temperature, pressure); };
+    { return asImp_().saturatedGasOilMassFraction_(regionIdx, temperature, pressure); }
 
-    virtual Evaluation saturatedGasOilMoleFraction(int regionIdx,
+    virtual Evaluation saturatedGasOilMoleFraction(unsigned regionIdx,
                                                    const Evaluation& temperature,
                                                    const Evaluation& pressure) const OPM_FINAL
-    { return asImp_().saturatedGasOilMoleFraction_(regionIdx, temperature, pressure); };
-    virtual Scalar saturatedGasOilMoleFraction(int regionIdx,
+    { return asImp_().saturatedGasOilMoleFraction_(regionIdx, temperature, pressure); }
+    virtual Scalar saturatedGasOilMoleFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const OPM_FINAL
-    { return asImp_().saturatedGasOilMoleFraction_(regionIdx, temperature, pressure); };
+    { return asImp_().saturatedGasOilMoleFraction_(regionIdx, temperature, pressure); }
 };
 
 template <class Scalar, class Implementation>
@@ -269,42 +271,42 @@ class GasPvtInterfaceTemplateWrapper<Scalar, Scalar, Implementation>
     { return *static_cast<const Implementation*>(this); }
 
 public:
-    virtual Scalar viscosity(int regionIdx,
+    virtual Scalar viscosity(unsigned regionIdx,
                              Scalar temperature,
                              Scalar pressure,
                              Scalar XgO) const OPM_FINAL
-    { return asImp_().viscosity_(regionIdx, temperature, pressure, XgO); };
-    virtual Scalar formationVolumeFactor(int regionIdx,
+    { return asImp_().viscosity_(regionIdx, temperature, pressure, XgO); }
+    virtual Scalar formationVolumeFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure,
                                          Scalar XgO) const OPM_FINAL
-    { return asImp_().formationVolumeFactor_(regionIdx, temperature, pressure, XgO); };
-    virtual Scalar density(int regionIdx,
+    { return asImp_().formationVolumeFactor_(regionIdx, temperature, pressure, XgO); }
+    virtual Scalar density(unsigned regionIdx,
                            Scalar temperature,
                            Scalar pressure,
                            Scalar XgO) const OPM_FINAL
-    { return asImp_().density_(regionIdx, temperature, pressure, XgO); };
-    virtual Scalar fugacityCoefficient(int regionIdx,
+    { return asImp_().density_(regionIdx, temperature, pressure, XgO); }
+    virtual Scalar fugacityCoefficient(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure,
-                                       int compIdx) const OPM_FINAL
-    { return asImp_().fugacityCoefficient_(regionIdx, temperature, pressure, compIdx); };
-    virtual Scalar oilVaporizationFactor(int regionIdx,
+                                       unsigned compIdx) const OPM_FINAL
+    { return asImp_().fugacityCoefficient_(regionIdx, temperature, pressure, compIdx); }
+    virtual Scalar oilVaporizationFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure) const OPM_FINAL
-    { return asImp_().oilVaporizationFactor_(regionIdx, temperature, pressure); };
-    virtual Scalar gasSaturationPressure(int regionIdx,
+    { return asImp_().oilVaporizationFactor_(regionIdx, temperature, pressure); }
+    virtual Scalar gasSaturationPressure(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar XgO) const OPM_FINAL
-    { return asImp_().gasSaturationPressure_(regionIdx, temperature, XgO); };
-    virtual Scalar saturatedGasOilMassFraction(int regionIdx,
+    { return asImp_().gasSaturationPressure_(regionIdx, temperature, XgO); }
+    virtual Scalar saturatedGasOilMassFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const OPM_FINAL
-    { return asImp_().saturatedGasOilMassFraction_(regionIdx, temperature, pressure); };
-    virtual Scalar saturatedGasOilMoleFraction(int regionIdx,
+    { return asImp_().saturatedGasOilMassFraction_(regionIdx, temperature, pressure); }
+    virtual Scalar saturatedGasOilMoleFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const OPM_FINAL
-    { return asImp_().saturatedGasOilMoleFraction_(regionIdx, temperature, pressure); };
+    { return asImp_().saturatedGasOilMoleFraction_(regionIdx, temperature, pressure); }
 };
 
 } // namespace Opm

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtInterface.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtInterface.hpp
@@ -44,14 +44,16 @@ template <class Scalar, class Evaluation = Scalar>
 class OilPvtInterface
 {
 public:
+    virtual ~OilPvtInterface() {}
+
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
-    virtual Evaluation viscosity(int regionIdx,
+    virtual Evaluation viscosity(unsigned regionIdx,
                                  const Evaluation& temperature,
                                  const Evaluation& pressure,
                                  const Evaluation& XoG) const = 0;
-    virtual Scalar viscosity(int regionIdx,
+    virtual Scalar viscosity(unsigned regionIdx,
                              Scalar temperature,
                              Scalar pressure,
                              Scalar XoG) const = 0;
@@ -59,11 +61,11 @@ public:
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */
-    virtual Evaluation formationVolumeFactor(int regionIdx,
+    virtual Evaluation formationVolumeFactor(unsigned regionIdx,
                                              const Evaluation& temperature,
                                              const Evaluation& pressure,
                                              const Evaluation& XoG) const = 0;
-    virtual Scalar formationVolumeFactor(int regionIdx,
+    virtual Scalar formationVolumeFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure,
                                          Scalar XoG) const = 0;
@@ -71,11 +73,11 @@ public:
     /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
      */
-    virtual Evaluation density(int regionIdx,
+    virtual Evaluation density(unsigned regionIdx,
                                const Evaluation& temperature,
                                const Evaluation& pressure,
                                const Evaluation& XoG) const = 0;
-    virtual Scalar density(int regionIdx,
+    virtual Scalar density(unsigned regionIdx,
                            Scalar temperature,
                            Scalar pressure,
                            Scalar XoG) const = 0;
@@ -84,22 +86,22 @@ public:
      * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
      *        a set of parameters.
      */
-    virtual Evaluation fugacityCoefficient(int regionIdx,
+    virtual Evaluation fugacityCoefficient(unsigned regionIdx,
                                            const Evaluation& temperature,
                                            const Evaluation& pressure,
-                                           int compIdx) const = 0;
-    virtual Scalar fugacityCoefficient(int regionIdx,
+                                           unsigned compIdx) const = 0;
+    virtual Scalar fugacityCoefficient(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure,
-                                       int compIdx) const = 0;
+                                       unsigned compIdx) const = 0;
 
     /*!
      * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of saturated oil.
      */
-    virtual Evaluation gasDissolutionFactor(int regionIdx,
+    virtual Evaluation gasDissolutionFactor(unsigned regionIdx,
                                             const Evaluation& temperature,
                                             const Evaluation& pressure) const = 0;
-    virtual Scalar gasDissolutionFactor(int regionIdx,
+    virtual Scalar gasDissolutionFactor(unsigned regionIdx,
                                         Scalar temperature,
                                         Scalar pressure) const = 0;
 
@@ -110,10 +112,10 @@ public:
      * Calling this method only makes sense for live oil. All other implementations of
      * the black-oil PVT interface will just throw an exception...
      */
-    virtual Evaluation oilSaturationPressure(int regionIdx,
+    virtual Evaluation oilSaturationPressure(unsigned regionIdx,
                                              const Evaluation& temperature,
                                              const Evaluation& XoG) const = 0;
-    virtual Scalar oilSaturationPressure(int regionIdx,
+    virtual Scalar oilSaturationPressure(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar XoG) const = 0;
 
@@ -124,10 +126,10 @@ public:
      * Calling this method only makes sense for oil. For all other phases an exception
      * will be thrown...
      */
-    virtual Evaluation saturatedOilGasMassFraction(int regionIdx,
+    virtual Evaluation saturatedOilGasMassFraction(unsigned regionIdx,
                                                    const Evaluation& temperature,
                                                    const Evaluation& pressure) const = 0;
-    virtual Scalar saturatedOilGasMassFraction(int regionIdx,
+    virtual Scalar saturatedOilGasMassFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const = 0;
 
@@ -138,10 +140,10 @@ public:
      * Calling this method only makes sense for oil. For all other phases an exception
      * will be thrown...
      */
-    virtual Evaluation saturatedOilGasMoleFraction(int regionIdx,
+    virtual Evaluation saturatedOilGasMoleFraction(unsigned regionIdx,
                                                    const Evaluation& temperature,
                                                    const Evaluation& pressure) const = 0;
-    virtual Scalar saturatedOilGasMoleFraction(int regionIdx,
+    virtual Scalar saturatedOilGasMoleFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const = 0;
 };
@@ -155,7 +157,7 @@ public:
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
-    virtual Scalar viscosity(int regionIdx,
+    virtual Scalar viscosity(unsigned regionIdx,
                              Scalar temperature,
                              Scalar pressure,
                              Scalar XoG) const = 0;
@@ -163,7 +165,7 @@ public:
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */
-    virtual Scalar formationVolumeFactor(int regionIdx,
+    virtual Scalar formationVolumeFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure,
                                          Scalar XoG) const = 0;
@@ -171,7 +173,7 @@ public:
     /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
      */
-    virtual Scalar density(int regionIdx,
+    virtual Scalar density(unsigned regionIdx,
                            Scalar temperature,
                            Scalar pressure,
                            Scalar XoG) const = 0;
@@ -180,15 +182,15 @@ public:
      * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
      *        a set of parameters.
      */
-    virtual Scalar fugacityCoefficient(int regionIdx,
+    virtual Scalar fugacityCoefficient(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure,
-                                       int compIdx) const = 0;
+                                       unsigned compIdx) const = 0;
 
     /*!
      * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of saturated oil.
      */
-    virtual Scalar gasDissolutionFactor(int regionIdx,
+    virtual Scalar gasDissolutionFactor(unsigned regionIdx,
                                         Scalar temperature,
                                         Scalar pressure) const = 0;
 
@@ -199,7 +201,7 @@ public:
      * Calling this method only makes sense for live oil. All other implementations of
      * the black-oil PVT interface will just throw an exception...
      */
-    virtual Scalar oilSaturationPressure(int regionIdx,
+    virtual Scalar oilSaturationPressure(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar XoG) const = 0;
 
@@ -210,7 +212,7 @@ public:
      * Calling this method only makes sense for oil. For all other phases an exception
      * will be thrown...
      */
-    virtual Scalar saturatedOilGasMassFraction(int regionIdx,
+    virtual Scalar saturatedOilGasMassFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const = 0;
 
@@ -221,7 +223,7 @@ public:
      * Calling this method only makes sense for oil. For all other phases an exception
      * will be thrown...
      */
-    virtual Scalar saturatedOilGasMoleFraction(int regionIdx,
+    virtual Scalar saturatedOilGasMoleFraction(unsigned regionIdx,
                                                Scalar temperature,
                                                Scalar pressure) const = 0;
 };
@@ -232,82 +234,82 @@ template <class Scalar, class Evaluation, class Implementation>
 class OilPvtInterfaceTemplateWrapper
     : public OilPvtInterface<Scalar, Evaluation>
 {
-    Evaluation viscosity(int regionIdx,
+    Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& temperature,
                          const Evaluation& pressure,
                          const Evaluation& XoG) const OPM_FINAL
     { return asImp_().template viscosity_<Evaluation>(regionIdx, temperature, pressure, XoG); }
-    Scalar viscosity(int regionIdx,
+    Scalar viscosity(unsigned regionIdx,
                      Scalar temperature,
                      Scalar pressure,
                      Scalar XoG) const OPM_FINAL
     { return asImp_().template viscosity_<Scalar>(regionIdx, temperature, pressure, XoG); }
 
-    Evaluation formationVolumeFactor(int regionIdx,
+    Evaluation formationVolumeFactor(unsigned regionIdx,
                                      const Evaluation& temperature,
                                      const Evaluation& pressure,
                                      const Evaluation& XoG) const OPM_FINAL
     { return asImp_().template formationVolumeFactor_<Evaluation>(regionIdx, temperature, pressure, XoG); }
-    Scalar formationVolumeFactor(int regionIdx,
+    Scalar formationVolumeFactor(unsigned regionIdx,
                                  Scalar temperature,
                                  Scalar pressure,
                                  Scalar XoG) const OPM_FINAL
     { return asImp_().template formationVolumeFactor_<Scalar>(regionIdx, temperature, pressure, XoG); }
 
-    Evaluation density(int regionIdx,
+    Evaluation density(unsigned regionIdx,
                        const Evaluation& temperature,
                        const Evaluation& pressure,
                        const Evaluation& XoG) const OPM_FINAL
     { return asImp_().template density_<Evaluation>(regionIdx, temperature, pressure, XoG); }
-    Scalar density(int regionIdx,
+    Scalar density(unsigned regionIdx,
                    Scalar temperature,
                    Scalar pressure,
                    Scalar XoG) const OPM_FINAL
     { return asImp_().template density_<Scalar>(regionIdx, temperature, pressure, XoG); }
 
-    Evaluation fugacityCoefficient(int regionIdx,
+    Evaluation fugacityCoefficient(unsigned regionIdx,
                                    const Evaluation& temperature,
                                    const Evaluation& pressure,
-                                   int compIdx) const OPM_FINAL
+                                   unsigned compIdx) const OPM_FINAL
     { return asImp_().template fugacityCoefficient_<Evaluation>(regionIdx, temperature, pressure, compIdx); }
-    Scalar fugacityCoefficient(int regionIdx,
+    Scalar fugacityCoefficient(unsigned regionIdx,
                                Scalar temperature,
                                Scalar pressure,
-                               int compIdx) const OPM_FINAL
+                               unsigned compIdx) const OPM_FINAL
     { return asImp_().template fugacityCoefficient_<Scalar>(regionIdx, temperature, pressure, compIdx); }
 
-    Evaluation gasDissolutionFactor(int regionIdx,
+    Evaluation gasDissolutionFactor(unsigned regionIdx,
                                     const Evaluation& temperature,
                                     const Evaluation& pressure) const OPM_FINAL
     { return asImp_().template gasDissolutionFactor_<Evaluation>(regionIdx, temperature, pressure); }
-    Scalar gasDissolutionFactor(int regionIdx,
+    Scalar gasDissolutionFactor(unsigned regionIdx,
                                 Scalar temperature,
                                 Scalar pressure) const OPM_FINAL
     { return asImp_().template gasDissolutionFactor_<Scalar>(regionIdx, temperature, pressure); }
 
-    Evaluation oilSaturationPressure(int regionIdx,
+    Evaluation oilSaturationPressure(unsigned regionIdx,
                                      const Evaluation& temperature,
                                      const Evaluation& XoG) const OPM_FINAL
     { return asImp_().template oilSaturationPressure_<Evaluation>(regionIdx, temperature, XoG); }
-    Scalar oilSaturationPressure(int regionIdx,
+    Scalar oilSaturationPressure(unsigned regionIdx,
                                  Scalar temperature,
                                  Scalar XoG) const OPM_FINAL
     { return asImp_().template oilSaturationPressure_<Scalar>(regionIdx, temperature, XoG); }
 
-    Evaluation saturatedOilGasMassFraction(int regionIdx,
+    Evaluation saturatedOilGasMassFraction(unsigned regionIdx,
                                            const Evaluation& temperature,
                                            const Evaluation& pressure) const OPM_FINAL
     { return asImp_().template saturatedOilGasMassFraction_<Evaluation>(regionIdx, temperature, pressure); }
-    Scalar saturatedOilGasMassFraction(int regionIdx,
+    Scalar saturatedOilGasMassFraction(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure) const OPM_FINAL
     { return asImp_().template saturatedOilGasMassFraction_<Scalar>(regionIdx, temperature, pressure); }
 
-    Evaluation saturatedOilGasMoleFraction(int regionIdx,
+    Evaluation saturatedOilGasMoleFraction(unsigned regionIdx,
                                            const Evaluation& temperature,
                                            const Evaluation& pressure) const OPM_FINAL
     { return asImp_().template saturatedOilGasMoleFraction_<Evaluation>(regionIdx, temperature, pressure); }
-    Scalar saturatedOilGasMoleFraction(int regionIdx,
+    Scalar saturatedOilGasMoleFraction(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure) const OPM_FINAL
     { return asImp_().template saturatedOilGasMoleFraction_<Scalar>(regionIdx, temperature, pressure); }
@@ -321,39 +323,39 @@ template <class Scalar, class Implementation>
 class OilPvtInterfaceTemplateWrapper<Scalar, Scalar, Implementation>
     : public OilPvtInterface<Scalar, Scalar>
 {
-    Scalar viscosity(int regionIdx,
+    Scalar viscosity(unsigned regionIdx,
                      Scalar temperature,
                      Scalar pressure,
                      Scalar XoG) const OPM_FINAL
     { return asImp_().template viscosity_<Scalar>(regionIdx, temperature, pressure, XoG); }
-    Scalar formationVolumeFactor(int regionIdx,
+    Scalar formationVolumeFactor(unsigned regionIdx,
                                  Scalar temperature,
                                  Scalar pressure,
                                  Scalar XoG) const OPM_FINAL
     { return asImp_().template formationVolumeFactor_<Scalar>(regionIdx, temperature, pressure, XoG); }
-    Scalar density(int regionIdx,
+    Scalar density(unsigned regionIdx,
                    Scalar temperature,
                    Scalar pressure,
                    Scalar XoG) const OPM_FINAL
     { return asImp_().template density_<Scalar>(regionIdx, temperature, pressure, XoG); }
-    Scalar fugacityCoefficient(int regionIdx,
+    Scalar fugacityCoefficient(unsigned regionIdx,
                                Scalar temperature,
                                Scalar pressure,
-                               int compIdx) const OPM_FINAL
+                               unsigned compIdx) const OPM_FINAL
     { return asImp_().template fugacityCoefficient_<Scalar>(regionIdx, temperature, pressure, compIdx); }
-    Scalar gasDissolutionFactor(int regionIdx,
+    Scalar gasDissolutionFactor(unsigned regionIdx,
                                 Scalar temperature,
                                 Scalar pressure) const OPM_FINAL
     { return asImp_().template gasDissolutionFactor_<Scalar>(regionIdx, temperature, pressure); }
-    Scalar oilSaturationPressure(int regionIdx,
+    Scalar oilSaturationPressure(unsigned regionIdx,
                                  Scalar temperature,
                                  Scalar XoG) const OPM_FINAL
     { return asImp_().template oilSaturationPressure_<Scalar>(regionIdx, temperature, XoG); }
-    Scalar saturatedOilGasMassFraction(int regionIdx,
+    Scalar saturatedOilGasMassFraction(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure) const OPM_FINAL
     { return asImp_().template saturatedOilGasMassFraction_<Scalar>(regionIdx, temperature, pressure); }
-    Scalar saturatedOilGasMoleFraction(int regionIdx,
+    Scalar saturatedOilGasMoleFraction(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure) const OPM_FINAL
     { return asImp_().template saturatedOilGasMoleFraction_<Scalar>(regionIdx, temperature, pressure); }

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtInterface.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtInterface.hpp
@@ -44,33 +44,35 @@ template <class Scalar, class Evaluation = Scalar>
 class WaterPvtInterface
 {
 public:
+    virtual ~WaterPvtInterface() {}
+
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
-    virtual Evaluation viscosity(int regionIdx,
+    virtual Evaluation viscosity(unsigned regionIdx,
                                  const Evaluation& temperature,
                                  const Evaluation& pressure) const = 0;
-    virtual Scalar viscosity(int regionIdx,
+    virtual Scalar viscosity(unsigned regionIdx,
                              Scalar temperature,
                              Scalar pressure) const = 0;
 
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */
-    virtual Evaluation formationVolumeFactor(int regionIdx,
+    virtual Evaluation formationVolumeFactor(unsigned regionIdx,
                                              const Evaluation& temperature,
                                              const Evaluation& pressure) const = 0;
-    virtual Scalar formationVolumeFactor(int regionIdx,
+    virtual Scalar formationVolumeFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure) const = 0;
 
     /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
      */
-    virtual Evaluation density(int regionIdx,
+    virtual Evaluation density(unsigned regionIdx,
                                const Evaluation& temperature,
                                const Evaluation& pressure) const = 0;
-    virtual Scalar density(int regionIdx,
+    virtual Scalar density(unsigned regionIdx,
                            Scalar temperature,
                            Scalar pressure) const = 0;
 
@@ -78,34 +80,34 @@ public:
      * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
      *        a set of parameters.
      */
-    virtual Evaluation fugacityCoefficient(int regionIdx,
+    virtual Evaluation fugacityCoefficient(unsigned regionIdx,
                                            const Evaluation& temperature,
                                            const Evaluation& pressure,
-                                           int compIdx) const = 0;
-    virtual Scalar fugacityCoefficient(int regionIdx,
+                                           unsigned compIdx) const = 0;
+    virtual Scalar fugacityCoefficient(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure,
-                                       int compIdx) const = 0;
+                                       unsigned compIdx) const = 0;
 };
 
 template <class Scalar>
 class WaterPvtInterface<Scalar, Scalar>
 {
 public:
-    virtual Scalar viscosity(int regionIdx,
+    virtual Scalar viscosity(unsigned regionIdx,
                              Scalar temperature,
                              Scalar pressure) const = 0;
 
-    virtual Scalar formationVolumeFactor(int regionIdx,
+    virtual Scalar formationVolumeFactor(unsigned regionIdx,
                                          Scalar temperature,
                                          Scalar pressure) const = 0;
-    virtual Scalar density(int regionIdx,
+    virtual Scalar density(unsigned regionIdx,
                            Scalar temperature,
                            Scalar pressure) const = 0;
-    virtual Scalar fugacityCoefficient(int regionIdx,
+    virtual Scalar fugacityCoefficient(unsigned regionIdx,
                                        Scalar temperature,
                                        Scalar pressure,
-                                       int compIdx) const = 0;
+                                       unsigned compIdx) const = 0;
 };
 
 template <class Scalar, class Evaluation, class Implementation>
@@ -115,42 +117,42 @@ class WaterPvtInterfaceTemplateWrapper : public WaterPvtInterface<Scalar, Evalua
     { return *static_cast<const Implementation*>(this); }
 
 public:
-    Evaluation viscosity(int regionIdx,
+    Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& temperature,
                          const Evaluation& pressure) const OPM_FINAL
     { return asImp_().viscosity_(regionIdx, temperature, pressure); }
-    Scalar viscosity(int regionIdx,
+    Scalar viscosity(unsigned regionIdx,
                      Scalar temperature,
                      Scalar pressure) const OPM_FINAL
     { return asImp_().viscosity_(regionIdx, temperature, pressure); }
 
-    Evaluation formationVolumeFactor(int regionIdx,
+    Evaluation formationVolumeFactor(unsigned regionIdx,
                                      const Evaluation& temperature,
                                      const Evaluation& pressure) const OPM_FINAL
     { return asImp_().formationVolumeFactor_(regionIdx, temperature, pressure); }
-    Scalar formationVolumeFactor(int regionIdx,
+    Scalar formationVolumeFactor(unsigned regionIdx,
                                  Scalar temperature,
                                  Scalar pressure) const OPM_FINAL
     { return asImp_().formationVolumeFactor_(regionIdx, temperature, pressure); }
 
-    Evaluation density(int regionIdx,
+    Evaluation density(unsigned regionIdx,
                        const Evaluation& temperature,
                        const Evaluation& pressure) const OPM_FINAL
     { return asImp_().density_(regionIdx, temperature, pressure); }
-    Scalar density(int regionIdx,
+    Scalar density(unsigned regionIdx,
                    Scalar temperature,
                    Scalar pressure) const OPM_FINAL
     { return asImp_().density_(regionIdx, temperature, pressure); }
 
-    Evaluation fugacityCoefficient(int regionIdx,
+    Evaluation fugacityCoefficient(unsigned regionIdx,
                                    const Evaluation& temperature,
                                    const Evaluation& pressure,
-                                   int compIdx) const OPM_FINAL
+                                   unsigned compIdx) const OPM_FINAL
     { return asImp_().fugacityCoefficient_(regionIdx, temperature, pressure, compIdx); }
-    Scalar fugacityCoefficient(int regionIdx,
+    Scalar fugacityCoefficient(unsigned regionIdx,
                                Scalar temperature,
                                Scalar pressure,
-                               int compIdx) const OPM_FINAL
+                               unsigned compIdx) const OPM_FINAL
     { return asImp_().fugacityCoefficient_(regionIdx, temperature, pressure, compIdx); }
 };
 
@@ -162,25 +164,25 @@ class WaterPvtInterfaceTemplateWrapper<Scalar, Scalar, Implementation>
     { return *static_cast<const Implementation*>(this); }
 
 public:
-    Scalar viscosity(int regionIdx,
+    Scalar viscosity(unsigned regionIdx,
                      Scalar temperature,
                      Scalar pressure) const OPM_FINAL
     { return asImp_().viscosity_(regionIdx, temperature, pressure); }
 
-    Scalar formationVolumeFactor(int regionIdx,
+    Scalar formationVolumeFactor(unsigned regionIdx,
                                  Scalar temperature,
                                  Scalar pressure) const OPM_FINAL
     { return asImp_().formationVolumeFactor_(regionIdx, temperature, pressure); }
 
-    Scalar density(int regionIdx,
+    Scalar density(unsigned regionIdx,
                    Scalar temperature,
                    Scalar pressure) const OPM_FINAL
     { return asImp_().density_(regionIdx, temperature, pressure); }
 
-    Scalar fugacityCoefficient(int regionIdx,
+    Scalar fugacityCoefficient(unsigned regionIdx,
                                Scalar temperature,
                                Scalar pressure,
-                               int compIdx) const OPM_FINAL
+                               unsigned compIdx) const OPM_FINAL
     { return asImp_().fugacityCoefficient_(regionIdx, temperature, pressure, compIdx); }
 };
 

--- a/opm/material/localad/Evaluation.hpp
+++ b/opm/material/localad/Evaluation.hpp
@@ -49,7 +49,7 @@ public:
     enum { size = numVars };
 
     Evaluation()
-    {};
+    {}
 
     // copy other function evaluation
     Evaluation(const Evaluation& other)
@@ -57,7 +57,7 @@ public:
         // copy evaluated function value and derivatives
         value = other.value;
         std::copy(other.derivatives.begin(), other.derivatives.end(), derivatives.begin());
-    };
+    }
 
     // create an evaluation which represents a constant function
     //
@@ -67,10 +67,10 @@ public:
     {
         value = c;
         std::fill(derivatives.begin(), derivatives.end(), 0.0);
-    };
+    }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
-    static Evaluation createVariable(Scalar value, int varPos)
+    static Evaluation createVariable(Scalar value, unsigned varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size);
@@ -111,7 +111,7 @@ public:
     {
         // value and derivatives are added
         this->value += other.value;
-        for (int varIdx= 0; varIdx < size; ++varIdx)
+        for (unsigned varIdx = 0; varIdx < size; ++varIdx)
             this->derivatives[varIdx] += other.derivatives[varIdx];
 
         return *this;
@@ -129,7 +129,7 @@ public:
     {
         // value and derivatives are subtracted
         this->value -= other.value;
-        for (int varIdx= 0; varIdx < size; ++varIdx)
+        for (unsigned varIdx = 0; varIdx < size; ++varIdx)
             this->derivatives[varIdx] -= other.derivatives[varIdx];
 
         return *this;
@@ -150,7 +150,7 @@ public:
         Scalar u = this->value;
         Scalar v = other.value;
         this->value *= v;
-        for (int varIdx= 0; varIdx < size; ++varIdx) {
+        for (unsigned varIdx = 0; varIdx < size; ++varIdx) {
             Scalar uPrime = this->derivatives[varIdx];
             Scalar vPrime = other.derivatives[varIdx];
 
@@ -164,7 +164,7 @@ public:
     {
         // values and derivatives are multiplied
         this->value *= other;
-        for (int varIdx= 0; varIdx < size; ++varIdx)
+        for (unsigned varIdx = 0; varIdx < size; ++varIdx)
             this->derivatives[varIdx] *= other;
 
         return *this;
@@ -177,7 +177,7 @@ public:
         Scalar u = this->value;
         Scalar v = other.value;
         this->value /= v;
-        for (int varIdx= 0; varIdx < size; ++varIdx) {
+        for (unsigned varIdx = 0; varIdx < size; ++varIdx) {
             Scalar uPrime = this->derivatives[varIdx];
             Scalar vPrime = other.derivatives[varIdx];
 
@@ -192,7 +192,7 @@ public:
         // values and derivatives are divided
         other = 1.0/other;
         this->value *= other;
-        for (int varIdx= 0; varIdx < size; ++varIdx)
+        for (unsigned varIdx = 0; varIdx < size; ++varIdx)
             this->derivatives[varIdx] *= other;
 
         return *this;
@@ -231,7 +231,7 @@ public:
     {
         Evaluation result;
         result.value = -this->value;
-        for (int varIdx= 0; varIdx < size; ++varIdx)
+        for (unsigned varIdx = 0; varIdx < size; ++varIdx)
             result.derivatives[varIdx] = - this->derivatives[varIdx];
 
         return result;
@@ -288,7 +288,7 @@ public:
         if (this->value != other.value)
             return false;
 
-        for (int varIdx= 0; varIdx < size; ++varIdx)
+        for (unsigned varIdx = 0; varIdx < size; ++varIdx)
             if (this->derivatives[varIdx] != other.derivatives[varIdx])
                 return false;
 
@@ -301,7 +301,7 @@ public:
         if (std::abs(value_diff) > tolerance && std::abs(value_diff)/tolerance > 1.0)
             return false;
 
-        for (int varIdx= 0; varIdx < size; ++varIdx) {
+        for (unsigned varIdx = 0; varIdx < size; ++varIdx) {
             Scalar deriv_diff = other.derivatives[varIdx] - this->derivatives[varIdx];
             if (std::abs(deriv_diff) > tolerance && std::abs(deriv_diff)/tolerance > 1.0)
                 return false;
@@ -378,7 +378,7 @@ Evaluation<Scalar, VarSetTag, numVars> operator-(const ScalarA& a, const Evaluat
     Evaluation<Scalar, VarSetTag, numVars> result;
 
     result.value = a - b.value;
-    for (int varIdx= 0; varIdx < numVars; ++varIdx)
+    for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
         result.derivatives[varIdx] = - b.derivatives[varIdx];
 
     return result;
@@ -393,7 +393,7 @@ Evaluation<Scalar, VarSetTag, numVars> operator/(const ScalarA& a, const Evaluat
 
     // outer derivative
     Scalar df_dg = - a/(b.value*b.value);
-    for (int varIdx= 0; varIdx < numVars; ++varIdx)
+    for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
         result.derivatives[varIdx] = df_dg*b.derivatives[varIdx];
 
     return result;
@@ -405,7 +405,7 @@ Evaluation<Scalar, VarSetTag, numVars> operator*(const ScalarA& a, const Evaluat
     Evaluation<Scalar, VarSetTag, numVars> result;
 
     result.value = a*b.value;
-    for (int varIdx= 0; varIdx < numVars; ++varIdx)
+    for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
         result.derivatives[varIdx] = a*b.derivatives[varIdx];
 
     return result;

--- a/tests/checkFluidSystem.hpp
+++ b/tests/checkFluidSystem.hpp
@@ -92,114 +92,114 @@ public:
     void restrictToPhase(int phaseIdx)
     { restrictPhaseIdx_ = phaseIdx; }
 
-    Scalar temperature(int phaseIdx) const
+    Scalar temperature(unsigned phaseIdx) const
     {
         assert(allowTemperature_);
-        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == phaseIdx);
+        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
         OPM_UNUSED Scalar tmp = BaseFluidState::temperature(phaseIdx);
         return 1e100;
     }
 
-    Scalar pressure(int phaseIdx) const
+    Scalar pressure(unsigned phaseIdx) const
     {
         assert(allowPressure_);
-        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == phaseIdx);
+        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
         OPM_UNUSED Scalar tmp = BaseFluidState::pressure(phaseIdx);
         return 1e100;
     }
 
-    Scalar moleFraction(int phaseIdx, int compIdx) const
+    Scalar moleFraction(unsigned phaseIdx, unsigned compIdx) const
     {
         assert(allowComposition_);
-        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == phaseIdx);
+        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
         OPM_UNUSED Scalar tmp = BaseFluidState::moleFraction(phaseIdx, compIdx);
         return 1e100;
     }
 
-    Scalar massFraction(int phaseIdx, int compIdx) const
+    Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
     {
         assert(allowComposition_);
-        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == phaseIdx);
+        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
         OPM_UNUSED Scalar tmp = BaseFluidState::massFraction(phaseIdx, compIdx);
         return 1e100;
     }
 
-    Scalar averageMolarMass(int phaseIdx) const
+    Scalar averageMolarMass(unsigned phaseIdx) const
     {
         assert(allowComposition_);
-        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == phaseIdx);
+        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
         OPM_UNUSED Scalar tmp = BaseFluidState::averageMolarMass(phaseIdx);
         return 1e100;
     }
 
-    Scalar molarity(int phaseIdx, int compIdx) const
+    Scalar molarity(unsigned phaseIdx, unsigned compIdx) const
     {
         assert(allowDensity_ && allowComposition_);
-        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == phaseIdx);
+        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
         OPM_UNUSED Scalar tmp = BaseFluidState::molarity(phaseIdx, compIdx);
         return 1e100;
     }
 
-    Scalar molarDensity(int phaseIdx) const
+    Scalar molarDensity(unsigned phaseIdx) const
     {
         assert(allowDensity_);
-        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == phaseIdx);
+        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
         OPM_UNUSED Scalar tmp = BaseFluidState::molarDensity(phaseIdx);
         return 1e100;
     }
 
-    Scalar molarVolume(int phaseIdx) const
+    Scalar molarVolume(unsigned phaseIdx) const
     {
         assert(allowDensity_);
-        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == phaseIdx);
+        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
         OPM_UNUSED Scalar tmp = BaseFluidState::molarVolume(phaseIdx);
         return 1e100;
     }
 
-    Scalar density(int phaseIdx) const
+    Scalar density(unsigned phaseIdx) const
     {
         assert(allowDensity_);
-        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == phaseIdx);
+        assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
         OPM_UNUSED Scalar tmp = BaseFluidState::density(phaseIdx);
         return 1e100;
     }
 
-    Scalar saturation(int phaseIdx) const
+    Scalar saturation(unsigned phaseIdx) const
     {
         assert(false);
         OPM_UNUSED Scalar tmp =  BaseFluidState::saturation(phaseIdx);
         return 1e100;
     }
 
-    Scalar fugacity(int phaseIdx, int compIdx) const
+    Scalar fugacity(unsigned phaseIdx, unsigned compIdx) const
     {
         assert(false);
         OPM_UNUSED Scalar tmp = BaseFluidState::fugacity(phaseIdx, compIdx);
         return 1e100;
     }
 
-    Scalar fugacityCoefficient(int phaseIdx, int compIdx) const
+    Scalar fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
     {
         assert(false);
         OPM_UNUSED Scalar tmp = BaseFluidState::fugacityCoefficient(phaseIdx, compIdx);
         return 1e100;
     }
 
-    Scalar enthalpy(int phaseIdx) const
+    Scalar enthalpy(unsigned phaseIdx) const
     {
         assert(false);
         OPM_UNUSED Scalar tmp = BaseFluidState::enthalpy(phaseIdx);
         return 1e100;
     }
 
-    Scalar internalEnergy(int phaseIdx) const
+    Scalar internalEnergy(unsigned phaseIdx) const
     {
         assert(false);
         OPM_UNUSED Scalar tmp = BaseFluidState::internalEnergy(phaseIdx);
         return 1e100;
     }
 
-    Scalar viscosity(int phaseIdx) const
+    Scalar viscosity(unsigned phaseIdx) const
     {
         assert(false);
         OPM_UNUSED Scalar tmp = BaseFluidState::viscosity(phaseIdx);
@@ -280,8 +280,8 @@ void checkFluidSystem()
     try { paramCache.updateAll(fs, /*except=*/PC::Temperature | PC::Pressure | PC::Composition); } catch (...) {};
     try { paramCache.updateAllPressures(fs); } catch (...) {};
 
-    for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-        fs.restrictToPhase(phaseIdx);
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        fs.restrictToPhase(static_cast<int>(phaseIdx));
         try { paramCache.updatePhase(fs, phaseIdx); } catch (...) {};
         try { paramCache.updatePhase(fs, phaseIdx, /*except=*/PC::None); } catch (...) {};
         try { paramCache.updatePhase(fs, phaseIdx, /*except=*/PC::Temperature | PC::Pressure | PC::Composition); } catch (...) {};
@@ -298,8 +298,8 @@ void checkFluidSystem()
 
     // actually check the fluid system API
     try { FluidSystem::init(); } catch (...) {};
-    for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
-        fs.restrictToPhase(phaseIdx);
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+        fs.restrictToPhase(static_cast<int>(phaseIdx));
         fs.allowPressure(FluidSystem::isCompressible(phaseIdx));
         fs.allowComposition(true);
         fs.allowDensity(false);
@@ -322,7 +322,7 @@ void checkFluidSystem()
         try { scalarVal = FluidSystem::template heatCapacity<FluidState, Scalar>(fs, paramCache, phaseIdx); } catch (...) {};
         try { scalarVal = FluidSystem::template thermalConductivity<FluidState, Scalar>(fs, paramCache, phaseIdx); } catch (...) {};
 
-        for (int compIdx = 0; compIdx < numComponents; ++ compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
             fs.allowComposition(!FluidSystem::isIdealMixture(phaseIdx));
             try { auto OPM_UNUSED tmpVal = FluidSystem::fugacityCoefficient(fs, paramCache, phaseIdx, compIdx); static_assert(std::is_same<decltype(tmpVal), RhsEval>::value, "The default return value must be the scalar used by the fluid state!"); } catch (...) {};
             try { val = FluidSystem::template fugacityCoefficient<FluidState, LhsEval>(fs, paramCache, phaseIdx, compIdx); } catch (...) {};
@@ -335,14 +335,14 @@ void checkFluidSystem()
     }
 
     // test for phaseName(), isLiquid() and isIdealGas()
-    for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
         std::string OPM_UNUSED name = FluidSystem::phaseName(phaseIdx);
         bool OPM_UNUSED bVal = FluidSystem::isLiquid(phaseIdx);
         bVal = FluidSystem::isIdealGas(phaseIdx);
     }
 
     // test for molarMass() and componentName()
-    for (int compIdx = 0; compIdx < numComponents; ++ compIdx) {
+    for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
         val = FluidSystem::molarMass(compIdx);
         std::string OPM_UNUSED name = FluidSystem::componentName(compIdx);
     }

--- a/tests/test_2dtables.cpp
+++ b/tests/test_2dtables.cpp
@@ -36,6 +36,11 @@
 
 typedef double Scalar;
 
+// prototypes
+Scalar testFn1(Scalar x, Scalar y);
+Scalar testFn2(Scalar x, Scalar y);
+Scalar testFn3(Scalar x, Scalar y);
+
 Scalar testFn1(Scalar x, Scalar /* y */)
 { return x; }
 
@@ -51,18 +56,18 @@ createUniformTabulatedFunction(Fn &f)
 {
     Scalar xMin = -2.0;
     Scalar xMax = 3.0;
-    Scalar m = 50;
+    unsigned m = 50;
 
     Scalar yMin = -1/2.0;
     Scalar yMax = 1/3.0;
-    Scalar n = 40;
+    unsigned n = 40;
 
     auto tab = std::make_shared<Opm::UniformTabulated2DFunction<Scalar>>(
         xMin, xMax, m,
         yMin, yMax, n);
-    for (int i = 0; i < m; ++i) {
+    for (unsigned i = 0; i < m; ++i) {
         Scalar x = xMin + Scalar(i)/(m - 1) * (xMax - xMin);
-        for (int j = 0; j < n; ++j) {
+        for (unsigned j = 0; j < n; ++j) {
             Scalar y = yMin + Scalar(j)/(n - 1) * (yMax - yMin);
             tab->setSamplePoint(i, j, f(x, y));
         }
@@ -77,17 +82,17 @@ createUniformXTabulatedFunction(Fn &f)
 {
     Scalar xMin = -2.0;
     Scalar xMax = 3.0;
-    Scalar m = 50;
+    unsigned m = 50;
 
     Scalar yMin = -1/2.0;
     Scalar yMax = 1/3.0;
-    Scalar n = 40;
+    unsigned n = 40;
 
     auto tab = std::make_shared<Opm::UniformXTabulated2DFunction<Scalar>>();
-    for (int i = 0; i < m; ++i) {
+    for (unsigned i = 0; i < m; ++i) {
         Scalar x = xMin + Scalar(i)/(m - 1) * (xMax - xMin);
         tab->appendXPos(x);
-        for (int j = 0; j < n; ++j) {
+        for (unsigned j = 0; j < n; ++j) {
             Scalar y = yMin + Scalar(j)/(n -1) * (yMax - yMin);
             tab->appendSamplePoint(i, y, f(x, y));
         }
@@ -107,7 +112,7 @@ createUniformXTabulatedFunction2(Fn &f)
 
 
     auto tab = std::make_shared<Opm::UniformXTabulated2DFunction<Scalar>>();
-    for (int i = 0; i < m; ++i) {
+    for (unsigned i = 0; i < m; ++i) {
         Scalar x = xMin + Scalar(i)/(m - 1) * (xMax - xMin);
         tab->appendXPos(x);
 
@@ -115,7 +120,7 @@ createUniformXTabulatedFunction2(Fn &f)
         Scalar yMin = - (x + 1);
         Scalar yMax = (x + 1);
 
-        for (int j = 0; j < n; ++j) {
+        for (unsigned j = 0; j < n; ++j) {
             Scalar y = yMin + Scalar(j)/(n -1) * (yMax - yMin);
             tab->appendSamplePoint(i, y, f(x, y));
         }
@@ -128,21 +133,21 @@ template <class Fn, class Table>
 bool compareTableWithAnalyticFn(const Table &table,
                                 Scalar xMin,
                                 Scalar xMax,
-                                int numX,
+                                unsigned numX,
 
                                 Scalar yMin,
                                 Scalar yMax,
-                                int numY,
+                                unsigned numY,
 
                                 Fn &f,
                                 Scalar tolerance = 1e-8)
 {
     // make sure that the tabulated function evaluates to the same thing as the analytic
     // one (modulo tolerance)
-    for (int i = 1; i <= numX; ++i) {
+    for (unsigned i = 1; i <= numX; ++i) {
         Scalar x = xMin + Scalar(i)/numX*(xMax - xMin);
 
-        for (int j = 0; j < numY; ++j) {
+        for (unsigned j = 0; j < numY; ++j) {
             Scalar y = yMin + Scalar(j)/numY*(yMax - yMin);
             if (std::abs(table->eval(x, y) - f(x, y)) > tolerance) {
                 std::cerr << __FILE__ << ":" << __LINE__ << ": table->eval("<<x<<","<<y<<") != f("<<x<<","<<y<<"): " << table->eval(x,y) << " != " << f(x,y) << "\n";
@@ -174,7 +179,7 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    for (int i = 0; i < uTable->numX(); ++i) {
+    for (unsigned i = 0; i < uTable->numX(); ++i) {
         if (std::abs(uTable->yMin() - uXTable->yMin(i)) > 1e-8) {
             std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->yMin() != uXTable->yMin("<<i<<"): " << uTable->yMin() << " != " << uXTable->yMin(i) << "\n";
             return false;
@@ -192,13 +197,13 @@ bool compareTables(const UniformTablePtr uTable,
     }
 
     // make sure that the x and y values are identical
-    for (int i = 0; i < uTable->numX(); ++i) {
+    for (unsigned i = 0; i < uTable->numX(); ++i) {
         if (std::abs(uTable->iToX(i) - uXTable->iToX(i)) > 1e-8) {
             std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->iToX("<<i<<") != uXTable->iToX("<<i<<"): " << uTable->iToX(i) << " != " << uXTable->iToX(i) << "\n";
             return false;
         }
 
-        for (int j = 0; j < uTable->numY(); ++j) {
+        for (unsigned j = 0; j < uTable->numY(); ++j) {
             if (std::abs(uTable->jToY(j) - uXTable->jToY(i, j)) > 1e-8) {
                 std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->jToY("<<j<<") != uXTable->jToY("<<i<<","<<j<<"): " << uTable->jToY(i) << " != " << uXTable->jToY(i, j) << "\n";
                 return false;
@@ -303,8 +308,8 @@ bool compareTables(const UniformTablePtr uTable,
 
     // make sure that the function values at the sampling points are identical and that
     // they correspond to the analytic function
-    int m2 = uTable->numX()*5;
-    int n2 = uTable->numY()*5;
+    unsigned m2 = uTable->numX()*5;
+    unsigned n2 = uTable->numY()*5;
     if (!compareTableWithAnalyticFn(uTable,
                                     xMin, xMax, m2,
                                     yMin, yMax, n2,

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -58,28 +58,13 @@ namespace ComponentsTest {
 #include <opm/material/components/co2tables.inc>
 }}
 
-// include the MPI header if available
-#if HAVE_MPI
-#include <mpi.h>
-#endif // HAVE_MPI
-
-class MyMpiHelper
-{
-public:
-    MyMpiHelper(int &argc, char **&argv)
-    {
-#if HAVE_MPI
-        MPI_Init(&argc, &argv);
-#endif // HAVE_MPI
-    };
-
-    ~MyMpiHelper()
-    {
-#if HAVE_MPI
-        MPI_Finalize();
-#endif // HAVE_MPI
-    };
-};
+// include dune's MPI helper header
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
 
 template <class Scalar, class Evaluation>
 void testAllComponents()
@@ -109,7 +94,7 @@ int main(int argc, char **argv)
     typedef double Scalar;
     typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
 
-    MyMpiHelper mpiHelper(argc, argv);
+    Dune::MPIHelper::instance(argc, argv);
 
     // ensure that all components are API-compliant
     testAllComponents<Scalar, Scalar>();

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -59,28 +59,13 @@ namespace FluidSystemsTest {
 #include <opm/material/components/co2tables.inc>
 } }
 
-// include the MPI header if available
-#if HAVE_MPI
-#include <mpi.h>
-#endif // HAVE_MPI
-
-class MyMpiHelper
-{
-public:
-    MyMpiHelper(int &argc, char **&argv)
-    {
-#if HAVE_MPI
-        MPI_Init(&argc, &argv);
-#endif // HAVE_MPI
-    };
-
-    ~MyMpiHelper()
-    {
-#if HAVE_MPI
-        MPI_Finalize();
-#endif // HAVE_MPI
-    };
-};
+// include dune's MPI helper header
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
 
 // check the API of all fluid states
 template <class Scalar>
@@ -232,7 +217,7 @@ int main(int argc, char **argv)
     typedef double Scalar;
     typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
 
-    MyMpiHelper mpiHelper(argc, argv);
+    Dune::MPIHelper::instance(argc, argv);
 
     // ensure that all fluid states are API-compliant
     testAllFluidStates<Scalar>();

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -49,7 +49,7 @@ void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
     enum { numPhases = FluidState::numPhases };
     enum { numComponents = FluidState::numComponents };
 
-    for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
         Scalar error;
 
         // check the pressures
@@ -70,7 +70,7 @@ void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
                       << " error=" << error << "\n";
 
         // check the compositions
-        for (int compIdx = 0; compIdx < numComponents; ++ compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
             error = fsRef.moleFraction(phaseIdx, compIdx) - fsFlash.moleFraction(phaseIdx, compIdx);
             if (std::abs(error) > 1e-6)
                 std::cout << "composition error phase " << phaseIdx << ", component " << compIdx << ": "
@@ -92,8 +92,8 @@ void checkImmiscibleFlash(const FluidState &fsRef,
     // calculate the total amount of stuff in the reference fluid
     // phase
     ComponentVector globalMolarities(0.0);
-    for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+    for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             globalMolarities[compIdx] +=
                 fsRef.saturation(phaseIdx)*fsRef.molarity(phaseIdx, compIdx);
         }
@@ -118,12 +118,12 @@ void checkImmiscibleFlash(const FluidState &fsRef,
 template <class Scalar, class FluidSystem, class MaterialLaw, class FluidState>
 void completeReferenceFluidState(FluidState &fs,
                                  typename MaterialLaw::Params &matParams,
-                                 int refPhaseIdx)
+                                 unsigned refPhaseIdx)
 {
     enum { numPhases = FluidSystem::numPhases };
     typedef Dune::FieldVector<Scalar, numPhases> PhaseVector;
 
-    int otherPhaseIdx = 1 - refPhaseIdx;
+    unsigned otherPhaseIdx = 1 - refPhaseIdx;
 
     // calculate the other saturation
     fs.setSaturation(otherPhaseIdx, 1.0 - fs.saturation(refPhaseIdx));
@@ -138,7 +138,7 @@ void completeReferenceFluidState(FluidState &fs,
     // set all phase densities
     typename FluidSystem::ParameterCache paramCache;
     paramCache.updateAll(fs);
-    for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
         Scalar rho = FluidSystem::density(fs, paramCache, phaseIdx);
         fs.setDensity(phaseIdx, rho);
     }
@@ -169,11 +169,11 @@ int main()
     // initialize the tables of the fluid system
     Scalar Tmin = T - 1.0;
     Scalar Tmax = T + 1.0;
-    int nT = 3;
+    unsigned nT = 3;
 
     Scalar pmin = 0.0;
     Scalar pmax = 1.25 * 2e6;
-    int np = 100;
+    unsigned np = 100;
 
     FluidSystem::init(Tmin, Tmax, nT, pmin, pmax, np);
 

--- a/tests/test_localad.cpp
+++ b/tests/test_localad.cpp
@@ -25,6 +25,13 @@
  */
 #include "config.h"
 
+// for testing the "!=" and "==" operators, we need to disable the -Wfloat-equal to
+// prevent clang from producing a warning with -Weverything
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
 #include <iostream>
 #include <array>
 #include <cmath>
@@ -63,57 +70,57 @@ void testOperators()
     // test the non-inplace operators
     {
         Eval a = xEval + yEval;
-        if (a.value != x + y)
+        if (std::abs(a.value - (x + y)) > 1e-10)
             throw std::logic_error("oops: operator+");
 
         Eval b = xEval + c;
-        if (b.value != x + c)
+        if (std::abs(b.value - (x + c)) > 1e-10)
             throw std::logic_error("oops: operator+");
 
         Eval d = xEval + cEval;
-        if (d.value != x + c)
+        if (std::abs(d.value - (x + c)) > 1e-10)
             throw std::logic_error("oops: operator+");
     }
 
     {
         Eval a = xEval - yEval;
-        if (a.value != x - y)
+        if (std::abs(a.value - (x - y)) > 1e-10)
             throw std::logic_error("oops: operator-");
 
         Eval b = xEval - c;
-        if (b.value != x - c)
+        if (std::abs(b.value - (x - c)) > 1e-10)
             throw std::logic_error("oops: operator-");
 
         Eval d = xEval - cEval;
-        if (d.value != x - c)
+        if (std::abs(d.value - (x - c)) > 1e-10)
             throw std::logic_error("oops: operator-");
     }
 
     {
         Eval a = xEval*yEval;
-        if (a.value != x*y)
+        if (std::abs(a.value - (x*y)) > 1e-10)
             throw std::logic_error("oops: operator*");
 
         Eval b = xEval*c;
-        if (b.value != x*c)
+        if (std::abs(b.value - (x*c)) > 1e-10)
             throw std::logic_error("oops: operator*");
 
         Eval d = xEval*cEval;
-        if (d.value != x*c)
+        if (std::abs(d.value - (x*c)) > 1e-10)
             throw std::logic_error("oops: operator*");
     }
 
     {
         Eval a = xEval/yEval;
-        if (a.value != x/y)
+        if (std::abs(a.value - (x/y)) > 1e-10)
             throw std::logic_error("oops: operator/");
 
         Eval b = xEval/c;
-        if (b.value != x/c)
+        if (std::abs(b.value - (x/c)) > 1e-10)
             throw std::logic_error("oops: operator/");
 
         Eval d = xEval/cEval;
-        if (d.value != x/c)
+        if (std::abs(d.value - (x/c)) > 1e-10)
             throw std::logic_error("oops: operator/");
     }
 
@@ -121,68 +128,68 @@ void testOperators()
     {
         Eval a = xEval;
         a += yEval;
-        if (a.value != x + y)
+        if (std::abs(a.value - (x + y)) > 1e-10)
             throw std::logic_error("oops: operator+");
 
         Eval b = xEval;
         b += c;
-        if (b.value != x + c)
+        if (std::abs(b.value - (x + c)) > 1e-10)
             throw std::logic_error("oops: operator+");
 
         Eval d = xEval;
         d += cEval;
-        if (d.value != x + c)
+        if (std::abs(d.value - (x + c)) > 1e-10)
             throw std::logic_error("oops: operator+");
     }
 
     {
         Eval a = xEval;
         a -= yEval;
-        if (a.value != x - y)
+        if (std::abs(a.value - (x - y)) > 1e-10)
             throw std::logic_error("oops: operator-");
 
         Eval b = xEval;
         b -= c;
-        if (b.value != x - c)
+        if (std::abs(b.value - (x - c)) > 1e-10)
             throw std::logic_error("oops: operator-");
 
         Eval d = xEval;
         d -= cEval;
-        if (d.value != x - c)
+        if (std::abs(d.value - (x - c)) > 1e-10)
             throw std::logic_error("oops: operator-");
     }
 
     {
         Eval a = xEval;
         a *= yEval;
-        if (a.value != x*y)
+        if (std::abs(a.value - (x*y)) > 1e-10)
             throw std::logic_error("oops: operator*");
 
         Eval b = xEval;
         b *= c;
-        if (b.value != x*c)
+        if (std::abs(b.value - (x*c)) > 1e-10)
             throw std::logic_error("oops: operator*");
 
         Eval d = xEval;
         d *= cEval;
-        if (d.value != x*c)
+        if (std::abs(d.value - (x*c)) > 1e-10)
             throw std::logic_error("oops: operator*");
     }
 
     {
         Eval a = xEval;
         a /= yEval;
-        if (a.value != x/y)
+        if (std::abs(a.value - (x/y)) > 1e-10)
             throw std::logic_error("oops: operator/");
 
         Eval b = xEval;
         b /= c;
-        if (b.value != x/c)
+        if (std::abs(b.value - (x/c)) > 1e-10)
             throw std::logic_error("oops: operator/");
 
         Eval d = xEval;
         d /= cEval;
-        if (d.value != x/c)
+        if (std::abs(d.value - (x/c)) > 1e-10)
             throw std::logic_error("oops: operator/");
     }
 
@@ -444,6 +451,10 @@ void testAtan2()
         }
     }
 }
+
+// prototypes
+double myScalarMin(double a, double b);
+double myScalarMax(double a, double b);
 
 double myScalarMin(double a, double b)
 { return std::min(a, b); }

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -49,7 +49,7 @@ void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
     enum { numPhases = FluidState::numPhases };
     enum { numComponents = FluidState::numComponents };
 
-    for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
         Scalar error;
 
         // check the pressures
@@ -70,7 +70,7 @@ void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
                       << " error=" << error << "\n";
 
         // check the compositions
-        for (int compIdx = 0; compIdx < numComponents; ++ compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
             error = fsRef.moleFraction(phaseIdx, compIdx) - fsFlash.moleFraction(phaseIdx, compIdx);
             if (std::abs(error) > 1e-6)
                 std::cout << "composition error phase " << phaseIdx << ", component " << compIdx << ": "
@@ -92,8 +92,8 @@ void checkNcpFlash(const FluidState &fsRef,
     // calculate the total amount of stuff in the reference fluid
     // phase
     ComponentVector globalMolarities(0.0);
-    for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+    for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             globalMolarities[compIdx] +=
                 fsRef.saturation(phaseIdx)*fsRef.molarity(phaseIdx, compIdx);
         }
@@ -118,14 +118,14 @@ void checkNcpFlash(const FluidState &fsRef,
 template <class Scalar, class FluidSystem, class MaterialLaw, class FluidState>
 void completeReferenceFluidState(FluidState &fs,
                                  typename MaterialLaw::Params &matParams,
-                                 int refPhaseIdx)
+                                 unsigned refPhaseIdx)
 {
     enum { numPhases = FluidSystem::numPhases };
 
     typedef Opm::ComputeFromReferencePhase<Scalar, FluidSystem> ComputeFromReferencePhase;
     typedef Dune::FieldVector<Scalar, numPhases> PhaseVector;
 
-    int otherPhaseIdx = 1 - refPhaseIdx;
+    unsigned otherPhaseIdx = 1 - refPhaseIdx;
 
     // calculate the other saturation
     fs.setSaturation(otherPhaseIdx, 1.0 - fs.saturation(refPhaseIdx));
@@ -172,11 +172,11 @@ int main()
     // initialize the tables of the fluid system
     Scalar Tmin = T - 1.0;
     Scalar Tmax = T + 1.0;
-    int nT = 3;
+    unsigned nT = 3;
 
     Scalar pmin = 0.0;
     Scalar pmax = 1.25 * 2e6;
-    int np = 100;
+    unsigned np = 100;
 
     FluidSystem::init(Tmin, Tmax, nT, pmin, pmax, np);
 

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -80,7 +80,7 @@ Scalar computeSumxg(FluidState &resultFluidState,
 
     // add a bit of additional gas components
     ComponentVector totalMolarities;
-    for (int compIdx = 0; compIdx < FluidSystem::numComponents; ++ compIdx)
+    for (unsigned compIdx = 0; compIdx < FluidSystem::numComponents; ++ compIdx)
         totalMolarities =
             prestineFluidState.molarity(oilPhaseIdx, compIdx)
             + additionalGas*gasFluidState.moleFraction(gasPhaseIdx, compIdx);
@@ -90,7 +90,7 @@ Scalar computeSumxg(FluidState &resultFluidState,
     Flash::solve(resultFluidState, totalMolarities);
 
     Scalar sumxg = 0;
-    for (int compIdx = 0; compIdx < FluidSystem::numComponents; ++compIdx)
+    for (unsigned compIdx = 0; compIdx < FluidSystem::numComponents; ++compIdx)
         sumxg += resultFluidState.moleFraction(gasPhaseIdx, compIdx);
 
     return sumxg;
@@ -105,7 +105,7 @@ void makeOilSaturated(FluidState &fluidState, const FluidState &gasFluidState)
     prestineFluidState.assign(fluidState);
 
     Scalar sumxg = 0;
-    for (int compIdx = 0; compIdx < FluidSystem::numComponents; ++compIdx)
+    for (unsigned compIdx = 0; compIdx < FluidSystem::numComponents; ++compIdx)
         sumxg += fluidState.moleFraction(gasPhaseIdx, compIdx);
 
     // Newton method
@@ -132,7 +132,7 @@ void makeOilSaturated(FluidState &fluidState, const FluidState &gasFluidState)
 }
 
 template <class FluidSystem, class FluidState>
-void guessInitial(FluidState &fluidState, int phaseIdx)
+void guessInitial(FluidState &fluidState, unsigned phaseIdx)
 {
     if (phaseIdx == FluidSystem::gasPhaseIdx) {
         fluidState.setMoleFraction(phaseIdx, FluidSystem::H2OIdx, 0.0);
@@ -179,7 +179,7 @@ Scalar bringOilToSurface(FluidState &surfaceFluidState, Scalar alpha, const Flui
 
     // set the parameters for the capillary pressure law
     MaterialLawParams matParams;
-    for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
         matParams.setPcMinSat(phaseIdx, 0.0);
         matParams.setPcMaxSat(phaseIdx, 0.0);
     }
@@ -189,13 +189,13 @@ Scalar bringOilToSurface(FluidState &surfaceFluidState, Scalar alpha, const Flui
     surfaceFluidState.setTemperature(273.15 + 20);
 
     ComponentVector molarities;
-    for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
+    for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx)
         molarities[compIdx] = reservoirFluidState.molarity(oilPhaseIdx, compIdx);
 
     if (guessInitial) {
         // we start at a fluid state with reservoir oil.
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
-            for (int compIdx = 0; compIdx < numComponents; ++ compIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
                 surfaceFluidState.setMoleFraction(phaseIdx,
                                                   compIdx,
                                                   reservoirFluidState.moleFraction(phaseIdx, compIdx));
@@ -285,7 +285,7 @@ void printResult(const RawTable& rawTable,
     std::cout << "};\n";
 }
 
-int main(int argc, char** argv)
+int main(int /*argc*/, char** /*argv*/)
 {
     typedef double Scalar;
     typedef Opm::FluidSystems::Spe5<Scalar> FluidSystem;
@@ -328,7 +328,7 @@ int main(int argc, char** argv)
 
     // set the parameters for the capillary pressure law
     MaterialLawParams matParams;
-    for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
         matParams.setPcMinSat(phaseIdx, 0.0);
         matParams.setPcMaxSat(phaseIdx, 0.0);
     }
@@ -365,7 +365,7 @@ int main(int argc, char** argv)
     //makeOilSaturated<Scalar, FluidSystem>(fluidState, gasFluidState);
 
     // set the saturations and pressures of the other phases
-    for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
         if (phaseIdx != oilPhaseIdx) {
             fluidState.setSaturation(phaseIdx, 0.0);
             fluidState.setPressure(phaseIdx, fluidState.pressure(oilPhaseIdx));
@@ -387,7 +387,7 @@ int main(int argc, char** argv)
     // Calculate the total molarities of the components
     ////////////
     ComponentVector totalMolarities;
-    for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
+    for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx)
         totalMolarities[compIdx] = fluidState.saturation(oilPhaseIdx)*fluidState.molarity(oilPhaseIdx, compIdx);
 
     ////////////

--- a/tests/test_spline.cpp
+++ b/tests/test_spline.cpp
@@ -54,8 +54,8 @@ void testCommon(const Spline &sp,
     static double eps = 1e-10;
     static double epsFD = 1e-7;
 
-    int n = sp.numSamples();
-    for (int i = 0; i < n; ++i) {
+    size_t n = sp.numSamples();
+    for (size_t i = 0; i < n; ++i) {
         // sure that we hit all sampling points
         double y0 = (i>0)?sp.eval(x[i]-eps):y[0];
         double y1 = sp.eval(x[i]);
@@ -80,8 +80,8 @@ void testCommon(const Spline &sp,
     }
 
     // make sure the derivatives are consistent with the curve
-    int np = 3*n;
-    for (int i = 0; i < np; ++i) {
+    size_t np = 3*n;
+    for (size_t i = 0; i < np; ++i) {
         double xval = sp.xMin() + (sp.xMax() - sp.xMin())*i/np;
 
         // first derivative
@@ -133,7 +133,7 @@ void testFull(const Spline &sp,
     testCommon(sp, x, y);
 
     static double eps = 1e-5;
-    int n = sp.numSamples();
+    size_t n = sp.numSamples();
 
     // make sure the derivative at both end points is correct
     double d0 = sp.evalDerivative(x[0]);
@@ -157,7 +157,7 @@ void testNatural(const Spline &sp,
     testCommon(sp, x, y);
 
     static double eps = 1e-5;
-    int n = sp.numSamples();
+    size_t n = sp.numSamples();
 
     // make sure the second derivatives at both end points are 0
     double d0 = sp.evalDerivative(x[0]);
@@ -185,9 +185,9 @@ void testMonotonic(const Spline &sp,
     // test the common properties of splines
     testCommon(sp, x, y);
 
-    int n = sp.numSamples();
+    size_t n = sp.numSamples();
 
-    for (int i = 0; i < n - 1; ++ i) {
+    for (size_t i = 0; i < n - 1; ++ i) {
         // make sure that the spline is monotonic for each interval
         // between sampling points
         if (!sp.monotonic(x[i], x[i + 1]))
@@ -215,7 +215,7 @@ void testMonotonic(const Spline &sp,
         OPM_THROW(std::runtime_error,
                   "Spline says it is not monotonic on right side where it should be");
 
-    for (int i = 0; i < n - 2; ++ i) {
+    for (size_t i = 0; i < n - 2; ++ i) {
         // make sure that the spline says that it is non-monotonic for
         // if extrema are within the queried interval
         if (sp.monotonic((x[i] + x[i + 1])/2, (x[i + 1] + x[i + 2])/2))
@@ -224,6 +224,9 @@ void testMonotonic(const Spline &sp,
                       << i << " where it should not be");
     }
 }
+
+// function prototype to prevent some compilers producing a warning
+void testAll();
 
 void testAll()
 {
@@ -268,7 +271,7 @@ void testAll()
     // full spline
     { Opm::Spline<double> sp(x[0], x[1], y[0], y[1], m0, m1); sp.set(x[0],x[1],y[0],y[1],m0, m1); testFull(sp, x, y, m0, m1); };
     { Opm::Spline<double> sp(2, x, y, m0, m1); sp.setXYArrays(2, x, y, m0, m1); testFull(sp, x, y, m0, m1);  };
-    { Opm::Spline<double> sp(2, points, m0, m1); sp.setArrayOfPoints(2, points, m0, m1); testFull(sp, x, y, m0, m1); };
+    { Opm::Spline<double> sp(static_cast<size_t>(2), points, m0, m1); sp.setArrayOfPoints(2, points, m0, m1); testFull(sp, x, y, m0, m1); };
 
     /////////
     // test variable length splines
@@ -292,6 +295,9 @@ void testAll()
     { Opm::Spline<double> sp; sp.setContainerOfTuples(pointsInitList); testNatural(sp, x, y); };
 #endif
 }
+
+// function prototype to prevent some compilers producing a warning
+void plot();
 
 void plot()
 {

--- a/tests/test_tabulation.cpp
+++ b/tests/test_tabulation.cpp
@@ -32,6 +32,7 @@
 #include <opm/material/components/H2O.hpp>
 #include <opm/material/components/TabulatedComponent.hpp>
 
+extern bool success;
 bool success;
 
 template <class Scalar>
@@ -52,11 +53,11 @@ int main()
 
     Scalar tempMin = 274.15;
     Scalar tempMax = 622.15;
-    int nTemp = static_cast<int>(tempMax - tempMin) * 6/8;
+    unsigned nTemp = static_cast<unsigned>(tempMax - tempMin) * 6/8;
 
     Scalar pMin = 10.00;
     Scalar pMax = IapwsH2O::vaporPressure(tempMax*1.1);
-    int nPress = 200;
+    unsigned nPress = 200;
 
     std::cout << "Creating tabulation with " << nTemp*nPress << " entries per quantity\n";
     TabulatedH2O::init(tempMin, tempMax, nTemp,
@@ -64,12 +65,12 @@ int main()
 
     std::cout << "Checking tabulation\n";
     success = true;
-    int m = nTemp*3;
-    int n = nPress*3;
-    for (int i = 0; i < m; ++i) {
+    unsigned m = nTemp*3;
+    unsigned n = nPress*3;
+    for (unsigned i = 0; i < m; ++i) {
         Scalar T = tempMin + (tempMax - tempMin)*Scalar(i)/m;
 
-        if (i % std::max(1, m/1000) == 0) {
+        if (i % std::max<unsigned>(1, m/1000) == 0) {
             std::cout << Scalar(i)/m*100 << "% done        \r";
             std::cout.flush();
         }
@@ -78,7 +79,7 @@ int main()
                TabulatedH2O::vaporPressure(T),
                IapwsH2O::vaporPressure(T),
                1e-3);
-        for (int j = 0; j < n; ++j) {
+        for (unsigned j = 0; j < n; ++j) {
             Scalar p = pMin + (pMax - pMin)*Scalar(j)/n;
             if (p < IapwsH2O::vaporPressure(T) * 1.001) {
                 Scalar tol = 1e-3;


### PR DESCRIPTION
this fixes most warnings that are produced by `make` when using clang's `-Weverything` flag in debug mode. fixing the remaining warnings would either produce incorrect code (e.g. `-Wfloat-equal` in 'test_localad.cc') or would be too much work (e.g. `-Wdocumentation`)