### PR TITLE
blackoil-PVT: fix a few "non-void method may not return anything" warnings on GCC5

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -145,7 +145,7 @@ public:
                          const Evaluation& temperature,
                          const Evaluation& pressure,
                          const Evaluation& XgO) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, XgO)); }
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, XgO)); return 0; }
 
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
@@ -155,7 +155,7 @@ public:
                                      const Evaluation& temperature,
                                      const Evaluation& pressure,
                                      const Evaluation& XgO) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, XgO)); }
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, XgO)); return 0; }
 
     /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
@@ -165,7 +165,7 @@ public:
                        const Evaluation& temperature,
                        const Evaluation& pressure,
                        const Evaluation& XgO) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure, XgO)); }
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure, XgO)); return 0; }
 
     /*!
      * \brief Returns the fugacity coefficient [Pa] of the gas component in the gas phase
@@ -175,19 +175,19 @@ public:
     Evaluation fugacityCoefficientGas(unsigned regionIdx,
                                       const Evaluation& temperature,
                                       const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientGas(regionIdx, temperature, pressure)); }
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientGas(regionIdx, temperature, pressure)); return 0; }
 
     template <class Evaluation = Scalar>
     Evaluation fugacityCoefficientOil(unsigned regionIdx,
                                       const Evaluation& temperature,
                                       const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientOil(regionIdx, temperature, pressure)); }
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientOil(regionIdx, temperature, pressure)); return 0; }
 
     template <class Evaluation = Scalar>
     Evaluation fugacityCoefficientWater(unsigned regionIdx,
                                         const Evaluation& temperature,
                                         const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientWater(regionIdx, temperature, pressure)); }
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientWater(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of oil saturated gas.
@@ -196,7 +196,7 @@ public:
     Evaluation oilVaporizationFactor(unsigned regionIdx,
                                      const Evaluation& temperature,
                                      const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.oilVaporizationFactor(regionIdx, temperature, pressure)); }
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.oilVaporizationFactor(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the saturation pressure of the gas phase [Pa]
@@ -208,7 +208,7 @@ public:
     Evaluation gasSaturationPressure(unsigned regionIdx,
                                      const Evaluation& temperature,
                                      const Evaluation& XgO) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.gasSaturationPressure(regionIdx, temperature, XgO)); }
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.gasSaturationPressure(regionIdx, temperature, XgO)); return 0; }
 
     /*!
      * \brief Returns the gas mass fraction of oil-saturated gas at a given temperatire
@@ -218,7 +218,7 @@ public:
     Evaluation saturatedGasOilMassFraction(unsigned regionIdx,
                                            const Evaluation& temperature,
                                            const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasOilMassFraction(regionIdx, temperature, pressure)); }
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasOilMassFraction(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the gas mole fraction of oil-saturated gas at a given temperatire
@@ -228,7 +228,7 @@ public:
     Evaluation saturatedGasOilMoleFraction(unsigned regionIdx,
                                            const Evaluation& temperature,
                                            const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasOilMoleFraction(regionIdx, temperature, pressure)); }
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasOilMoleFraction(regionIdx, temperature, pressure)); return 0; }
 
 
     GasPvtApproach gasPvtApproach() const

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -136,7 +136,7 @@ public:
                          const Evaluation& temperature,
                          const Evaluation& pressure,
                          const Evaluation& XoG) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, XoG)); }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, XoG)); return 0; }
 
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
@@ -146,7 +146,7 @@ public:
                                      const Evaluation& temperature,
                                      const Evaluation& pressure,
                                      const Evaluation& XoG) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, XoG)); }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, XoG)); return 0; }
 
     /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
@@ -156,7 +156,7 @@ public:
                        const Evaluation& temperature,
                        const Evaluation& pressure,
                        const Evaluation& XoG) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure, XoG)); }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure, XoG)); return 0; }
 
     /*!
      * \brief Returns the fugacity coefficient [-] of the oil component in the oil phase
@@ -166,7 +166,7 @@ public:
     Evaluation fugacityCoefficientOil(unsigned regionIdx,
                                       const Evaluation& temperature,
                                       const Evaluation& pressure) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientOil(regionIdx, temperature, pressure)); }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientOil(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the fugacity coefficient [-] of the gas component in the oil phase
@@ -176,7 +176,7 @@ public:
     Evaluation fugacityCoefficientGas(unsigned regionIdx,
                                       const Evaluation& temperature,
                                       const Evaluation& pressure) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientGas(regionIdx, temperature, pressure)); }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientGas(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the fugacity coefficient [-] of the water component in the oil phase
@@ -186,7 +186,7 @@ public:
     Evaluation fugacityCoefficientWater(unsigned regionIdx,
                                         const Evaluation& temperature,
                                         const Evaluation& pressure) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientWater(regionIdx, temperature, pressure)); }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientWater(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of saturated oil.
@@ -195,7 +195,7 @@ public:
     Evaluation gasDissolutionFactor(unsigned regionIdx,
                                     const Evaluation& temperature,
                                     const Evaluation& pressure) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.gasDissolutionFactor(regionIdx, temperature, pressure)); }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.gasDissolutionFactor(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the saturation pressure [Pa] of oil given the mass fraction of the
@@ -208,7 +208,7 @@ public:
     Evaluation oilSaturationPressure(unsigned regionIdx,
                                      const Evaluation& temperature,
                                      const Evaluation& XoG) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.oilSaturationPressure(regionIdx, temperature, XoG)); }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.oilSaturationPressure(regionIdx, temperature, XoG)); return 0; }
 
     /*!
      * \brief Returns the gas mass fraction of gas-saturated oil at a given temperatire
@@ -221,7 +221,7 @@ public:
     Evaluation saturatedOilGasMassFraction(unsigned regionIdx,
                                            const Evaluation& temperature,
                                            const Evaluation& pressure) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilGasMassFraction(regionIdx, temperature, pressure)); }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilGasMassFraction(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the gas mole fraction of gas-saturated oil at a given temperatire
@@ -234,7 +234,7 @@ public:
     Evaluation saturatedOilGasMoleFraction(unsigned regionIdx,
                                            const Evaluation& temperature,
                                            const Evaluation& pressure) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilGasMoleFraction(regionIdx, temperature, pressure)); }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilGasMoleFraction(regionIdx, temperature, pressure)); return 0; }
 
     void setApproach(OilPvtApproach oilPvtApproach)
     {

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -94,7 +94,7 @@ public:
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& temperature,
                          const Evaluation& pressure) const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure)); }
+    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
@@ -103,7 +103,7 @@ public:
     Evaluation formationVolumeFactor(unsigned regionIdx,
                                      const Evaluation& temperature,
                                      const Evaluation& pressure) const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure)); }
+    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
@@ -112,7 +112,7 @@ public:
     Evaluation density(unsigned regionIdx,
                        const Evaluation& temperature,
                        const Evaluation& pressure) const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure)); }
+    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the fugacity coefficient [-] of the oil component in the water phase given
@@ -122,7 +122,7 @@ public:
     Evaluation fugacityCoefficientOil(unsigned regionIdx,
                                       const Evaluation& temperature,
                                       const Evaluation& pressure) const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientOil(regionIdx, temperature, pressure)); }
+    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientOil(regionIdx, temperature, pressure)); return 0; }
     /*!
      * \brief Returns the fugacity coefficient [-] of the gas component in the water phase given
      *        a pressure and a temperature.
@@ -131,7 +131,7 @@ public:
     Evaluation fugacityCoefficientGas(unsigned regionIdx,
                                       const Evaluation& temperature,
                                       const Evaluation& pressure) const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientGas(regionIdx, temperature, pressure)); }
+    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientGas(regionIdx, temperature, pressure)); return 0; }
     /*!
      * \brief Returns the fugacity coefficient [-] of the water component in the water phase given
      *        a pressure and a temperature.
@@ -140,7 +140,7 @@ public:
     Evaluation fugacityCoefficientWater(unsigned regionIdx,
                                         const Evaluation& temperature,
                                         const Evaluation& pressure) const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientWater(regionIdx, temperature, pressure)); }
+    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientWater(regionIdx, temperature, pressure)); return 0; }
 
     void setApproach(WaterPvtApproach waterPvtApproach)
     {


### PR DESCRIPTION
this warning is a false positive because the branch of the switch
statement which does not return a value throws an exception instead.