### PR TITLE
Give access to the shared_ptr of the parameters.

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -202,14 +202,24 @@ public:
 
     MaterialLawParams& materialLawParams(unsigned elemIdx)
     {
-        assert(0 <= elemIdx && elemIdx < materialLawParams_.size());
-        return *materialLawParams_[elemIdx];
+        return *materialLawParamsPointer(elemIdx);
     }
 
     const MaterialLawParams& materialLawParams(unsigned elemIdx) const
     {
-        assert(0 <= elemIdx && elemIdx < (int) materialLawParams_.size());
-        return *materialLawParams_[elemIdx];
+        return *materialLawParamsPointer(elemIdx);
+    }
+
+    std::shared_ptr<MaterialLawParams>& materialLawParamsPointer(unsigned elemIdx)
+    {
+        assert(0 <= elemIdx && elemIdx <  materialLawParams_.size());
+        return materialLawParams_[elemIdx];
+    }
+
+    const std::shared_ptr<MaterialLawParams>& materialLawParamsPointer(unsigned elemIdx) const
+    {
+        assert(0 <= elemIdx && elemIdx < materialLawParams_.size());
+        return materialLawParams_[elemIdx];
     }
 
     template <class FluidState>
@@ -227,6 +237,15 @@ public:
         return *oilWaterScaledEpsInfoDrainage_[elemIdx];
     }
 
+    const std::shared_ptr<EclEpsScalingPointsInfo<Scalar> >& oilWaterScaledEpsInfoDrainagePointer(unsigned elemIdx) const
+    {
+        return oilWaterScaledEpsInfoDrainage_[elemIdx];
+    }
+
+    std::shared_ptr<EclEpsScalingPointsInfo<Scalar> >& oilWaterScaledEpsInfoDrainagePointer(unsigned elemIdx)
+    {
+        return oilWaterScaledEpsInfoDrainage_[elemIdx];
+    }
 private:
     void readGlobalEpsOptions_(Opm::DeckConstPtr deck, Opm::EclipseStateConstPtr eclState)
     {


### PR DESCRIPTION
This is needed to keep the pointer structure when creating a new material law manager for just a subgrid. For this we either need to be able to copy the stored `shared_ptr` or somehow access the underlying pointer.

An alternative would be to make the version returning a mutable reference private and make stuff in opm-autodiff a friend of EclMaterialLawManager.