### PR TITLE
Pvt changes

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -667,7 +667,7 @@ public:
      *        corresponding gas dissolution factor.
      */
     template <class LhsEval>
-    static LhsEval XoGToRs(const LhsEval& XoG, unsigned regionIdx)
+    static LhsEval convertXoGToRs(const LhsEval& XoG, unsigned regionIdx)
     {
         return XoG/(1 - XoG)
             *(referenceDensity(oilPhaseIdx, regionIdx)/referenceDensity(gasPhaseIdx, regionIdx));
@@ -678,7 +678,7 @@ public:
      *        corresponding oil vaporization factor.
      */
     template <class LhsEval>
-    static LhsEval XgOToRv(const LhsEval& XgO, unsigned regionIdx)
+    static LhsEval convertXgOToRv(const LhsEval& XgO, unsigned regionIdx)
     {
         return XgO/(1 - XgO)
             *(referenceDensity(gasPhaseIdx, regionIdx)/referenceDensity(oilPhaseIdx, regionIdx));
@@ -698,7 +698,7 @@ private:
 
         const auto& XoG =
             FsToolbox::template toLhs<LhsEval>(fluidState.massFraction(oilPhaseIdx, gasCompIdx));
-        return XoGToRs(XoG, regionIdx);
+        return convertXoGToRs(XoG, regionIdx);
     }
 
     template <class LhsEval, class FluidState>
@@ -708,7 +708,7 @@ private:
 
         const auto& XgO =
             FsToolbox::template toLhs<LhsEval>(fluidState.massFraction(gasPhaseIdx, oilCompIdx));
-        return XgOToRv(XgO, regionIdx);
+        return convertXgOToRv(XgO, regionIdx);
     }
 
     static std::shared_ptr<GasPvt> gasPvt_;

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -169,16 +169,16 @@ public:
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
     template <class Evaluation>
-        Evaluation viscosity(unsigned regionIdx,
-                             const Evaluation& temperature,
-                             const Evaluation& pressure,
-                             const Evaluation& XoG) const
+    Evaluation viscosity(unsigned regionIdx,
+                         const Evaluation& temperature,
+                         const Evaluation& pressure,
+                         const Evaluation& Rs) const
     {
         // Eclipse calculates the viscosity in a weird way: it
         // calcultes the product of B_w and mu_w and then divides the
         // result by B_w...
         Scalar BoMuoRef = oilViscosity_[regionIdx]*oilReferenceFormationVolumeFactor_[regionIdx];
-        const Evaluation& Bo = formationVolumeFactor(regionIdx, temperature, pressure, XoG);
+        const Evaluation& Bo = formationVolumeFactor(regionIdx, temperature, pressure, Rs);
 
         Scalar pRef = oilReferencePressure_[regionIdx];
         const Evaluation& Y =
@@ -194,9 +194,9 @@ public:
         Evaluation density(unsigned regionIdx,
                            const Evaluation& temperature,
                            const Evaluation& pressure,
-                           const Evaluation& XoG) const
+                           const Evaluation& Rs) const
     {
-        const Evaluation& Bo = formationVolumeFactor(regionIdx, temperature, pressure, XoG);
+        const Evaluation& Bo = formationVolumeFactor(regionIdx, temperature, pressure, Rs);
         Scalar rhooRef = oilReferenceDensity_[regionIdx];
         return rhooRef/Bo;
     }
@@ -208,7 +208,7 @@ public:
         Evaluation formationVolumeFactor(unsigned regionIdx,
                                          const Evaluation& /*temperature*/,
                                          const Evaluation& pressure,
-                                         const Evaluation& /*XoG*/) const
+                                         const Evaluation& /*Rs*/) const
     {
         // cf. ECLiPSE 2011 technical description, p. 116
         Scalar pRef = oilReferencePressure_[regionIdx];
@@ -266,12 +266,12 @@ public:
      * \brief Returns the saturation pressure of the oil phase [Pa]
      *        depending on its mass fraction of the gas component
      *
-     * \param XoG The mass fraction of the gas component in the oil phase [-]
+     * \param Rs The surface volume of gas component dissolved in what will yield one cubic meter of oil at the surface [-]
      */
     template <class Evaluation>
-        Evaluation oilSaturationPressure(unsigned /*regionIdx*/,
-                                         const Evaluation& /*temperature*/,
-                                         const Evaluation& /*XoG*/) const
+    Evaluation oilSaturationPressure(unsigned /*regionIdx*/,
+                                     const Evaluation& /*temperature*/,
+                                     const Evaluation& /*Rs*/) const
     { return 0.0; /* this is dead oil, so there isn't any meaningful saturation pressure! */ }
 
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -246,7 +246,7 @@ public:
      * \brief Returns the saturation pressure of the oil phase [Pa]
      *        depending on its mass fraction of the gas component
      *
-     * \param Rs The mass fraction of the gas component in the oil phase [-]
+     * \param Rs The surface volume of gas component dissolved in what will yield one cubic meter of oil at the surface [-]
      */
     template <class Evaluation>
     Evaluation oilSaturationPressure(unsigned /*regionIdx*/,

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -165,7 +165,7 @@ public:
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& /*temperature*/,
                          const Evaluation& pressure,
-                         const Evaluation& /*XoG*/) const
+                         const Evaluation& /*Rs*/) const
     {
         const Evaluation& invBo = inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true);
         const Evaluation& invMuoBo = inverseOilBMu_[regionIdx].eval(pressure, /*extrapolate=*/true);
@@ -180,11 +180,11 @@ public:
     Evaluation density(unsigned regionIdx,
                        const Evaluation& temperature,
                        const Evaluation& pressure,
-                       const Evaluation& XoG) const
+                       const Evaluation& Rs) const
     {
         Scalar rhooRef = oilReferenceDensity_[regionIdx];
 
-        const Evaluation& Bo = formationVolumeFactor(regionIdx, temperature, pressure, XoG);
+        const Evaluation& Bo = formationVolumeFactor(regionIdx, temperature, pressure, Rs);
         return rhooRef/Bo;
     }
 
@@ -195,7 +195,7 @@ public:
     Evaluation formationVolumeFactor(unsigned regionIdx,
                                      const Evaluation& /*temperature*/,
                                      const Evaluation& pressure,
-                                     const Evaluation& /*XoG*/) const
+                                     const Evaluation& /*Rs*/) const
     { return 1.0 / inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
@@ -246,12 +246,12 @@ public:
      * \brief Returns the saturation pressure of the oil phase [Pa]
      *        depending on its mass fraction of the gas component
      *
-     * \param XoG The mass fraction of the gas component in the oil phase [-]
+     * \param Rs The mass fraction of the gas component in the oil phase [-]
      */
     template <class Evaluation>
     Evaluation oilSaturationPressure(unsigned /*regionIdx*/,
                                      const Evaluation& /*temperature*/,
-                                     const Evaluation& /*XoG*/) const
+                                     const Evaluation& /*Rs*/) const
     { return 0.0; /* this is dead oil, so there isn't any meaningful saturation pressure! */ }
 
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -193,7 +193,7 @@ public:
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& /*temperature*/,
                          const Evaluation& pressure,
-                         const Evaluation& /*XgO*/) const
+                         const Evaluation& /*Rv*/) const
     {
         const Evaluation& invBg = inverseGasB_[regionIdx].eval(pressure, /*extrapolate=*/true);
         const Evaluation& invMugBg = inverseGasBMu_[regionIdx].eval(pressure, /*extrapolate=*/true);
@@ -208,10 +208,10 @@ public:
     Evaluation density(unsigned regionIdx,
                        const Evaluation& temperature,
                        const Evaluation& pressure,
-                       const Evaluation& XgO) const
+                       const Evaluation& Rv) const
     {
         // gas formation volume factor at reservoir pressure
-        const Evaluation& Bg = formationVolumeFactor(regionIdx, temperature, pressure, XgO);
+        const Evaluation& Bg = formationVolumeFactor(regionIdx, temperature, pressure, Rv);
         return gasReferenceDensity_[regionIdx]/Bg;
     }
 
@@ -222,7 +222,7 @@ public:
     Evaluation formationVolumeFactor(unsigned regionIdx,
                                      const Evaluation& /*temperature*/,
                                      const Evaluation& pressure,
-                                     const Evaluation& /*XgO*/) const
+                                     const Evaluation& /*Rv*/) const
     { return 1.0/inverseGasB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
@@ -262,12 +262,12 @@ public:
      * \brief Returns the saturation pressure of the gas phase [Pa]
      *        depending on its mass fraction of the oil component
      *
-     * \param XgO The mass fraction of the oil component in the gas phase [-]
+     * \param Rv The surface volume of oil component dissolved in what will yield one cubic meter of gas at the surface [-]
      */
     template <class Evaluation>
     Evaluation gasSaturationPressure(unsigned /*regionIdx*/,
                                      const Evaluation& /*temperature*/,
-                                     const Evaluation& /*XgO*/) const
+                                     const Evaluation& /*Rv*/) const
     { return 0.0; /* this is dry gas! */ }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -144,8 +144,8 @@ public:
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& temperature,
                          const Evaluation& pressure,
-                         const Evaluation& XgO) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, XgO)); return 0; }
+                         const Evaluation& Rv) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, Rv)); return 0; }
 
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
@@ -154,8 +154,8 @@ public:
     Evaluation formationVolumeFactor(unsigned regionIdx,
                                      const Evaluation& temperature,
                                      const Evaluation& pressure,
-                                     const Evaluation& XgO) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, XgO)); return 0; }
+                                     const Evaluation& Rv) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, Rv)); return 0; }
 
     /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
@@ -164,8 +164,8 @@ public:
     Evaluation density(unsigned regionIdx,
                        const Evaluation& temperature,
                        const Evaluation& pressure,
-                       const Evaluation& XgO) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure, XgO)); return 0; }
+                       const Evaluation& Rv) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure, Rv)); return 0; }
 
     /*!
      * \brief Returns the fugacity coefficient [Pa] of the gas component in the gas phase
@@ -202,13 +202,13 @@ public:
      * \brief Returns the saturation pressure of the gas phase [Pa]
      *        depending on its mass fraction of the oil component
      *
-     * \param XgO The mass fraction of the oil component in the gas phase [-]
+     * \param Rv The surface volume of oil component dissolved in what will yield one cubic meter of gas at the surface [-]
      */
     template <class Evaluation = Scalar>
     Evaluation gasSaturationPressure(unsigned regionIdx,
                                      const Evaluation& temperature,
-                                     const Evaluation& XgO) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.gasSaturationPressure(regionIdx, temperature, XgO)); return 0; }
+                                     const Evaluation& Rv) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.gasSaturationPressure(regionIdx, temperature, Rv)); return 0; }
 
     /*!
      * \brief Returns the gas mass fraction of oil-saturated gas at a given temperatire

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -135,8 +135,8 @@ public:
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& temperature,
                          const Evaluation& pressure,
-                         const Evaluation& XoG) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, XoG)); return 0; }
+                         const Evaluation& Rs) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, Rs)); return 0; }
 
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
@@ -145,8 +145,8 @@ public:
     Evaluation formationVolumeFactor(unsigned regionIdx,
                                      const Evaluation& temperature,
                                      const Evaluation& pressure,
-                                     const Evaluation& XoG) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, XoG)); return 0; }
+                                     const Evaluation& Rs) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, Rs)); return 0; }
 
     /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
@@ -155,8 +155,8 @@ public:
     Evaluation density(unsigned regionIdx,
                        const Evaluation& temperature,
                        const Evaluation& pressure,
-                       const Evaluation& XoG) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure, XoG)); return 0; }
+                       const Evaluation& Rs) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure, Rs)); return 0; }
 
     /*!
      * \brief Returns the fugacity coefficient [-] of the oil component in the oil phase
@@ -207,8 +207,8 @@ public:
     template <class Evaluation>
     Evaluation oilSaturationPressure(unsigned regionIdx,
                                      const Evaluation& temperature,
-                                     const Evaluation& XoG) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.oilSaturationPressure(regionIdx, temperature, XoG)); return 0; }
+                                     const Evaluation& Rs) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.oilSaturationPressure(regionIdx, temperature, Rs)); return 0; }
 
     /*!
      * \brief Returns the gas mass fraction of gas-saturated oil at a given temperatire


### PR DESCRIPTION
this changes the argument which specifies the oil/gas composition for the black-oil PVT classes from the mass fraction of the dissolved component to their specific surface volumes (i.e., it now uses R_s and R_v instead of X_o^G and X_g^O).

this makes it more straight-forward to match the PVT interface of opm-core.