### PR TITLE
fix build on GCC 4.4

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -33,6 +33,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #endif
 
+#include <array>
 #include <string>
 #include <iostream>
 #include <cassert>

--- a/tests/test_eclmateriallawmanager.cpp
+++ b/tests/test_eclmateriallawmanager.cpp
@@ -236,7 +236,7 @@ int main()
 
     {
         typedef Opm::EclMaterialLawManager<MaterialTraits> MaterialLawManager;
-        typedef typename MaterialLawManager::MaterialLaw MaterialLaw;
+        typedef MaterialLawManager::MaterialLaw MaterialLaw;
 
         const auto deck = parser.parseString(fam1DeckString, parseMode);
         const auto eclState = std::make_shared<Opm::EclipseState>(deck, parseMode);


### PR DESCRIPTION
the explicit include of <array> is beneficial anyway.