### PR TITLE
Do not store compressed to cartesian in ecl material law manager

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -210,7 +210,7 @@ public:
     MaterialLawParams& materialLawParams(unsigned elemIdx)
     {
         if (hasElementSpecificParameters()) {
-            assert(0 <= elemIdx && elemIdx < (int) materialLawParams_.size());
+            assert(0 <= elemIdx && elemIdx < materialLawParams_.size());
             return *materialLawParams_[elemIdx];
         }
         else

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -943,6 +943,8 @@ private:
             auto& realParams = materialParams.template getRealParams<Opm::EclTwoPhaseApproach>();
             return realParams.oilWaterParams().drainageParams().scaledPoints();
         }
+        default:
+            OPM_THROW(std::logic_error, "Enum value for material approach unknown!");
         }
     }
 


### PR DESCRIPTION
It is not needed after initialization. Therefore not storing it prevents some space. Additionally we fix some more warnings.