### PR TITLE
Fixes for the stone1 ECL material law

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -408,16 +408,26 @@ private:
         if (unscaledSats[1] >= unscaledSats[2])
             return scaledToUnscaledSatTwoPoint_(scaledSat, unscaledSats, scaledSats);
 
-        if (scaledSat < scaledSats[1])
+        if (scaledSat < scaledSats[1]) {
+            Scalar delta = scaledSats[1] - scaledSats[0];
+            if (delta <= 1e-20)
+                delta = 1.0; // prevent division by zero for (possibly) incorrect input data
+
             return
                 unscaledSats[0]
                 +
-                (scaledSat - scaledSats[0])*((unscaledSats[1] - unscaledSats[0])/(scaledSats[1] - scaledSats[0]));
-        else
+                (scaledSat - scaledSats[0])*((unscaledSats[1] - unscaledSats[0])/delta);
+        }
+        else {
+            Scalar delta = scaledSats[2] - scaledSats[1];
+            if (delta <= 1e-20)
+                delta = 1.0; // prevent division by zero for (possibly) incorrect input data
+
             return
                 unscaledSats[1]
                 +
-                (scaledSat - scaledSats[1])*((unscaledSats[2] - unscaledSats[1])/(scaledSats[2] - scaledSats[1]));
+                (scaledSat - scaledSats[1])*((unscaledSats[2] - unscaledSats[1])/delta);
+        }
     }
 
     template <class Evaluation, class PointsContainer>
@@ -428,16 +438,26 @@ private:
         if (unscaledSats[1] >= unscaledSats[2])
             return unscaledToScaledSatTwoPoint_(unscaledSat, unscaledSats, scaledSats);
 
-        if (unscaledSat < unscaledSats[1])
+        if (unscaledSat < unscaledSats[1]) {
+            Scalar delta = unscaledSats[1] - unscaledSats[0];
+            if (delta <= 1e-20)
+                delta = 1.0; // prevent division by zero for (possibly) incorrect input data
+
             return
                 scaledSats[0]
                 +
-                (unscaledSat - unscaledSats[0])*((scaledSats[1] - scaledSats[0])/(unscaledSats[1] - unscaledSats[0]));
-        else
+                (unscaledSat - unscaledSats[0])*((scaledSats[1] - scaledSats[0])/delta);
+        }
+        else {
+            Scalar delta = unscaledSats[2] - unscaledSats[1];
+            if (delta <= 1e-20)
+                delta = 1.0; // prevent division by zero for (possibly) incorrect input data
+
             return
                 scaledSats[1]
                 +
-                (unscaledSat - unscaledSats[1])*((scaledSats[2] - scaledSats[1])/(unscaledSats[2] - unscaledSats[1]));
+                (unscaledSat - unscaledSats[1])*((scaledSats[2] - scaledSats[1])/delta);
+        }
     }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -801,7 +801,6 @@ private:
             realParams.setGasOilParams(gasOilParams);
             realParams.setOilWaterParams(oilWaterParams);
             realParams.setSwl(epsInfo.Swl);
-            realParams.setSowcr(epsInfo.Sowcr);
 
             if (deck->hasKeyword("STONE1EX")) {
                 Scalar eta =

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -806,10 +806,10 @@ private:
             if (deck->hasKeyword("STONE1EX")) {
                 Scalar eta =
                     deck->getKeyword("STONE1EX")->getRecord(satnumIdx)->getItem(0)->getSIDouble(0);
-                realParams.setSogcr(eta);
+                realParams.setEta(eta);
             }
             else
-                realParams.setSogcr(1.0);
+                realParams.setEta(1.0);
             realParams.finalize();
             break;
         }

--- a/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
@@ -54,9 +54,7 @@ namespace Opm {
 template <class TraitsT,
           class GasOilMaterialLawT,
           class OilWaterMaterialLawT,
-          class ParamsT = EclStone1MaterialParams<TraitsT,
-                                                   typename GasOilMaterialLawT::Params,
-                                                   typename OilWaterMaterialLawT::Params> >
+          class ParamsT = EclStone1MaterialParams<TraitsT, GasOilMaterialLawT, OilWaterMaterialLawT> >
 class EclStone1Material : public TraitsT
 {
 public:
@@ -291,14 +289,16 @@ public:
         typedef MathToolbox<Evaluation> Toolbox;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        // the Eclipse docu is inconsistent here: In some places the connate water
-        // saturation is represented by "Swl", in others "Swco" is used.
+        // the Eclipse docu is inconsistent with naming the variable of connate water: In
+        // some places the connate water saturation is represented by "Swl", in others
+        // "Swco" is used.
         Scalar Swco = params.Swl();
+
+        // oil relperm at connate water saturations (with Sg=0)
+        Scalar krocw = params.krocw();
 
         const Evaluation& Sw = FsToolbox::template toLhs<Evaluation>(fluidState.saturation(waterPhaseIdx));
         const Evaluation& Sg = FsToolbox::template toLhs<Evaluation>(fluidState.saturation(gasPhaseIdx));
-
-        Scalar krocw = OilWaterMaterialLaw::twoPhaseSatKrn(params.oilWaterParams(), Swco);
 
         Evaluation kro_ow = OilWaterMaterialLaw::twoPhaseSatKrn(params.oilWaterParams(), Sw);
         Evaluation kro_go = GasOilMaterialLaw::twoPhaseSatKrw(params.gasOilParams(), 1 - Sg - Swco);

--- a/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
@@ -314,7 +314,10 @@ public:
             Evaluation SSg = Sg/(1.0 - Swco);
             Evaluation SSo = 1.0 - SSw - SSg;
 
-            beta = Toolbox::pow( SSo/((1 - SSw)*(1 - SSg)), params.eta());
+            if (SSw >= 1.0 || SSg >= 1.0)
+                beta = 1.0;
+            else
+                beta = Toolbox::pow( SSo/((1 - SSw)*(1 - SSg)), params.eta());
         }
 
         return Toolbox::max(0.0, Toolbox::min(1.0, beta*kro_ow*kro_go/krocw));

--- a/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
@@ -39,15 +39,15 @@ namespace Opm {
  * Essentially, this class just stores the two parameter objects for
  * the twophase capillary pressure laws.
  */
-template<class Traits, class GasOilParamsT, class OilWaterParamsT>
+template<class Traits, class GasOilLawT, class OilWaterLawT>
 class EclStone1MaterialParams
 {
     typedef typename Traits::Scalar Scalar;
     enum { numPhases = 3 };
 
 public:
-    typedef GasOilParamsT GasOilParams;
-    typedef OilWaterParamsT OilWaterParams;
+    typedef typename GasOilLawT::Params GasOilParams;
+    typedef typename OilWaterLawT::Params OilWaterParams;
 
     /*!
      * \brief The default constructor.
@@ -64,6 +64,8 @@ public:
      */
     void finalize()
     {
+        krocw_ = OilWaterLawT::twoPhaseSatKrn(*oilWaterParams_, Swl_);
+
 #ifndef NDEBUG
         finalized_ = true;
 #endif
@@ -126,28 +128,11 @@ public:
     { assertFinalized_(); return Swl_; }
 
     /*!
-     * \brief Set the critical saturation of oil in the water-oil system.
+     * \brief Return the oil relperm for the oil-water system at the connate water
+     *        saturation.
      */
-    void setSowcr(Scalar val)
-    { Sowcr_ = val; }
-
-    /*!
-     * \brief Return the critical saturation of oil in the water-oil system.
-     */
-    Scalar Sowcr() const
-    { assertFinalized_(); return Sowcr_; }
-
-    /*!
-     * \brief Set the critical saturation of oil in the oil-gas system.
-     */
-    void setSogcr(Scalar val)
-    { Sogcr_ = val; }
-
-    /*!
-     * \brief Return the critical saturation of oil in the oil-gas system.
-     */
-    Scalar Sogcr() const
-    { assertFinalized_(); return Sogcr_; }
+    Scalar krocw() const
+    { assertFinalized_(); return krocw_; }
 
     /*!
      * \brief Set the exponent of the extended Stone 1 model.
@@ -176,9 +161,8 @@ private:
     std::shared_ptr<OilWaterParams> oilWaterParams_;
 
     Scalar Swl_;
-    Scalar Sowcr_;
-    Scalar Sogcr_;
     Scalar eta_;
+    Scalar krocw_;
 };
 } // namespace Opm
 


### PR DESCRIPTION
It looks like the equations that scale the saturations for the Stone 1 model given by the Eclipse documentation are wrong. ("wrong" in the sense that they seem not to be the ones implemented by E100.)

With this change, the oil relperm seems to be identical to the ones of E100 for SPE-1 based test deck. I'd be grateful if somebody else (@osae or @totto82 ?) could have look at this before it is merged.