### PR TITLE
update the CDash drop site

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -2,6 +2,6 @@
 set(CTEST_PROJECT_NAME "${${project}_NAME}")
 set(CTEST_NIGHTLY_START_TIME "01:00:00 UTC")
 set(CTEST_DROP_METHOD "http")
-set(CTEST_DROP_SITE "opm-project.org")
+set(CTEST_DROP_SITE "oldopmweb.poware.org")
 set(CTEST_DROP_LOCATION "/CDash/submit.php?project=${${project}_NAME}")
 set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
the new website does not support CDash yet (and it looks like it never
will). since the only modules I really care about are opm-material and
eWoms, let's temporarily move the cdash dropsite for these to my private site
(poware.org). The exact URL will probably change once more before the
next OPM release.