### PR TITLE
Saturated blackoil pvt

### DIFF
--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -335,8 +335,8 @@ public:
         }
 
         OPM_THROW(std::invalid_argument,
-                  "Sampling points should be specified either monotonically "
-                  "ascending or descending.");
+                  "Sampling points must be specified in either monotonically "
+                  "ascending or descending order.");
     }
 
     /*!

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -50,11 +50,11 @@ namespace FluidSystems {
 template <class Scalar>
 class BlackOil : public BaseFluidSystem<Scalar, BlackOil<Scalar> >
 {
+public:
     typedef Opm::GasPvtMultiplexer<Scalar> GasPvt;
     typedef Opm::OilPvtMultiplexer<Scalar> OilPvt;
     typedef Opm::WaterPvtMultiplexer<Scalar> WaterPvt;
 
-public:
     //! \copydoc BaseFluidSystem::ParameterCache
     class ParameterCache : public Opm::NullParameterCache
     {
@@ -573,7 +573,7 @@ public:
     static LhsEval oilSaturationPressure(const LhsEval& temperature,
                                          const LhsEval& Rs,
                                          unsigned regionIdx)
-    { return oilPvt_->oilSaturationPressure(regionIdx, temperature, Rs); }
+    { return oilPvt_->saturationPressure(regionIdx, temperature, Rs); }
 
     /*!
      * \brief The maximum mass fraction of the gas component in the oil phase.
@@ -651,7 +651,7 @@ public:
     static LhsEval saturatedOilDensity(const LhsEval& temperature,
                                        const LhsEval& pressure,
                                        unsigned regionIdx)
-    { return oilPvt_->saturatedOilDensity(regionIdx, temperature, pressure); }
+    { return oilPvt_->saturatedDensity(regionIdx, temperature, pressure); }
 
     /*!
      * \brief Return the formation volume factor of gas.
@@ -680,7 +680,7 @@ public:
     static LhsEval saturatedGasDensity(const LhsEval& temperature,
                                        const LhsEval& pressure,
                                        unsigned regionIdx)
-    { return oilPvt_->saturatedGasDensity(regionIdx, temperature, pressure);  }
+    { return oilPvt_->saturatedDensity(regionIdx, temperature, pressure);  }
 
     /*!
      * \brief Return the density of water.

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -295,9 +295,9 @@ public:
      * \param Rs The surface volume of gas component dissolved in what will yield one cubic meter of oil at the surface [-]
      */
     template <class Evaluation>
-    Evaluation oilSaturationPressure(unsigned /*regionIdx*/,
-                                     const Evaluation& /*temperature*/,
-                                     const Evaluation& /*Rs*/) const
+    Evaluation saturationPressure(unsigned /*regionIdx*/,
+                                  const Evaluation& /*temperature*/,
+                                  const Evaluation& /*Rs*/) const
     { return 0.0; /* this is dead oil, so there isn't any meaningful saturation pressure! */ }
 
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -157,14 +157,15 @@ public:
         // Eclipse calculates the viscosity in a weird way: it
         // calcultes the product of B_w and mu_w and then divides the
         // result by B_w...
-        Scalar BwMuwRef = waterViscosity_[regionIdx]*waterReferenceFormationVolumeFactor_[regionIdx];
-        const Evaluation& Bw = formationVolumeFactor(regionIdx, temperature, pressure);
+        Scalar muwRef = waterViscosity_[regionIdx];
 
+        // note: this is NOT equivalent to the equation given by the ECL RM. It is
+        // equivalent to the code which was used by opm-core at the time when this was
+        // written.
         Scalar pRef = waterReferencePressure_[regionIdx];
-        const Evaluation& Y =
-            (waterCompressibility_[regionIdx] - waterViscosibility_[regionIdx])
-            * (pressure - pRef);
-        return BwMuwRef/((1 + Y*(1 + Y/2))*Bw);
+        const Evaluation& x = (-waterViscosibility_[regionIdx])*(pressure - pRef);
+        const Evaluation& d = 1.0 + x*(1.0 + x/2.0);
+        return muwRef/d;
     }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -163,9 +163,18 @@ public:
      */
     template <class Evaluation>
     Evaluation viscosity(unsigned regionIdx,
-                         const Evaluation& /*temperature*/,
+                         const Evaluation& temperature,
                          const Evaluation& pressure,
                          const Evaluation& /*Rs*/) const
+    { return saturatedViscosity(regionIdx, temperature, pressure); }
+
+    /*!
+     * \brief Returns the dynamic viscosity [Pa s] of gas saturated oil given a pressure.
+     */
+    template <class Evaluation>
+    Evaluation saturatedViscosity(unsigned regionIdx,
+                                  const Evaluation& /*temperature*/,
+                                  const Evaluation& pressure) const
     {
         const Evaluation& invBo = inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true);
         const Evaluation& invMuoBo = inverseOilBMu_[regionIdx].eval(pressure, /*extrapolate=*/true);
@@ -180,11 +189,20 @@ public:
     Evaluation density(unsigned regionIdx,
                        const Evaluation& temperature,
                        const Evaluation& pressure,
-                       const Evaluation& Rs) const
+                       const Evaluation& /*Rs*/) const
+    { return saturatedDensity(regionIdx, temperature, pressure); }
+
+    /*!
+     * \brief Returns the density [kg/m^3] of gas saturated oil given a pressure.
+     */
+    template <class Evaluation>
+    Evaluation saturatedDensity(unsigned regionIdx,
+                                const Evaluation& temperature,
+                                const Evaluation& pressure) const
     {
         Scalar rhooRef = oilReferenceDensity_[regionIdx];
 
-        const Evaluation& Bo = formationVolumeFactor(regionIdx, temperature, pressure, Rs);
+        const Evaluation& Bo = saturatedFormationVolumeFactor(regionIdx, temperature, pressure);
         return rhooRef/Bo;
     }
 
@@ -196,6 +214,17 @@ public:
                                      const Evaluation& /*temperature*/,
                                      const Evaluation& pressure,
                                      const Evaluation& /*Rs*/) const
+    { return 1.0 / inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
+
+    /*!
+     * \brief Returns the formation volume factor [-] of saturated oil.
+     *
+     * Note that by definition, dead oil is always gas saturated.
+     */
+    template <class Evaluation>
+    Evaluation saturatedFormationVolumeFactor(unsigned regionIdx,
+                                              const Evaluation& /*temperature*/,
+                                              const Evaluation& pressure) const
     { return 1.0 / inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
@@ -255,15 +284,15 @@ public:
     { return 0.0; /* this is dead oil, so there isn't any meaningful saturation pressure! */ }
 
     template <class Evaluation>
-    Evaluation saturatedOilGasMassFraction(unsigned /*regionIdx*/,
-                                           const Evaluation& /*temperature*/,
-                                           const Evaluation& /*pressure*/) const
+    Evaluation saturatedGasMassFraction(unsigned /*regionIdx*/,
+                                        const Evaluation& /*temperature*/,
+                                        const Evaluation& /*pressure*/) const
     { return 0.0; /* this is dead oil! */ }
 
     template <class Evaluation>
-    Evaluation saturatedOilGasMoleFraction(unsigned /*regionIdx*/,
-                                           const Evaluation& /*temperature*/,
-                                           const Evaluation& /*pressure*/) const
+    Evaluation saturatedGasMoleFraction(unsigned /*regionIdx*/,
+                                        const Evaluation& /*temperature*/,
+                                        const Evaluation& /*pressure*/) const
     { return 0.0; /* this is dead oil! */ }
 
 private:

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -278,9 +278,9 @@ public:
      * \param Rs The surface volume of gas component dissolved in what will yield one cubic meter of oil at the surface [-]
      */
     template <class Evaluation>
-    Evaluation oilSaturationPressure(unsigned /*regionIdx*/,
-                                     const Evaluation& /*temperature*/,
-                                     const Evaluation& /*Rs*/) const
+    Evaluation saturationPressure(unsigned /*regionIdx*/,
+                                  const Evaluation& /*temperature*/,
+                                  const Evaluation& /*Rs*/) const
     { return 0.0; /* this is dead oil, so there isn't any meaningful saturation pressure! */ }
 
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -218,7 +218,7 @@ public:
                        const Evaluation& temperature,
                        const Evaluation& pressure,
                        const Evaluation& Rv) const
-    { return saturatedViscosity(regionIdx, temperature, pressure); }
+    { return saturatedDensity(regionIdx, temperature, pressure); }
 
     /*!
      * \brief Returns the density [kg/m^3] of oil saturated gas at given pressure.

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -191,9 +191,18 @@ public:
      */
     template <class Evaluation>
     Evaluation viscosity(unsigned regionIdx,
-                         const Evaluation& /*temperature*/,
+                         const Evaluation& temperature,
                          const Evaluation& pressure,
                          const Evaluation& /*Rv*/) const
+    { return saturatedViscosity(regionIdx, temperature, pressure); }
+
+    /*!
+     * \brief Returns the dynamic viscosity [Pa s] of oil saturated gas at given pressure.
+     */
+    template <class Evaluation>
+    Evaluation saturatedViscosity(unsigned regionIdx,
+                                  const Evaluation& /*temperature*/,
+                                  const Evaluation& pressure) const
     {
         const Evaluation& invBg = inverseGasB_[regionIdx].eval(pressure, /*extrapolate=*/true);
         const Evaluation& invMugBg = inverseGasBMu_[regionIdx].eval(pressure, /*extrapolate=*/true);
@@ -209,9 +218,18 @@ public:
                        const Evaluation& temperature,
                        const Evaluation& pressure,
                        const Evaluation& Rv) const
+    { return saturatedViscosity(regionIdx, temperature, pressure); }
+
+    /*!
+     * \brief Returns the density [kg/m^3] of oil saturated gas at given pressure.
+     */
+    template <class Evaluation>
+    Evaluation saturatedDensity(unsigned regionIdx,
+                                const Evaluation& temperature,
+                                const Evaluation& pressure) const
     {
         // gas formation volume factor at reservoir pressure
-        const Evaluation& Bg = formationVolumeFactor(regionIdx, temperature, pressure, Rv);
+        const Evaluation& Bg = saturatedFormationVolumeFactor(regionIdx, temperature, pressure);
         return gasReferenceDensity_[regionIdx]/Bg;
     }
 
@@ -220,9 +238,18 @@ public:
      */
     template <class Evaluation>
     Evaluation formationVolumeFactor(unsigned regionIdx,
-                                     const Evaluation& /*temperature*/,
+                                     const Evaluation& temperature,
                                      const Evaluation& pressure,
                                      const Evaluation& /*Rv*/) const
+    { return saturatedFormationVolumeFactor(regionIdx, temperature, pressure); }
+
+    /*!
+     * \brief Returns the formation volume factor [-] of oil saturated gas at given pressure.
+     */
+    template <class Evaluation>
+    Evaluation saturatedFormationVolumeFactor(unsigned regionIdx,
+                                              const Evaluation& /*temperature*/,
+                                              const Evaluation& pressure) const
     { return 1.0/inverseGasB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
@@ -280,15 +307,15 @@ public:
     { return 0.0; /* this is dry gas! */ }
 
     template <class Evaluation>
-    Evaluation saturatedGasOilMassFraction(unsigned /*regionIdx*/,
-                                           const Evaluation& /*temperature*/,
-                                           const Evaluation& /*pressure*/) const
+    Evaluation saturatedOilMassFraction(unsigned /*regionIdx*/,
+                                        const Evaluation& /*temperature*/,
+                                        const Evaluation& /*pressure*/) const
     { return 0.0; /* this is dry gas! */ }
 
     template <class Evaluation>
-    Evaluation saturatedGasOilMoleFraction(unsigned /*regionIdx*/,
-                                           const Evaluation& /*temperature*/,
-                                           const Evaluation& /*pressure*/) const
+    Evaluation saturatedOilMoleFraction(unsigned /*regionIdx*/,
+                                        const Evaluation& /*temperature*/,
+                                        const Evaluation& /*pressure*/) const
     { return 0.0; /* this is dry gas! */ }
 
 private:

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -148,6 +148,15 @@ public:
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, Rv)); return 0; }
 
     /*!
+     * \brief Returns the dynamic viscosity [Pa s] of oil saturated gas given a set of parameters.
+     */
+    template <class Evaluation = Scalar>
+    Evaluation saturatedViscosity(unsigned regionIdx,
+                                  const Evaluation& temperature,
+                                  const Evaluation& pressure) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedViscosity(regionIdx, temperature, pressure)); return 0; }
+
+    /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */
     template <class Evaluation = Scalar>
@@ -158,6 +167,15 @@ public:
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, Rv)); return 0; }
 
     /*!
+     * \brief Returns the formation volume factor [-] of oil saturated gas given a set of parameters.
+     */
+    template <class Evaluation = Scalar>
+    Evaluation saturatedFormationVolumeFactor(unsigned regionIdx,
+                                              const Evaluation& temperature,
+                                              const Evaluation& pressure) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedFormationVolumeFactor(regionIdx, temperature, pressure)); return 0; }
+
+    /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
      */
     template <class Evaluation = Scalar>
@@ -166,6 +184,15 @@ public:
                        const Evaluation& pressure,
                        const Evaluation& Rv) const
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure, Rv)); return 0; }
+
+    /*!
+     * \brief Returns the density [kg/m^3] of oil saturated gas given a set of parameters.
+     */
+    template <class Evaluation = Scalar>
+    Evaluation saturatedDensity(unsigned regionIdx,
+                                const Evaluation& temperature,
+                                const Evaluation& pressure) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedDensity(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the fugacity coefficient [Pa] of the gas component in the gas phase
@@ -215,20 +242,20 @@ public:
      *        and pressure [-].
      */
     template <class Evaluation = Scalar>
-    Evaluation saturatedGasOilMassFraction(unsigned regionIdx,
-                                           const Evaluation& temperature,
-                                           const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasOilMassFraction(regionIdx, temperature, pressure)); return 0; }
+    Evaluation saturatedOilMassFraction(unsigned regionIdx,
+                                        const Evaluation& temperature,
+                                        const Evaluation& pressure) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilMassFraction(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the gas mole fraction of oil-saturated gas at a given temperatire
      *        and pressure [-].
      */
     template <class Evaluation = Scalar>
-    Evaluation saturatedGasOilMoleFraction(unsigned regionIdx,
-                                           const Evaluation& temperature,
-                                           const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasOilMoleFraction(regionIdx, temperature, pressure)); return 0; }
+    Evaluation saturatedOilMoleFraction(unsigned regionIdx,
+                                        const Evaluation& temperature,
+                                        const Evaluation& pressure) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilMoleFraction(regionIdx, temperature, pressure)); return 0; }
 
 
     GasPvtApproach gasPvtApproach() const

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -279,7 +279,7 @@ public:
             for (size_t pIdx = 0; pIdx < nP; ++pIdx) {
                 Scalar po = poMin + (poMax - poMin)*pIdx/nP;
 
-                Scalar poSat = oilSaturationPressure(regionIdx, T, Rs);
+                Scalar poSat = saturationPressure(regionIdx, T, Rs);
                 Scalar BoSat = oilFormationVolumeFactorSpline.eval(poSat, /*extrapolate=*/true);
                 Scalar drhoo_dp = (1.1200 - 1.1189)/((5000 - 4000)*6894.76);
                 Scalar rhoo = oilReferenceDensity_[regionIdx]/BoSat*(1 + drhoo_dp*(po - poSat));
@@ -573,9 +573,9 @@ public:
      * \param Rs The surface volume of gas component dissolved in what will yield one cubic meter of oil at the surface [-]
      */
     template <class Evaluation>
-    Evaluation oilSaturationPressure(unsigned regionIdx,
-                                     const Evaluation& temperature,
-                                     const Evaluation& Rs) const
+    Evaluation saturationPressure(unsigned regionIdx,
+                                  const Evaluation& temperature,
+                                  const Evaluation& Rs) const
     {
         typedef Opm::MathToolbox<Evaluation> Toolbox;
 

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -232,10 +232,10 @@ public:
      * the black-oil PVT interface will just throw an exception...
      */
     template <class Evaluation>
-    Evaluation oilSaturationPressure(unsigned regionIdx,
+    Evaluation saturationPressure(unsigned regionIdx,
                                      const Evaluation& temperature,
                                      const Evaluation& Rs) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.oilSaturationPressure(regionIdx, temperature, Rs)); return 0; }
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturationPressure(regionIdx, temperature, Rs)); return 0; }
 
     /*!
      * \brief Returns the gas mass fraction of gas-saturated oil at a given temperatire

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -139,6 +139,24 @@ public:
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, Rs)); return 0; }
 
     /*!
+     * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation saturatedViscosity(unsigned regionIdx,
+                                  const Evaluation& temperature,
+                                  const Evaluation& pressure) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedViscosity(regionIdx, temperature, pressure)); return 0; }
+
+    /*!
+     * \brief Returns the formation volume factor [-] of the fluid phase.
+     */
+    template <class Evaluation>
+    Evaluation saturatedFormationVolumeFactor(unsigned regionIdx,
+                                              const Evaluation& temperature,
+                                              const Evaluation& pressure) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedFormationVolumeFactor(regionIdx, temperature, pressure)); return 0; }
+
+    /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */
     template <class Evaluation>
@@ -157,6 +175,15 @@ public:
                        const Evaluation& pressure,
                        const Evaluation& Rs) const
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure, Rs)); return 0; }
+
+    /*!
+     * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation saturatedDensity(unsigned regionIdx,
+                                const Evaluation& temperature,
+                                const Evaluation& pressure) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedDensity(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the fugacity coefficient [-] of the oil component in the oil phase
@@ -218,10 +245,10 @@ public:
      * will be thrown...
      */
     template <class Evaluation>
-    Evaluation saturatedOilGasMassFraction(unsigned regionIdx,
-                                           const Evaluation& temperature,
-                                           const Evaluation& pressure) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilGasMassFraction(regionIdx, temperature, pressure)); return 0; }
+    Evaluation saturatedGasMassFraction(unsigned regionIdx,
+                                        const Evaluation& temperature,
+                                        const Evaluation& pressure) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasMassFraction(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the gas mole fraction of gas-saturated oil at a given temperatire
@@ -231,10 +258,10 @@ public:
      * will be thrown...
      */
     template <class Evaluation>
-    Evaluation saturatedOilGasMoleFraction(unsigned regionIdx,
-                                           const Evaluation& temperature,
-                                           const Evaluation& pressure) const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilGasMoleFraction(regionIdx, temperature, pressure)); return 0; }
+    Evaluation saturatedGasMoleFraction(unsigned regionIdx,
+                                        const Evaluation& temperature,
+                                        const Evaluation& pressure) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasMoleFraction(regionIdx, temperature, pressure)); return 0; }
 
     void setApproach(OilPvtApproach oilPvtApproach)
     {

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -96,18 +96,28 @@ public:
 
             auto& gasMu = gasMu_[regionIdx];
             auto& invGasB = inverseGasB_[regionIdx];
+            auto& invSatGasB = inverseSaturatedGasB_[regionIdx];
+            auto& invSatGasBMu = inverseSaturatedGasBMu_[regionIdx];
             auto& oilVaporizationFac = oilVaporizationFactorTable_[regionIdx];
 
             oilVaporizationFac.setXYArrays(saturatedTable->numRows(),
-                                              saturatedTable->getPressureColumn(),
-                                              saturatedTable->getOilSolubilityColumn());
+                                           saturatedTable->getPressureColumn(),
+                                           saturatedTable->getOilSolubilityColumn());
+
+            std::vector<Scalar> invSatGasBArray;
+            std::vector<Scalar> invSatGasBMuArray;
 
             // extract the table for the gas dissolution and the oil formation volume factors
             for (size_t outerIdx = 0; outerIdx < saturatedTable->numRows(); ++ outerIdx) {
                 Scalar pg = saturatedTable->getPressureColumn()[outerIdx];
+                Scalar B = saturatedTable->getGasFormationFactorColumn()[outerIdx];
+                Scalar mu = saturatedTable->getGasViscosityColumn()[outerIdx];
 
                 invGasB.appendXPos(pg);
                 gasMu.appendXPos(pg);
+
+                invSatGasBArray.push_back(1.0/B);
+                invSatGasBMuArray.push_back(1.0/(mu*B));
 
                 assert(invGasB.numX() == outerIdx + 1);
                 assert(gasMu.numX() == outerIdx + 1);
@@ -124,7 +134,10 @@ public:
                 }
             }
 
-            // make sure to have at least two sample points per mole fraction
+            invSatGasB.setXYContainers(saturatedTable->getPressureColumn(), invSatGasBArray);
+            invSatGasBMu.setXYContainers(saturatedTable->getPressureColumn(), invSatGasBMuArray);
+
+            // make sure to have at least two sample points per R_v value
             for (size_t xIdx = 0; xIdx < invGasB.numX(); ++xIdx) {
                 // a single sample point is definitely needed
                 assert(invGasB.numY(xIdx) > 0);
@@ -188,6 +201,8 @@ public:
         gasReferenceDensity_.resize(numRegions);
         inverseGasB_.resize(numRegions);
         inverseGasBMu_.resize(numRegions);
+        inverseSaturatedGasB_.resize(numRegions);
+        inverseSaturatedGasBMu_.resize(numRegions);
         gasMu_.resize(numRegions);
         oilVaporizationFactorTable_.resize(numRegions);
         saturationPressureSpline_.resize(numRegions);
@@ -362,19 +377,31 @@ public:
             assert(gasMu.numX() == invGasB.numX());
 
             auto& invGasBMu = inverseGasBMu_[regionIdx];
+            auto& invSatGasB = inverseSaturatedGasB_[regionIdx];
+            auto& invSatGasBMu = inverseSaturatedGasBMu_[regionIdx];
 
+            std::vector<Scalar> satPressuresArray;
+            std::vector<Scalar> invSatGasBArray;
+            std::vector<Scalar> invSatGasBMuArray;
             for (size_t pIdx = 0; pIdx < gasMu.numX(); ++pIdx) {
                 invGasBMu.appendXPos(gasMu.xAt(pIdx));
 
                 assert(gasMu.numY(pIdx) == invGasB.numY(pIdx));
 
-                size_t numPressures = gasMu.numY(pIdx);
-                for (size_t rvIdx = 0; rvIdx < numPressures; ++rvIdx)
+                satPressuresArray.push_back(gasMu.xAt(pIdx));
+                invSatGasBArray.push_back(invGasB.valueAt(pIdx, 0));
+                invSatGasBMuArray.push_back(invGasB.valueAt(pIdx, 0)*1.0/gasMu.xAt(pIdx));
+
+                size_t numRv = gasMu.numY(pIdx);
+                for (size_t rvIdx = 0; rvIdx < numRv; ++rvIdx)
                     invGasBMu.appendSamplePoint(pIdx,
                                                 gasMu.yAt(pIdx, rvIdx),
                                                 invGasB.valueAt(pIdx, rvIdx)*
                                                 1/gasMu.valueAt(pIdx, rvIdx));
             }
+
+            invSatGasB.setXYContainers(satPressuresArray, invSatGasBArray);
+            invSatGasBMu.setXYContainers(satPressuresArray, invSatGasBMuArray);
 
             updateSaturationPressureSpline_(regionIdx);
         }
@@ -396,6 +423,20 @@ public:
     }
 
     /*!
+     * \brief Returns the dynamic viscosity [Pa s] of oil saturated gas at a given pressure.
+     */
+    template <class Evaluation>
+    Evaluation saturatedViscosity(unsigned regionIdx,
+                                  const Evaluation& /*temperature*/,
+                                  const Evaluation& pressure) const
+    {
+        const Evaluation& invBg = inverseSaturatedGasB_[regionIdx].eval(pressure, /*extrapolate=*/true);
+        const Evaluation& invMugBg = inverseSaturatedGasBMu_[regionIdx].eval(pressure, /*extrapolate=*/true);
+
+        return invBg/invMugBg;
+    }
+
+    /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
      */
     template <class Evaluation>
@@ -406,13 +447,36 @@ public:
     {
         const Evaluation& Bg = formationVolumeFactor(regionIdx, temperature, pressure, Rv);
 
+        Scalar rhooRef = oilReferenceDensity_[regionIdx];
         Scalar rhogRef = gasReferenceDensity_[regionIdx];
         Evaluation rhog = rhogRef/Bg;
 
         // the oil formation volume factor just represents the partial density of the gas
         // component in the gas phase. to get the total density of the phase, we have to
         // add the partial density of the oil component.
-        rhog += (rhogRef*Rv)/Bg;
+        rhog += (rhooRef*Rv)/Bg;
+
+        return rhog;
+    }
+
+    /*!
+     * \brief Returns the density [kg/m^3] of oil saturated gas at a given pressure.
+     */
+    template <class Evaluation>
+    Evaluation saturatedDensity(unsigned regionIdx,
+                                const Evaluation& temperature,
+                                const Evaluation& pressure) const
+    {
+        Scalar rhooRef = oilReferenceDensity_[regionIdx];
+        Scalar rhogRef = gasReferenceDensity_[regionIdx];
+        Valgrind::CheckDefined(rhooRef);
+        Valgrind::CheckDefined(rhogRef);
+
+        const Evaluation& Bg = saturatedFormationVolumeFactor(regionIdx, temperature, pressure);
+
+        Evaluation rhog = rhogRef/Bg;
+        const Evaluation& RvSat = oilVaporizationFactor(regionIdx, temperature, pressure);
+        rhog += (rhooRef*RvSat)/Bg;
 
         return rhog;
     }
@@ -426,6 +490,15 @@ public:
                                      const Evaluation& pressure,
                                      const Evaluation& Rv) const
     { return 1.0 / inverseGasB_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true); }
+
+    /*!
+     * \brief Returns the formation volume factor [-] of oil saturated gas at a given pressure.
+     */
+    template <class Evaluation>
+    Evaluation saturatedFormationVolumeFactor(unsigned regionIdx,
+                                              const Evaluation& /*temperature*/,
+                                              const Evaluation& pressure) const
+    { return 1.0 / inverseSaturatedGasB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
      * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
@@ -450,7 +523,7 @@ public:
         //
         // first, retrieve the mole fraction of gas a saturated oil would exhibit at the
         // given pressure
-        const Evaluation& x_gOSat = saturatedGasOilMoleFraction(regionIdx, temperature, pressure);
+        const Evaluation& x_gOSat = saturatedOilMoleFraction(regionIdx, temperature, pressure);
 
         // then, scale the oil component's gas phase fugacity coefficient, so that the
         // gas phase ends up at the right composition if we were doing a flash experiment
@@ -513,9 +586,9 @@ public:
     }
 
     template <class Evaluation>
-    Evaluation saturatedGasOilMassFraction(unsigned regionIdx,
-                                           const Evaluation& temperature,
-                                           const Evaluation& pressure) const
+    Evaluation saturatedOilMassFraction(unsigned regionIdx,
+                                        const Evaluation& temperature,
+                                        const Evaluation& pressure) const
     {
         Scalar rho_gRef = gasReferenceDensity_[regionIdx];
         Scalar rho_oRef = oilReferenceDensity_[regionIdx];
@@ -532,12 +605,12 @@ public:
     }
 
     template <class Evaluation>
-    Evaluation saturatedGasOilMoleFraction(unsigned regionIdx,
-                                           const Evaluation& temperature,
-                                           const Evaluation& pressure) const
+    Evaluation saturatedOilMoleFraction(unsigned regionIdx,
+                                        const Evaluation& temperature,
+                                        const Evaluation& pressure) const
     {
         // calculate the mass fractions of gas and oil
-        const Evaluation& Rv = saturatedGasOilMassFraction(regionIdx, temperature, pressure);
+        const Evaluation& Rv = saturatedOilMassFraction(regionIdx, temperature, pressure);
 
         // which can be converted to mole fractions, given the
         // components' molar masses
@@ -578,8 +651,10 @@ private:
     std::vector<Scalar> gasReferenceDensity_;
     std::vector<Scalar> oilReferenceDensity_;
     std::vector<TabulatedTwoDFunction> inverseGasB_;
+    std::vector<TabulatedOneDFunction> inverseSaturatedGasB_;
     std::vector<TabulatedTwoDFunction> gasMu_;
     std::vector<TabulatedTwoDFunction> inverseGasBMu_;
+    std::vector<TabulatedOneDFunction> inverseSaturatedGasBMu_;
     std::vector<TabulatedOneDFunction> oilVaporizationFactorTable_;
     std::vector<Spline> saturationPressureSpline_;
 };

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -42,6 +42,9 @@
 #include <opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp>
 #include <opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp>
 
+#include <opm/material/localad/Evaluation.hpp>
+#include <opm/material/localad/Math.hpp>
+
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
@@ -123,6 +126,119 @@ static const char* deckString1 =
     "              1.1e-3       2.25    2.015 /\n"
     "/\n"
     "\n";
+
+template <class Evaluation, class OilPvt, class GasPvt, class WaterPvt>
+void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& waterPvt)
+{
+    // we don't want to run this, we just want to make sure that it compiles
+    while (0) {
+        Evaluation temperature = 273.15 + 20.0;
+        Evaluation pressure = 1e5;
+        Evaluation Rs = 0.0;
+        Evaluation Rv = 0.0;
+        Evaluation OPM_UNUSED tmp;
+
+        /////
+        // water PVT API
+        /////
+        tmp = waterPvt.viscosity(/*regionIdx=*/0,
+                                 temperature,
+                                 pressure);
+        tmp = waterPvt.density(/*regionIdx=*/0,
+                               temperature,
+                               pressure);
+        tmp = waterPvt.fugacityCoefficientOil(/*regionIdx=*/0,
+                                              temperature,
+                                              pressure);
+        tmp = waterPvt.fugacityCoefficientGas(/*regionIdx=*/0,
+                                              temperature,
+                                              pressure);
+        tmp = waterPvt.fugacityCoefficientWater(/*regionIdx=*/0,
+                                                temperature,
+                                                pressure);
+
+        /////
+        // oil PVT API
+        /////
+        tmp = oilPvt.viscosity(/*regionIdx=*/0,
+                               temperature,
+                               pressure,
+                               Rs);
+        tmp = oilPvt.density(/*regionIdx=*/0,
+                             temperature,
+                             pressure,
+                             Rs);
+        tmp = oilPvt.formationVolumeFactor(/*regionIdx=*/0,
+                                           temperature,
+                                           pressure,
+                                           Rs);
+        tmp = oilPvt.saturatedViscosity(/*regionIdx=*/0,
+                                        temperature,
+                                        pressure);
+        tmp = oilPvt.saturatedDensity(/*regionIdx=*/0,
+                                      temperature,
+                                      pressure);
+        tmp = oilPvt.saturatedFormationVolumeFactor(/*regionIdx=*/0,
+                                                    temperature,
+                                                    pressure);
+        tmp = oilPvt.saturatedGasMassFraction(/*regionIdx=*/0,
+                                              temperature,
+                                              pressure);
+        tmp = oilPvt.saturatedGasMoleFraction(/*regionIdx=*/0,
+                                              temperature,
+                                              pressure);
+        tmp = oilPvt.fugacityCoefficientOil(/*regionIdx=*/0,
+                                            temperature,
+                                            pressure);
+        tmp = oilPvt.fugacityCoefficientGas(/*regionIdx=*/0,
+                                            temperature,
+                                            pressure);
+        tmp = oilPvt.fugacityCoefficientWater(/*regionIdx=*/0,
+                                              temperature,
+                                              pressure);
+
+        /////
+        // gas PVT API
+        /////
+        tmp = gasPvt.viscosity(/*regionIdx=*/0,
+                               temperature,
+                               pressure,
+                               Rv);
+        tmp = gasPvt.density(/*regionIdx=*/0,
+                             temperature,
+                             pressure,
+                             Rv);
+        tmp = gasPvt.saturatedViscosity(/*regionIdx=*/0,
+                                        temperature,
+                                        pressure);
+        tmp = gasPvt.saturatedDensity(/*regionIdx=*/0,
+                                      temperature,
+                                      pressure);
+        tmp = gasPvt.saturatedFormationVolumeFactor(/*regionIdx=*/0,
+                                                    temperature,
+                                                    pressure);
+        tmp = gasPvt.formationVolumeFactor(/*regionIdx=*/0,
+                                           temperature,
+                                           pressure,
+                                           Rv);
+        tmp = gasPvt.saturatedOilMassFraction(/*regionIdx=*/0,
+                                              temperature,
+                                              pressure);
+        tmp = gasPvt.saturatedOilMoleFraction(/*regionIdx=*/0,
+                                              temperature,
+                                              pressure);
+
+        tmp = gasPvt.fugacityCoefficientOil(/*regionIdx=*/0,
+                                            temperature,
+                                            pressure);
+        tmp = gasPvt.fugacityCoefficientGas(/*regionIdx=*/0,
+                                            temperature,
+                                            pressure);
+        tmp = gasPvt.fugacityCoefficientWater(/*regionIdx=*/0,
+                                              temperature,
+                                              pressure);
+    }
+}
 
 int main()
 {
@@ -206,6 +322,11 @@ int main()
     gasPvt.initEnd(&oilPvt);
     oilPvt.initEnd(&gasPvt);
     waterPvt.initEnd();
+
+    struct Foo;
+    typedef Opm::LocalAd::Evaluation<Scalar, Foo, 1> FooEval;
+    ensurePvtApi<Scalar>(oilPvt, gasPvt, waterPvt);
+    ensurePvtApi<FooEval>(oilPvt, gasPvt, waterPvt);
 
     // make sure that the BlackOil fluid system's initFromDeck() method compiles.
     typedef Opm::FluidSystems::BlackOil<Scalar> BlackOilFluidSystem;


### PR DESCRIPTION
this hopefully lifts the features provided by the black-oil PVT classes of opm-material to a superset of those of the PVT classes of opm-core. It is thus required to be able to replace the opm-core PVT classes by the ones of opm-material. Note that since opm-core currently ships its own PVT classes, the `flow*` simulators are not affected by this PR in any way. (it is thus a good time for requests to change the API of the PVT classes.)