### PR TITLE
[bugfix] Fix inconsistent assumptions about the size of materialLawParams_

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -209,22 +209,14 @@ public:
 
     MaterialLawParams& materialLawParams(unsigned elemIdx)
     {
-        if (hasElementSpecificParameters()) {
-            assert(0 <= elemIdx && elemIdx < materialLawParams_.size());
-            return *materialLawParams_[elemIdx];
-        }
-        else
-            return *materialLawParams_[satnumRegionIdx_[elemIdx]];
+        assert(0 <= elemIdx && elemIdx < materialLawParams_.size());
+        return *materialLawParams_[elemIdx];
     }
 
     const MaterialLawParams& materialLawParams(unsigned elemIdx) const
     {
-        if (hasElementSpecificParameters()) {
-            assert(0 <= elemIdx && elemIdx < (int) materialLawParams_.size());
-            return *materialLawParams_[elemIdx];
-        }
-        else
-            return *materialLawParams_[satnumRegionIdx_[elemIdx]];
+        assert(0 <= elemIdx && elemIdx < (int) materialLawParams_.size());
+        return *materialLawParams_[elemIdx];
     }
 
     template <class FluidState>

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -3,6 +3,8 @@
 /*
   Copyright (C) 2015 by Andreas Lauser
   Copyright (C) 2015 by IRIS AS
+  Copyright (C) 2015 by Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright (C) 2015 by Statoil AS
 
   This file is part of the Open Porous Media project (OPM).
 


### PR DESCRIPTION
In the functions ECLMaterialLawManager::materialLawParam(unsigned
elemetIdx) there is a switch on
ECLMaterialLawManager::hasElementSpecificParameters(). If true the
size is assumed to equal to the number elements in the grid, other it
is supposed to be the number of satNumRegions.

Note that this function is used when calculating the capillary
pressure in  ECLMaterialLawManager::swatInit.

Nevertheless, during ECLMaterialLawManager::init the same switch is
used to either call ECLMaterialLawManager::initElemSpecific_ or
ECLMaterialLawManager::initNonElemSpecific_. But both methods create
ECLMaterialLawManager::materialLawParams_ with the same size as the
number of elements and initialize one entry for each element.

This commit makes the assumption about the size of
ECLMaterialLawManager::materialLawParams_ in
ECLMaterialLawManager::materialLawParams() the same as in the init
method.

Fixes issue #65 in my opinion. Please double check.