### PR TITLE
Blackoil api refactor

### DIFF
--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -252,12 +252,6 @@ public:
     { this->setContainerOfPoints(points, m0, m1, sortInputs); }
 
     /*!
-     * \brief Returns the number of sampling points.
-     */
-    size_t numSamples() const
-    { return xPos_.size(); }
-
-    /*!
      * \brief Set the sampling points and the boundary slopes of the
      *        spline with two sampling points.
      *
@@ -717,29 +711,24 @@ public:
         return x_(0) <= x && x <= x_(numSamples() - 1);
     }
 
-    /*!
-     * \brief Return the x value of the leftmost sampling point.
-     */
-    Scalar xMin() const
-    { return x_(0); }
 
     /*!
-     * \brief Return the x value of the rightmost sampling point.
+     * \brief Return the number of (x, y) values.
      */
-    Scalar xMax() const
-    { return x_(numSamples() - 1); }
+    size_t numSamples() const
+    { return xPos_.size(); }
 
     /*!
-     * \brief Return the y value of the leftmost sampling point.
+     * \brief Return the x value of a given sampling point.
      */
-    Scalar yFirst() const
-    { return y_(0); }
+    Scalar xAt(int sampleIdx) const
+    { return x_(sampleIdx); }
 
     /*!
-     * \brief Return the y value of the rightmost sampling point.
+     * \brief Return the x value of a given sampling point.
      */
-    Scalar yLast() const
-    { return y_(numSamples() - 1); }
+    Scalar valueAt(int sampleIdx) const
+    { return y_(sampleIdx); }
 
     /*!
      * \brief Prints k tuples of the format (x, y, dx/dy, isMonotonic)
@@ -812,15 +801,15 @@ public:
 
         // handle extrapolation
         if (extrapolate) {
-            if (x < xMin()) {
-                Scalar m = evalDerivative_(xMin(), /*segmentIdx=*/0);
+            if (x < xAt(0)) {
+                Scalar m = evalDerivative_(xAt(0), /*segmentIdx=*/0);
                 Scalar y0 = y_(0);
-                return y0 + m*(x - xMin());
+                return y0 + m*(x - xAt(0));
             }
-            else if (x > xMax()) {
-                Scalar m = evalDerivative_(xMax(), /*segmentIdx=*/numSamples()-2);
+            else if (x > xAt(numSamples() - 1)) {
+                Scalar m = evalDerivative_(xAt(numSamples() - 1), /*segmentIdx=*/numSamples()-2);
                 Scalar y0 = y_(numSamples() - 1);
-                return y0 + m*(x - xMax());
+                return y0 + m*(x - xAt(numSamples() - 1));
             }
         }
 
@@ -845,15 +834,15 @@ public:
 
         // handle extrapolation
         if (extrapolate) {
-            if (x.value < xMin()) {
-                Scalar m = evalDerivative_(xMin(), /*segmentIdx=*/0);
+            if (x.value < xAt(0)) {
+                Scalar m = evalDerivative_(xAt(0), /*segmentIdx=*/0);
                 Scalar y0 = y_(0);
-                return Evaluation::createConstant(y0 + m*(x.value - xMin()));
+                return Evaluation::createConstant(y0 + m*(x.value - xAt(0)));
             }
-            else if (x > xMax()) {
-                Scalar m = evalDerivative_(xMax(), /*segmentIdx=*/numSamples()-2);
+            else if (x > xAt(numSamples() - 1)) {
+                Scalar m = evalDerivative_(xAt(numSamples() - 1), /*segmentIdx=*/numSamples()-2);
                 Scalar y0 = y_(numSamples() - 1);
-                return Evaluation::createConstant(y0 + m*(x.value - xMax()));
+                return Evaluation::createConstant(y0 + m*(x.value - xAt(numSamples() - 1)));
             }
         }
 
@@ -876,10 +865,10 @@ public:
     {
         assert(extrapolate || applies(x));
         if (extrapolate) {
-            if (x < xMin())
-                return evalDerivative_(xMin(), /*segmentIdx=*/0);
-            else if (x > xMax())
-                return evalDerivative_(xMax(), /*segmentIdx=*/numSamples() - 2);
+            if (x < xAt(0))
+                return evalDerivative_(xAt(0), /*segmentIdx=*/0);
+            else if (x > xAt(numSamples() - 1))
+                return evalDerivative_(xAt(numSamples() - 1), /*segmentIdx=*/numSamples() - 2);
         }
 
         return evalDerivative_(x, segmentIdx_(x));
@@ -939,7 +928,7 @@ public:
                          const Evaluation& c,
                          const Evaluation& d) const
     {
-        return intersectInterval(xMin(), xMax(), a, b, c, d);
+        return intersectInterval(xAt(0), xAt(numSamples() - 1), a, b, c, d);
     }
 
     /*!
@@ -1000,12 +989,12 @@ public:
         assert(x0 < x1);
 
         int r = 3;
-        if (x0 < xMin()) {
+        if (x0 < xAt(0)) {
             assert(extrapolate);
-            Scalar m = evalDerivative_(xMin(), /*segmentIdx=*/0);
+            Scalar m = evalDerivative_(xAt(0), /*segmentIdx=*/0);
             if (std::abs(m) < 1e-20)
                 r = (m < 0)?-1:1;
-            x0 = xMin();
+            x0 = xAt(0);
         };
 
         size_t i = segmentIdx_(x0);
@@ -1033,10 +1022,10 @@ public:
         // if the user asked for a part of the spline which is
         // extrapolated, we need to check the slope at the spline's
         // endpoint
-        if (x1 > xMax()) {
+        if (x1 > xAt(numSamples() - 1)) {
             assert(extrapolate);
 
-            Scalar m = evalDerivative_(xMax(), /*segmentIdx=*/numSamples() - 2);
+            Scalar m = evalDerivative_(xAt(numSamples() - 1), /*segmentIdx=*/numSamples() - 2);
             if (m < 0)
                 return (r < 0 || r==3)?-1:0;
             else if (m > 0)
@@ -1056,7 +1045,7 @@ public:
      *        spline as interval.
      */
     int monotonic() const
-    { return monotonic(xMin(), xMax()); }
+    { return monotonic(xAt(0), xAt(numSamples() - 1)); }
 
 protected:
     /*!

--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -1196,16 +1196,16 @@ protected:
                                DestVector &destY,
                                const SourceVector &srcX,
                                const SourceVector &srcY,
-                               int numSamples)
+                               int nSamples)
     {
-        assert(numSamples >= 2);
+        assert(nSamples >= 2);
 
         // copy sample points, make sure that the first x value is
         // smaller than the last one
-        for (int i = 0; i < numSamples; ++i) {
+        for (int i = 0; i < nSamples; ++i) {
             int idx = i;
-            if (srcX[0] > srcX[numSamples - 1])
-                idx = numSamples - i - 1;
+            if (srcX[0] > srcX[nSamples - 1])
+                idx = nSamples - i - 1;
             destX[i] = srcX[idx];
             destY[i] = srcY[idx];
         }
@@ -1216,9 +1216,9 @@ protected:
                               DestVector &destY,
                               const ListIterator &srcBegin,
                               const ListIterator &srcEnd,
-                              int numSamples)
+                              int nSamples)
     {
-        assert(numSamples >= 2);
+        assert(nSamples >= 2);
 
         // find out wether the x values are in reverse order
         ListIterator it = srcBegin;
@@ -1232,7 +1232,7 @@ protected:
         for (int i = 0; it != srcEnd; ++i, ++it) {
             int idx = i;
             if (reverse)
-                idx = numSamples - i - 1;
+                idx = nSamples - i - 1;
             destX[i] = (*it)[0];
             destY[i] = (*it)[1];
         }
@@ -1250,9 +1250,9 @@ protected:
                               DestVector &destY,
                               ListIterator srcBegin,
                               ListIterator srcEnd,
-                              int numSamples)
+                              int nSamples)
     {
-        assert(numSamples >= 2);
+        assert(nSamples >= 2);
 
         // copy sample points, make sure that the first x value is
         // smaller than the last one
@@ -1269,7 +1269,7 @@ protected:
         for (int i = 0; it != srcEnd; ++i, ++it) {
             int idx = i;
             if (reverse)
-                idx = numSamples - i - 1;
+                idx = nSamples - i - 1;
             destX[i] = std::get<0>(*it);
             destY[i] = std::get<1>(*it);
         }

--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -55,28 +55,28 @@ public:
       * \brief Constructor where the tabulation parameters are already
       *        provided.
       */
-    UniformTabulated2DFunction(Scalar xMin, Scalar xMax, unsigned m,
-                               Scalar yMin, Scalar yMax, unsigned n)
+    UniformTabulated2DFunction(Scalar minX, Scalar maxX, unsigned m,
+                               Scalar minY, Scalar maxY, unsigned n)
     {
-        resize(xMin, xMax, m, yMin, yMax, n);
+        resize(minX, maxX, m, minY, maxY, n);
     }
 
     /*!
      * \brief Resize the tabulation to a new range.
      */
-    void resize(Scalar xMin, Scalar xMax, unsigned m,
-                Scalar yMin, Scalar yMax, unsigned n)
+    void resize(Scalar minX, Scalar maxX, unsigned m,
+                Scalar minY, Scalar maxY, unsigned n)
     {
         samples_.resize(m*n);
 
         m_ = m;
         n_ = n;
 
-        xMin_ = xMin;
-        xMax_ = xMax;
+        xMin_ = minX;
+        xMax_ = maxX;
 
-        yMin_ = yMin;
-        yMax_ = yMax;
+        yMin_ = minY;
+        yMax_ = maxY;
     }
 
     /*!

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -85,8 +85,8 @@ public:
     /*!
      * \brief Returns the value of a sampling point.
      */
-    Scalar valueAt(int i, int j) const
-    { return std::get<2>(samples_[static_cast<unsigned>(i)][static_cast<unsigned>(j)]); }
+    Scalar valueAt(size_t i, size_t j) const
+    { return std::get<2>(samples_[i][j]); }
 
     /*!
      * \brief Returns the number of sampling points in X direction.
@@ -228,15 +228,15 @@ public:
         const auto &col2SamplePoints = samples_.at(unsigned(i));
         Scalar alpha = i - int(i);
 
-        Scalar yMin =
+        Scalar minY =
                 alpha*std::get<1>(col1SamplePoints.front()) +
                 (1 - alpha)*std::get<1>(col2SamplePoints.front());
 
-        Scalar yMax =
+        Scalar maxY =
                 alpha*std::get<1>(col1SamplePoints.back()) +
                 (1 - alpha)*std::get<1>(col2SamplePoints.back());
 
-        return yMin <= y && y <= yMax;
+        return minY <= y && y <= maxY;
     }
     /*!
      * \brief Evaluate the function at a given (x,y) position.
@@ -259,7 +259,9 @@ public:
         // bi-linear interpolation: first, calculate the x and y indices in the lookup
         // table ...
         Evaluation alpha = xToI(x, extrapolate);
-        int i = std::max(0, std::min<int>(numX() - 2, Toolbox::value(alpha)));
+        size_t i =
+            static_cast<size_t>(std::max(0, std::min(static_cast<int>(numX() - 2),
+                                                     static_cast<int>(Toolbox::value(alpha)))));
         alpha -= i;
 
         Evaluation beta1;
@@ -268,9 +270,11 @@ public:
         beta1 = yToJ(i, y, extrapolate);
         beta2 = yToJ(i + 1, y, extrapolate);
 
-        int j1 = std::max(0, std::min<int>(numY(i) - 2, Toolbox::value(beta1)));
-        int j2 = std::max(0, std::min<int>(numY(i + 1) - 2, Toolbox::value(beta2)));
-
+        size_t j1 = static_cast<size_t>(std::max(0, std::min(static_cast<int>(numY(i) - 2),
+                                                             static_cast<int>(Toolbox::value(beta1)))));
+        size_t j2 = static_cast<size_t>(std::max(0, std::min(static_cast<int>(numY(i + 1) - 2),
+                                                             static_cast<int>(Toolbox::value(beta2)))));
+        
         beta1 -= j1;
         beta2 -= j2;
 

--- a/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
+++ b/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
@@ -58,20 +58,20 @@ public:
     MMPCAuxConstraint()
     {}
 
-    MMPCAuxConstraint(unsigned phaseIdx, unsigned compIdx, Scalar value)
-        : phaseIdx_(phaseIdx)
-        , compIdx_(compIdx)
-        , value_(value)
+    MMPCAuxConstraint(unsigned phaseIndex, unsigned compIndex, Scalar val)
+        : phaseIdx_(phaseIndex)
+        , compIdx_(compIndex)
+        , value_(val)
     {}
 
     /*!
      * \brief Specify the auxiliary constraint.
      */
-    void set(unsigned phaseIdx, unsigned compIdx, Scalar value)
+    void set(unsigned phaseIndex, unsigned compIndex, Scalar val)
     {
-        phaseIdx_ = phaseIdx;
-        compIdx_ = compIdx;
-        value_ = value;
+        phaseIdx_ = phaseIndex;
+        compIdx_ = compIndex;
+        value_ = val;
     }
 
     /*!

--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -150,8 +150,7 @@ public:
 
         if (tolerance <= 0)
             tolerance = std::min<Scalar>(1e-5,
-                                         Opm::geometricMean(Scalar(1.0),
-                                                            1e5*std::numeric_limits<Scalar>::epsilon()));
+                                         1e8*std::numeric_limits<Scalar>::epsilon());
 
         /////////////////////////
         // Newton method
@@ -360,7 +359,7 @@ protected:
 
             // deviate the mole fraction of the i-th component
             const Evaluation& x_i = getQuantity_(fluidState, pvIdx);
-            const Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e7/(quantityWeight_(fluidState, pvIdx));
+            const Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e8/(quantityWeight_(fluidState, pvIdx));
 
             setQuantity_<MaterialLaw>(fluidState, paramCache, matParams, pvIdx, x_i + eps);
 
@@ -721,7 +720,7 @@ protected:
     {
         // first pressure
         if (pvIdx < 1)
-            return 1/1e5;
+            return 1/1e6;
         // first M - 1 saturations
         else if (pvIdx < numPhases)
             return 1.0;

--- a/opm/material/eos/PengRobinsonParamsMixture.hpp
+++ b/opm/material/eos/PengRobinsonParamsMixture.hpp
@@ -108,13 +108,13 @@ public:
             Scalar tmp = 1 + f_omega*(1 - std::sqrt(Tr));
             tmp = tmp*tmp;
 
-            Scalar a = 0.4572355*RTc*RTc/pc * tmp;
-            Scalar b = 0.0777961 * RTc / pc;
-            assert(std::isfinite(a));
-            assert(std::isfinite(b));
+            Scalar newA = 0.4572355*RTc*RTc/pc * tmp;
+            Scalar newB = 0.0777961 * RTc / pc;
+            assert(std::isfinite(newA));
+            assert(std::isfinite(newB));
 
-            this->pureParams_[i].setA(a);
-            this->pureParams_[i].setB(b);
+            this->pureParams_[i].setA(newA);
+            this->pureParams_[i].setB(newB);
             Valgrind::CheckDefined(this->pureParams_[i].a());
             Valgrind::CheckDefined(this->pureParams_[i].b());
         }
@@ -141,8 +141,8 @@ public:
         //
         // See: R. Reid, et al.: The Properties of Gases and Liquids,
         // 4th edition, McGraw-Hill, 1987, p. 82
-        Scalar a = 0;
-        Scalar b = 0;
+        Scalar newA = 0;
+        Scalar newB = 0;
         for (unsigned compIIdx = 0; compIIdx < numComponents; ++compIIdx) {
             Scalar xi = std::max(0.0, std::min(1.0, fs.moleFraction(phaseIdx, compIIdx)));
             Valgrind::CheckDefined(xi);
@@ -152,19 +152,19 @@ public:
                 Valgrind::CheckDefined(xj);
 
                 // mixing rule from Reid, page 82
-                a +=  xi * xj * aCache_[compIIdx][compJIdx];
+                newA +=  xi * xj * aCache_[compIIdx][compJIdx];
 
-                assert(std::isfinite(a));
+                assert(std::isfinite(newA));
             }
 
             // mixing rule from Reid, page 82
-            b += std::max(0.0, xi) * this->pureParams_[compIIdx].b();
-            assert(std::isfinite(b));
+            newB += std::max(0.0, xi) * this->pureParams_[compIIdx].b();
+            assert(std::isfinite(newB));
         }
 
-        // assert(b > 0);
-        this->setA(a);
-        this->setB(b);
+        // assert(newB > 0);
+        this->setA(newA);
+        this->setB(newB);
 
         Valgrind::CheckDefined(this->a());
         Valgrind::CheckDefined(this->b());

--- a/opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
+++ b/opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
@@ -56,8 +56,8 @@ public:
 #endif
     }
 
-    BrooksCoreyParams(Scalar entryPressure, Scalar lambda)
-        : entryPressure_(entryPressure), lambda_(lambda)
+    BrooksCoreyParams(Scalar ePressure, Scalar shapeParam)
+        : entryPressure_(ePressure), lambda_(shapeParam)
     {
         finalize();
     }

--- a/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
+++ b/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
@@ -73,21 +73,21 @@ public:
     }
 
 protected:
-    PLScanningCurve(PLScanningCurve *prev,
-                    PLScanningCurve *next,
+    PLScanningCurve(PLScanningCurve *prevSC,
+                    PLScanningCurve *nextSC,
                     int loopN,
-                    Scalar Sw,
-                    Scalar pcnw,
-                    Scalar SwMic,
-                    Scalar SwMdc)
+                    Scalar SwReversal,
+                    Scalar pcnwReversal,
+                    Scalar SwMiCurve,
+                    Scalar SwMdCurve)
     {
-        prev_ = prev;
-        next_ = next;
+        prev_ = prevSC;
+        next_ = nextSC;
         loopNum_ = loopN;
-        Sw_ = Sw;
-        pcnw_ = pcnw;
-        SwMic_ = SwMic;
-        SwMdc_ = SwMdc;
+        Sw_ = SwReversal;
+        pcnw_ = pcnwReversal;
+        SwMic_ = SwMiCurve;
+        SwMdc_ = SwMdCurve;
     }
 
 public:
@@ -126,10 +126,10 @@ public:
      * curve already has a list of next curves, it is
      * deleted and thus forgotten.
      */
-    void setNext(Scalar Sw,
-                 Scalar pcnw,
-                 Scalar SwMic,
-                 Scalar SwMdc)
+    void setNext(Scalar SwReversal,
+                 Scalar pcnwReversal,
+                 Scalar SwMiCurve,
+                 Scalar SwMdCurve)
     {
         // if next_ is NULL, delete does nothing, so
         // this is valid!!
@@ -138,10 +138,10 @@ public:
         next_ = new PLScanningCurve(this, // prev
                                     NULL, // next
                                     loopNum() + 1,
-                                    Sw,
-                                    pcnw,
-                                    SwMic,
-                                    SwMdc);
+                                    SwReversal,
+                                    pcnwReversal,
+                                    SwMiCurve,
+                                    SwMdCurve);
     }
 
     /*!
@@ -150,20 +150,20 @@ public:
      *        whether Swei is part of the curve's
      *        domain and the curve thus applies to Swi.
      */
-    bool isValidAt_Sw(Scalar Sw)
+    bool isValidAt_Sw(Scalar SwReversal)
     {
         if (isImbib())
             // for inbibition the given saturation
             // must be between the start of the
             // current imbibition and the the start
             // of the last drainage
-            return this->Sw() < Sw && Sw < prev_->Sw();
+            return this->Sw() < SwReversal && SwReversal < prev_->Sw();
         else
             // for drainage the given saturation
             // must be between the start of the
             // last imbibition and the start
             // of the current drainage
-            return prev_->Sw() < Sw && Sw < this->Sw();
+            return prev_->Sw() < SwReversal && SwReversal < this->Sw();
     }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
@@ -139,12 +139,13 @@ public:
     static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
     {
         // this assumes that the capillary pressure is monotonically decreasing
-        if (Sw <= params.pcnwSpline().xMin())
-            return Evaluation(params.pcnwSpline().yFirst());
-        if (Sw >= params.pcnwSpline().xMax())
-            return Evaluation(params.pcnwSpline().yLast());
+        const auto& pcnwSpline = params.pcnwSpline();
+        if (Sw <= pcnwSpline.xAt(0))
+            return Evaluation(pcnwSpline.valueAt(0));
+        if (Sw >= pcnwSpline.xAt(pcnwSpline.numSamples() - 1))
+            return Evaluation(pcnwSpline.valueAt(pcnwSpline.numSamples() - 1));
 
-        return params.pcnwSpline().eval(Sw);
+        return pcnwSpline.eval(Sw);
     }
 
     template <class Evaluation>
@@ -153,14 +154,15 @@ public:
         static const Evaluation nil(0.0);
 
         // this assumes that the capillary pressure is monotonically decreasing
-        if (pcnw >= params.pcnwSpline().yFirst())
-            return Evaluation(params.pcnwSpline().xMin());
-        if (pcnw <= params.pcnwSpline().yLast())
-            return Evaluation(params.pcnwSpline().xMax());
+        const auto& pcnwSpline = params.pcnwSpline();
+        if (pcnw >= pcnwSpline.valueAt(0))
+            return Evaluation(pcnwSpline.xAt(0));
+        if (pcnw <= pcnwSpline.y(pcnwSpline.numSamples() - 1))
+            return Evaluation(pcnwSpline.xAt(pcnwSpline.numSamples() - 1));
 
         // the intersect() method of splines is a bit slow, but this code path is not too
         // time critical...
-        return params.pcnwSpline().intersect(/*a=*/nil, /*b=*/nil, /*c=*/nil, /*d=*/pcnw);
+        return pcnwSpline.intersect(/*a=*/nil, /*b=*/nil, /*c=*/nil, /*d=*/pcnw);
     }
 
     /*!
@@ -204,12 +206,13 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
     {
-        if (Sw <= params.krnSpline().xMin())
-            return Evaluation(params.krwSpline().yFirst());
-        if (Sw >= params.krnSpline().xMax())
-            return Evaluation(params.krwSpline().yLast());
+        const auto& krwSpline = params.krwSpline();
+        if (Sw <= krwSpline.xAt(0))
+            return Evaluation(krwSpline.valueAt(0));
+        if (Sw >= krwSpline.xAt(krwSpline.numSamples() - 1))
+            return Evaluation(krwSpline.valueAt(krwSpline.numSamples() - 1));
 
-        return params.krwSpline().eval(Sw);
+        return krwSpline.eval(Sw);
     }
 
     template <class Evaluation>
@@ -217,12 +220,13 @@ public:
     {
         static const Evaluation nil(0.0);
 
-        if (krw <= params.krwSpline().yFirst())
-            return Evaluation(params.krwSpline().xMin());
-        if (krw >= params.krwSpline().yLast())
-            return Evaluation(params.krwSpline().xMax());
+        const auto& krwSpline = params.krwSpline();
+        if (krw <= krwSpline.valueAt(0))
+            return Evaluation(krwSpline.xAt(0));
+        if (krw >= krwSpline.valueAt(krwSpline.numSamples() - 1))
+            return Evaluation(krwSpline.xAt(krwSpline.numSamples() - 1));
 
-        return params.krwSpline().intersect(/*a=*/nil, /*b=*/nil, /*c=*/nil, /*d=*/krw);
+        return krwSpline.intersect(/*a=*/nil, /*b=*/nil, /*c=*/nil, /*d=*/krw);
     }
 
     /*!
@@ -243,12 +247,13 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
     {
-        if (Sw <= params.krnSpline().xMin())
-            return Evaluation(params.krnSpline().yFirst());
-        if (Sw >= params.krnSpline().xMax())
-            return Evaluation(params.krnSpline().yLast());
+        const auto& krnSpline = params.krnSpline();
+        if (Sw <= krnSpline.xAt(0))
+            return Evaluation(krnSpline.valueAt(0));
+        if (Sw >= krnSpline.xAt(krnSpline.numSamples() - 1))
+            return Evaluation(krnSpline.valueAt(krnSpline.numSamples() - 1));
 
-        return params.krnSpline().eval(Sw);
+        return krnSpline.eval(Sw);
     }
 
     template <class Evaluation>
@@ -256,12 +261,13 @@ public:
     {
         static const Evaluation nil(0.0);
 
-        if (krn >= params.krnSpline().yFirst())
-            return Evaluation(params.krnSpline().xMin());
-        if (krn <= params.krnSpline().yLast())
-            return Evaluation(params.krnSpline().xMax());
+        const auto& krnSpline = params.krnSpline();
+        if (krn >= krnSpline.valueAt(0))
+            return Evaluation(krnSpline.xAt(0));
+        if (krn <= krnSpline.valueAt(krnSpline.numSamples() - 1))
+            return Evaluation(krnSpline.xAt(krnSpline.numSamples() - 1));
 
-        return params.krnSpline().intersect(/*a=*/nil, /*b=*/nil, /*c=*/nil, /*d=*/krn);
+        return krnSpline.intersect(/*a=*/nil, /*b=*/nil, /*c=*/nil, /*d=*/krn);
     }
 };
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/VanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/VanGenuchtenParams.hpp
@@ -53,10 +53,10 @@ public:
 #endif
     }
 
-    VanGenuchtenParams(Scalar vgAlpha, Scalar vgN)
+    VanGenuchtenParams(Scalar alphaParam, Scalar nParam)
     {
-        setVgAlpha(vgAlpha);
-        setVgN(vgN);
+        setVgAlpha(alphaParam);
+        setVgN(nParam);
         finalize();
     }
 

--- a/opm/material/fluidsystems/BaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/BaseFluidSystem.hpp
@@ -39,10 +39,15 @@ namespace Opm {
  * \ingroup Fluidsystems
  * \brief The base class for all fluid systems.
  */
-template <class Scalar, class Implementation>
+template <class ScalarT, class Implementation>
 class BaseFluidSystem
 {
 public:
+    /*!
+     * \brief The type used for scalar quantities.
+     */
+    typedef ScalarT Scalar;
+
     /*!
      * \brief The type of the fluid system's parameter cache
      *

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -245,7 +245,7 @@ public:
     static const Scalar surfaceTemperature;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(const unsigned phaseIdx)
+    static const char *phaseName(unsigned phaseIdx)
     {
         static const char *name[] = { "water", "oil", "gas" };
 
@@ -254,7 +254,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::isLiquid
-    static bool isLiquid(const unsigned phaseIdx)
+    static bool isLiquid(unsigned phaseIdx)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
         return phaseIdx != gasPhaseIdx;
@@ -348,7 +348,7 @@ public:
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval density(const FluidState &fluidState,
                            ParameterCache &paramCache,
-                           const unsigned phaseIdx)
+                           unsigned phaseIdx)
     { return density<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -44,8 +44,8 @@
 namespace Opm {
 namespace FluidSystems {
 /*!
- * \brief A fluid system which uses the black-oil parameters
- *        to calculate termodynamically meaningful quantities.
+ * \brief A fluid system which uses the black-oil model assumptions to calculate
+ *        termodynamically meaningful quantities.
  *
  * \tparam Scalar The type used for scalar floating point values
  */
@@ -67,6 +67,9 @@ public:
         /*!
          * \brief Return the index of the region which should be used to determine the
          *        thermodynamic properties
+         *
+         * This is only required because "oil" and "gas" are pseudo-components, i.e. for
+         * more comprehensive equations of state there would only be one "region".
          */
         unsigned regionIndex() const
         { return regionIdx_; }
@@ -74,6 +77,9 @@ public:
         /*!
          * \brief Set the index of the region which should be used to determine the
          *        thermodynamic properties
+         *
+         * This is only required because "oil" and "gas" are pseudo-components, i.e. for
+         * more comprehensive equations of state there would only be one "region".
          */
         void setRegionIndex(unsigned val)
         { regionIdx_ = val; }
@@ -83,25 +89,8 @@ public:
     };
 
     /****************************************
-     * Fluid phase parameters
+     * Initialization
      ****************************************/
-
-    //! \copydoc BaseFluidSystem::numPhases
-    static const int numPhases = 3;
-
-    //! Index of the water phase
-    static const int waterPhaseIdx = 0;
-    //! Index of the oil phase
-    static const int oilPhaseIdx = 1;
-    //! Index of the gas phase
-    static const int gasPhaseIdx = 2;
-
-    //! The pressure at the surface
-    static const Scalar surfacePressure;
-
-    //! The temperature at the surface
-    static const Scalar surfaceTemperature;
-
 #if HAVE_OPM_PARSER
     /*!
      * \brief Initialize the fluid system using an ECL deck object
@@ -235,6 +224,26 @@ public:
         }
     }
 
+    /****************************************
+     * Generic phase properties
+     ****************************************/
+
+    //! \copydoc BaseFluidSystem::numPhases
+    static const int numPhases = 3;
+
+    //! Index of the water phase
+    static const int waterPhaseIdx = 0;
+    //! Index of the oil phase
+    static const int oilPhaseIdx = 1;
+    //! Index of the gas phase
+    static const int gasPhaseIdx = 2;
+
+    //! The pressure at the surface
+    static const Scalar surfacePressure;
+
+    //! The temperature at the surface
+    static const Scalar surfaceTemperature;
+
     //! \copydoc BaseFluidSystem::phaseName
     static const char *phaseName(const unsigned phaseIdx)
     {
@@ -252,7 +261,7 @@ public:
     }
 
     /****************************************
-     * Generic component related parameters
+     * Generic component related properties
      ****************************************/
 
     //! \copydoc BaseFluidSystem::numComponents
@@ -296,7 +305,7 @@ public:
 
 
     /****************************************
-     * black-oil specific parameters
+     * Black-oil specific properties
      ****************************************/
     /*!
      * \brief Returns the number of PVT regions which are considered.
@@ -333,7 +342,7 @@ public:
     { return referenceDensity_[regionIdx][phaseIdx]; }
 
     /****************************************
-     * thermodynamic relations (generic version, only isothermal)
+     * thermodynamic quantities (generic version, only isothermal)
      ****************************************/
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
@@ -359,8 +368,8 @@ public:
 
 
     /****************************************
-     * thermodynamic relations (black-oil specific version: Note that the parameter cache
-     * is not used and the PVT region index is explicitly passed as an argument.)
+     * thermodynamic quantities (black-oil specific version: Note that the PVT region
+     * index is explicitly passed instead of a parameter cache object)
      ****************************************/
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
@@ -784,7 +793,7 @@ public:
     }
 
     /****************************************
-     * auxiliary and convenience methods for the black-oil model
+     * Auxiliary and convenience methods for the black-oil model
      ****************************************/
     /*!
      * \brief Convert the mass fraction of the gas component in the oil phase to the

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -35,9 +35,6 @@
 #endif
 
 namespace Opm {
-template <class Scalar>
-class GasPvtMultiplexer;
-
 /*!
  * \brief This class represents the Pressure-Volume-Temperature relations of the oil phase
  *        without dissolved gas and constant compressibility/"viscosibility".
@@ -45,8 +42,6 @@ class GasPvtMultiplexer;
 template <class Scalar>
 class ConstantCompressibilityOilPvt
 {
-    typedef Opm::GasPvtMultiplexer<Scalar> GasPvtMultiplexer;
-
     typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
@@ -116,15 +111,6 @@ public:
     { oilReferenceDensity_[regionIdx] = rhoRefOil; }
 
     /*!
-     * \brief Initialize the reference densities of all fluids for a given PVT region
-     */
-    void setMolarMasses(unsigned /*regionIdx*/,
-                        Scalar /*MOil*/,
-                        Scalar /*MGas*/,
-                        Scalar /*MWater*/)
-    { }
-
-    /*!
      * \brief Set the viscosity and "viscosibility" of the oil phase.
      */
     void setViscosity(unsigned regionIdx, Scalar muo, Scalar oilViscosibility = 0.0)
@@ -160,7 +146,7 @@ public:
     /*!
      * \brief Finish initializing the oil phase PVT properties.
      */
-    void initEnd(const GasPvtMultiplexer */*gasPvt*/)
+    void initEnd()
     { }
 
     template <class Evaluation>
@@ -245,47 +231,12 @@ public:
     }
 
     /*!
-     * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
-     *        a set of parameters.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientOil(unsigned /*regionIdx*/,
-                                      const Evaluation& /*temperature*/,
-                                      const Evaluation& pressure) const
-    {
-        // set the oil component fugacity coefficient in oil phase
-        // arbitrarily. we use some pseudo-realistic value for the vapor
-        // pressure to ease physical interpretation of the results
-        return 20e3/pressure;
-    }
-
-    template <class Evaluation>
-    Evaluation fugacityCoefficientWater(unsigned regionIdx,
-                                        const Evaluation& temperature,
-                                        const Evaluation& pressure) const
-    {
-        // assume that the affinity of the water component to the oil phase is many orders
-        // of magnitude smaller than that of the oil component
-        return 1e8*fugacityCoefficientOil(regionIdx, temperature, pressure);
-    }
-
-    template <class Evaluation>
-    Evaluation fugacityCoefficientGas(unsigned regionIdx,
-                                      const Evaluation& temperature,
-                                      const Evaluation& pressure) const
-    {
-        // assume that the affinity of the gas component to the oil phase is many orders
-        // of magnitude smaller than that of the oil component
-        return 1.01e8*fugacityCoefficientOil(regionIdx, temperature, pressure);
-    }
-
-    /*!
      * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
      */
     template <class Evaluation>
-    Evaluation gasDissolutionFactor(unsigned /*regionIdx*/,
-                                    const Evaluation& /*temperature*/,
-                                    const Evaluation& /*pressure*/) const
+    Evaluation saturatedGasDissolutionFactor(unsigned /*regionIdx*/,
+                                             const Evaluation& /*temperature*/,
+                                             const Evaluation& /*pressure*/) const
     { return 0.0; /* this is dead oil! */ }
 
     /*!
@@ -299,18 +250,6 @@ public:
                                   const Evaluation& /*temperature*/,
                                   const Evaluation& /*Rs*/) const
     { return 0.0; /* this is dead oil, so there isn't any meaningful saturation pressure! */ }
-
-    template <class Evaluation>
-    Evaluation saturatedGasMassFraction(unsigned /*regionIdx*/,
-                                        const Evaluation& /*temperature*/,
-                                        const Evaluation& /*pressure*/) const
-    { return 0.0; /* this is dead oil! */ }
-
-    template <class Evaluation>
-    Evaluation saturatedGasMoleFraction(unsigned /*regionIdx*/,
-                                        const Evaluation& /*temperature*/,
-                                        const Evaluation& /*pressure*/) const
-    { return 0.0; /* this is dead oil! */ }
 
 private:
     std::vector<Scalar> oilReferenceDensity_;

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -150,7 +150,7 @@ public:
      */
     template <class Evaluation>
     Evaluation viscosity(unsigned regionIdx,
-                         const Evaluation& temperature,
+                         const Evaluation& /*temperature*/,
                          const Evaluation& pressure) const
     {
         // Eclipse calculates the viscosity in a weird way: it

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -34,7 +34,6 @@
 #include <vector>
 
 namespace Opm {
-
 /*!
  * \brief This class represents the Pressure-Volume-Temperature relations of the gas phase
  *        without vaporized oil.
@@ -196,60 +195,6 @@ public:
 
         // TODO (?): consider the salt concentration of the brine
         return BwRef/(1 + X*(1 + X/2));
-    }
-
-    /*!
-     * \brief Returns the fugacity coefficient [Pa] of the oil component in the water
-     *        phase given a set of parameters.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientOil(unsigned /*regionIdx*/,
-                                      const Evaluation& /*temperature*/,
-                                      const Evaluation& pressure) const
-    {
-        // set the affinity of the gas and oil components to the water phase to be 10
-        // orders of magnitude smaller than that of the water component. for this we use
-        // a pseudo-realistic vapor pressure of water as a starting point. (we just set
-        // it to 30 kPa to ease interpreting the results.)
-        const Scalar pvWater = 30e3;
-
-        return 1e10*pvWater / pressure;
-    }
-
-    /*!
-     * \brief Returns the fugacity coefficient [Pa] of the gas component in the water
-     *        phase given a set of parameters.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientGas(unsigned /*regionIdx*/,
-                                      const Evaluation& /*temperature*/,
-                                      const Evaluation& pressure) const
-    {
-        // set the affinity of the gas and oil components to the water phase to be 10
-        // orders of magnitude smaller than that of the water component. for this we use
-        // a pseudo-realistic vapor pressure of water as a starting point. (we just set
-        // it to 30 kPa to ease interpreting the results.)
-        const Scalar pvWater = 30e3;
-
-        return 1.01e10*pvWater / pressure;
-    }
-
-    /*!
-     * \brief Returns the fugacity coefficient [Pa] of the water component in the water
-     *        phase given a set of parameters.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientWater(unsigned /*regionIdx*/,
-                                        const Evaluation& /*temperature*/,
-                                        const Evaluation& pressure) const
-    {
-        // set the affinity of the gas and oil components to the water phase to be 10
-        // orders of magnitude smaller than that of the water component. for this we use
-        // a pseudo-realistic vapor pressure of water as a starting point. (we just set
-        // it to 30 kPa to ease interpreting the results.)
-        const Scalar pvWater = 30e3;
-
-        return pvWater / pressure;
     }
 
 private:

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -34,9 +34,6 @@
 #endif
 
 namespace Opm {
-template <class Scalar>
-class GasPvtMultiplexer;
-
 /*!
  * \brief This class represents the Pressure-Volume-Temperature relations of the oil phase
  *        without dissolved gas.
@@ -44,8 +41,6 @@ class GasPvtMultiplexer;
 template <class Scalar>
 class DeadOilPvt
 {
-    typedef Opm::GasPvtMultiplexer<Scalar> GasPvtMultiplexer;
-
     typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
@@ -131,7 +126,7 @@ public:
     /*!
      * \brief Finish initializing the oil phase PVT properties.
      */
-    void initEnd(const GasPvtMultiplexer */*gasPvt*/)
+    void initEnd()
     {
         // calculate the final 2D functions which are used for interpolation.
         size_t numRegions = oilMu_.size();
@@ -228,47 +223,12 @@ public:
     { return 1.0 / inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
-     * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
-     *        a set of parameters.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientOil(unsigned /*regionIdx*/,
-                                      const Evaluation& /*temperature*/,
-                                      const Evaluation& pressure) const
-    {
-        // set the oil component fugacity coefficient in oil phase
-        // arbitrarily. we use some pseudo-realistic value for the vapor
-        // pressure to ease physical interpretation of the results
-        return 20e3/pressure;
-    }
-
-    template <class Evaluation>
-    Evaluation fugacityCoefficientWater(unsigned regionIdx,
-                                        const Evaluation& temperature,
-                                        const Evaluation& pressure) const
-    {
-        // assume that the affinity of the water component to the
-        // oil phase is one million times smaller than that of the
-        // oil component
-        return 1e8*fugacityCoefficientOil(regionIdx, temperature, pressure);
-    }
-
-    template <class Evaluation>
-    Evaluation fugacityCoefficientGas(unsigned regionIdx,
-                                      const Evaluation& temperature,
-                                      const Evaluation& pressure) const
-    {
-        // gas is immiscible with dead oil as well...
-        return 1.01e8*fugacityCoefficientOil(regionIdx, temperature, pressure);
-    }
-
-    /*!
      * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
      */
     template <class Evaluation>
-    Evaluation gasDissolutionFactor(unsigned /*regionIdx*/,
-                                    const Evaluation& /*temperature*/,
-                                    const Evaluation& /*pressure*/) const
+    Evaluation saturatedGasDissolutionFactor(unsigned /*regionIdx*/,
+                                             const Evaluation& /*temperature*/,
+                                             const Evaluation& /*pressure*/) const
     { return 0.0; /* this is dead oil! */ }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -210,7 +210,7 @@ public:
     Evaluation density(unsigned regionIdx,
                        const Evaluation& temperature,
                        const Evaluation& pressure,
-                       const Evaluation& Rv) const
+                       const Evaluation& /*Rv*/) const
     { return saturatedDensity(regionIdx, temperature, pressure); }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -39,10 +39,6 @@
 #include <vector>
 
 namespace Opm {
-
-template <class Scalar>
-class OilPvtMultiplexer;
-
 /*!
  * \brief This class represents the Pressure-Volume-Temperature relations of the gas phase
  *        without vaporized oil.
@@ -50,7 +46,6 @@ class OilPvtMultiplexer;
 template <class Scalar>
 class DryGasPvt
 {
-    typedef Opm::OilPvtMultiplexer<Scalar> OilPvtMultiplexer;
     typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
@@ -162,10 +157,8 @@ public:
     /*!
      * \brief Finish initializing the oil phase PVT properties.
      */
-    void initEnd(const OilPvtMultiplexer *oilPvt)
+    void initEnd()
     {
-        oilPvt_ = oilPvt;
-
         // calculate the final 2D functions which are used for interpolation.
         size_t numRegions = gasMu_.size();
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
@@ -253,74 +246,27 @@ public:
     { return 1.0/inverseGasB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
-     * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
-     *        a set of parameters.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientGas(unsigned /*regionIdx*/,
-                                      const Evaluation& /*temperature*/,
-                                      const Evaluation& /*pressure*/) const
-    {
-        // make the gas component more affine to the gas phase than the other components
-        return 1.0;
-    }
-
-    /*!
-     * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
-     *        a set of parameters.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientOil(unsigned /*regionIdx*/,
-                                      const Evaluation& /*temperature*/,
-                                      const Evaluation& /*pressure*/) const
-    { return 1.0e6; }
-
-    /*!
-     * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
-     *        a set of parameters.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientWater(unsigned /*regionIdx*/,
-                                        const Evaluation& /*temperature*/,
-                                        const Evaluation& /*pressure*/) const
-    { return 1.1e6; }
-
-    /*!
      * \brief Returns the saturation pressure of the gas phase [Pa]
      *        depending on its mass fraction of the oil component
      *
      * \param Rv The surface volume of oil component dissolved in what will yield one cubic meter of gas at the surface [-]
      */
     template <class Evaluation>
-    Evaluation gasSaturationPressure(unsigned /*regionIdx*/,
-                                     const Evaluation& /*temperature*/,
-                                     const Evaluation& /*Rv*/) const
+    Evaluation saturationPressure(unsigned /*regionIdx*/,
+                                  const Evaluation& /*temperature*/,
+                                  const Evaluation& /*Rv*/) const
     { return 0.0; /* this is dry gas! */ }
 
     /*!
      * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
      */
     template <class Evaluation>
-    Evaluation oilVaporizationFactor(unsigned /*regionIdx*/,
-                                     const Evaluation& /*temperature*/,
-                                     const Evaluation& /*pressure*/) const
-    { return 0.0; /* this is dry gas! */ }
-
-    template <class Evaluation>
-    Evaluation saturatedOilMassFraction(unsigned /*regionIdx*/,
-                                        const Evaluation& /*temperature*/,
-                                        const Evaluation& /*pressure*/) const
-    { return 0.0; /* this is dry gas! */ }
-
-    template <class Evaluation>
-    Evaluation saturatedOilMoleFraction(unsigned /*regionIdx*/,
-                                        const Evaluation& /*temperature*/,
-                                        const Evaluation& /*pressure*/) const
+    Evaluation saturatedOilVaporizationFactor(unsigned /*regionIdx*/,
+                                              const Evaluation& /*temperature*/,
+                                              const Evaluation& /*pressure*/) const
     { return 0.0; /* this is dry gas! */ }
 
 private:
-    const OilPvtMultiplexer *oilPvt_;
-
     std::vector<Scalar> gasReferenceDensity_;
     std::vector<TabulatedOneDFunction> inverseGasB_;
     std::vector<TabulatedOneDFunction> gasMu_;

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -36,18 +36,15 @@
 #endif
 
 namespace Opm {
-template <class Scalar>
-class OilPvtMultiplexer;
-
 #define OPM_GAS_PVT_MULTIPLEXER_CALL(codeToCall)                        \
     switch (gasPvtApproach_) {                                          \
     case DryGasPvt: {                                                   \
-        auto &pvtImpl = getRealGasPvt<DryGasPvt>();                     \
+        auto &pvtImpl = getRealPvt<DryGasPvt>();                        \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
     case WetGasPvt: {                                                   \
-        auto &pvtImpl = getRealGasPvt<WetGasPvt>();                     \
+        auto &pvtImpl = getRealPvt<WetGasPvt>();                        \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
@@ -69,8 +66,6 @@ class OilPvtMultiplexer;
 template <class Scalar>
 class GasPvtMultiplexer
 {
-    typedef Opm::OilPvtMultiplexer<Scalar> OilPvtMultiplexer;
-
 public:
     enum GasPvtApproach {
         NoGasPvt,
@@ -87,11 +82,11 @@ public:
     {
         switch (gasPvtApproach_) {
         case DryGasPvt: {
-            delete &getRealGasPvt<DryGasPvt>();
+            delete &getRealPvt<DryGasPvt>();
             break;
         }
         case WetGasPvt: {
-            delete &getRealGasPvt<WetGasPvt>();
+            delete &getRealPvt<WetGasPvt>();
             break;
         }
         case NoGasPvt:
@@ -134,8 +129,8 @@ public:
         gasPvtApproach_ = gasPvtApproach;
     }
 
-    void initEnd(const OilPvtMultiplexer *oilPvt)
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(pvtImpl.initEnd(oilPvt)); }
+    void initEnd()
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(pvtImpl.initEnd()); }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
@@ -157,25 +152,6 @@ public:
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedViscosity(regionIdx, temperature, pressure)); return 0; }
 
     /*!
-     * \brief Returns the formation volume factor [-] of the fluid phase.
-     */
-    template <class Evaluation = Scalar>
-    Evaluation formationVolumeFactor(unsigned regionIdx,
-                                     const Evaluation& temperature,
-                                     const Evaluation& pressure,
-                                     const Evaluation& Rv) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, Rv)); return 0; }
-
-    /*!
-     * \brief Returns the formation volume factor [-] of oil saturated gas given a set of parameters.
-     */
-    template <class Evaluation = Scalar>
-    Evaluation saturatedFormationVolumeFactor(unsigned regionIdx,
-                                              const Evaluation& temperature,
-                                              const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedFormationVolumeFactor(regionIdx, temperature, pressure)); return 0; }
-
-    /*!
      * \brief Returns the density [kg/m^3] of the fluid phase given a set of parameters.
      */
     template <class Evaluation = Scalar>
@@ -195,35 +171,32 @@ public:
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedDensity(regionIdx, temperature, pressure)); return 0; }
 
     /*!
-     * \brief Returns the fugacity coefficient [Pa] of the gas component in the gas phase
-     *        given a set of parameters.
+     * \brief Returns the formation volume factor [-] of the fluid phase.
      */
     template <class Evaluation = Scalar>
-    Evaluation fugacityCoefficientGas(unsigned regionIdx,
-                                      const Evaluation& temperature,
-                                      const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientGas(regionIdx, temperature, pressure)); return 0; }
+    Evaluation formationVolumeFactor(unsigned regionIdx,
+                                     const Evaluation& temperature,
+                                     const Evaluation& pressure,
+                                     const Evaluation& Rv) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.formationVolumeFactor(regionIdx, temperature, pressure, Rv)); return 0; }
 
+    /*!
+     * \brief Returns the formation volume factor [-] of oil saturated gas given a set of parameters.
+     */
     template <class Evaluation = Scalar>
-    Evaluation fugacityCoefficientOil(unsigned regionIdx,
-                                      const Evaluation& temperature,
-                                      const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientOil(regionIdx, temperature, pressure)); return 0; }
-
-    template <class Evaluation = Scalar>
-    Evaluation fugacityCoefficientWater(unsigned regionIdx,
-                                        const Evaluation& temperature,
-                                        const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientWater(regionIdx, temperature, pressure)); return 0; }
+    Evaluation saturatedFormationVolumeFactor(unsigned regionIdx,
+                                              const Evaluation& temperature,
+                                              const Evaluation& pressure) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedFormationVolumeFactor(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of oil saturated gas.
      */
     template <class Evaluation = Scalar>
-    Evaluation oilVaporizationFactor(unsigned regionIdx,
-                                     const Evaluation& temperature,
-                                     const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.oilVaporizationFactor(regionIdx, temperature, pressure)); return 0; }
+    Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
+                                              const Evaluation& temperature,
+                                              const Evaluation& pressure) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilVaporizationFactor(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the saturation pressure of the gas phase [Pa]
@@ -232,45 +205,29 @@ public:
      * \param Rv The surface volume of oil component dissolved in what will yield one cubic meter of gas at the surface [-]
      */
     template <class Evaluation = Scalar>
-    Evaluation gasSaturationPressure(unsigned regionIdx,
-                                     const Evaluation& temperature,
-                                     const Evaluation& Rv) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.gasSaturationPressure(regionIdx, temperature, Rv)); return 0; }
+    Evaluation saturationPressure(unsigned regionIdx,
+                                  const Evaluation& temperature,
+                                  const Evaluation& Rv) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturationPressure(regionIdx, temperature, Rv)); return 0; }
 
     /*!
-     * \brief Returns the gas mass fraction of oil-saturated gas at a given temperatire
-     *        and pressure [-].
+     * \brief Returns the concrete approach for calculating the PVT relations.
+     *
+     * (This is only determined at runtime.)
      */
-    template <class Evaluation = Scalar>
-    Evaluation saturatedOilMassFraction(unsigned regionIdx,
-                                        const Evaluation& temperature,
-                                        const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilMassFraction(regionIdx, temperature, pressure)); return 0; }
-
-    /*!
-     * \brief Returns the gas mole fraction of oil-saturated gas at a given temperatire
-     *        and pressure [-].
-     */
-    template <class Evaluation = Scalar>
-    Evaluation saturatedOilMoleFraction(unsigned regionIdx,
-                                        const Evaluation& temperature,
-                                        const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilMoleFraction(regionIdx, temperature, pressure)); return 0; }
-
-
     GasPvtApproach gasPvtApproach() const
     { return gasPvtApproach_; }
 
     // get the parameter object for the dry gas case
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == DryGasPvt, Opm::DryGasPvt<Scalar> >::type& getRealGasPvt()
+    typename std::enable_if<approachV == DryGasPvt, Opm::DryGasPvt<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<Opm::DryGasPvt<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == DryGasPvt, const Opm::DryGasPvt<Scalar> >::type& getRealGasPvt() const
+    typename std::enable_if<approachV == DryGasPvt, const Opm::DryGasPvt<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<const Opm::DryGasPvt<Scalar>* >(realGasPvt_);
@@ -278,14 +235,14 @@ public:
 
     // get the parameter object for the wet gas case
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == WetGasPvt, Opm::WetGasPvt<Scalar> >::type& getRealGasPvt()
+    typename std::enable_if<approachV == WetGasPvt, Opm::WetGasPvt<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<Opm::WetGasPvt<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == WetGasPvt, const Opm::WetGasPvt<Scalar> >::type& getRealGasPvt() const
+    typename std::enable_if<approachV == WetGasPvt, const Opm::WetGasPvt<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<const Opm::WetGasPvt<Scalar>* >(realGasPvt_);

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -111,9 +111,9 @@ public:
     }
 #endif // HAVE_OPM_PARSER
 
-    void setApproach(GasPvtApproach gasPvtApproach)
+    void setApproach(GasPvtApproach gasPvtAppr)
     {
-        switch (gasPvtApproach) {
+        switch (gasPvtAppr) {
         case DryGasPvt:
             realGasPvt_ = new Opm::DryGasPvt<Scalar>;
             break;
@@ -126,7 +126,7 @@ public:
             OPM_THROW(std::logic_error, "Not implemented: Gas PVT of this deck!");
         }
 
-        gasPvtApproach_ = gasPvtApproach;
+        gasPvtApproach_ = gasPvtAppr;
     }
 
     void initEnd()

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -160,8 +160,8 @@ public:
     }
 
 private:
-    void extendPvtoTable_(int regionIdx,
-                          int xIdx,
+    void extendPvtoTable_(unsigned regionIdx,
+                          unsigned xIdx,
                           const PvtoInnerTable& curTable,
                           const PvtoInnerTable& masterTable)
     {

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -96,16 +96,20 @@ public:
             assert(saturatedTable->numRows() > 1);
 
             auto& oilMu = oilMuTable_[regionIdx];
+            auto& satOilMu = saturatedOilMuTable_[regionIdx];
             auto& invOilB = inverseOilBTable_[regionIdx];
             auto& invSatOilB = inverseSaturatedOilBTable_[regionIdx];
             auto& gasDissolutionFac = gasDissolutionFactorTable_[regionIdx];
             std::vector<Scalar> invSatOilBArray;
+            std::vector<Scalar> satOilMuArray;
 
             // extract the table for the gas dissolution and the oil formation volume factors
             for (unsigned outerIdx = 0; outerIdx < saturatedTable->numRows(); ++ outerIdx) {
                 Scalar Rs = saturatedTable->getGasSolubilityColumn()[outerIdx];
                 Scalar BoSat = saturatedTable->getOilFormationFactorColumn()[outerIdx];
+                Scalar muoSat = saturatedTable->getOilViscosityColumn()[outerIdx];
 
+                satOilMuArray.push_back(muoSat);
                 invSatOilBArray.push_back(1.0/BoSat);
 
                 invOilB.appendXPos(Rs);
@@ -130,6 +134,8 @@ public:
             // dissolution factor of saturated oil
             invSatOilB.setXYContainers(saturatedTable->getPressureColumn(),
                                        invSatOilBArray);
+            satOilMu.setXYContainers(saturatedTable->getPressureColumn(),
+                                     satOilMuArray);
             gasDissolutionFac.setXYContainers(saturatedTable->getPressureColumn(),
                                               saturatedTable->getGasSolubilityColumn());
 
@@ -229,6 +235,7 @@ public:
         gasReferenceDensity_.resize(numRegions);
         inverseOilBTable_.resize(numRegions);
         inverseOilBMuTable_.resize(numRegions);
+        saturatedOilMuTable_.resize(numRegions);
         inverseSaturatedOilBTable_.resize(numRegions);
         inverseSaturatedOilBMuTable_.resize(numRegions);
         oilMuTable_.resize(numRegions);
@@ -705,6 +712,7 @@ private:
     std::vector<TabulatedTwoDFunction> inverseOilBTable_;
     std::vector<TabulatedTwoDFunction> oilMuTable_;
     std::vector<TabulatedTwoDFunction> inverseOilBMuTable_;
+    std::vector<TabulatedOneDFunction> saturatedOilMuTable_;
     std::vector<TabulatedOneDFunction> inverseSaturatedOilBTable_;
     std::vector<TabulatedOneDFunction> inverseSaturatedOilBMuTable_;
     std::vector<TabulatedOneDFunction> gasDissolutionFactorTable_;

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -202,9 +202,9 @@ public:
                                      const Evaluation& Rs) const
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturationPressure(regionIdx, temperature, Rs)); return 0; }
 
-    void setApproach(OilPvtApproach approach)
+    void setApproach(OilPvtApproach appr)
     {
-        switch (approach) {
+        switch (appr) {
         case ConstantCompressibilityOilPvt:
             realOilPvt_ = new Opm::ConstantCompressibilityOilPvt<Scalar>;
             break;
@@ -221,7 +221,7 @@ public:
             OPM_THROW(std::logic_error, "Not implemented: Oil PVT of this deck!");
         }
 
-        approach_ = approach;
+        approach_ = appr;
     }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -28,9 +28,9 @@
 #include "ConstantCompressibilityWaterPvt.hpp"
 
 #define OPM_WATER_PVT_MULTIPLEXER_CALL(codeToCall)                      \
-    switch (waterPvtApproach_) {                                        \
+    switch (approach_) {                                                \
     case ConstantCompressibilityWaterPvt: {                             \
-        auto &pvtImpl = getRealWaterPvt<ConstantCompressibilityWaterPvt>(); \
+        auto &pvtImpl = getRealPvt<ConstantCompressibilityWaterPvt>();  \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
@@ -54,14 +54,14 @@ public:
 
     WaterPvtMultiplexer()
     {
-        waterPvtApproach_ = NoWaterPvt;
+        approach_ = NoWaterPvt;
     }
 
     ~WaterPvtMultiplexer()
     {
-        switch (waterPvtApproach_) {
+        switch (approach_) {
         case ConstantCompressibilityWaterPvt: {
-            delete &getRealWaterPvt<ConstantCompressibilityWaterPvt>();
+            delete &getRealPvt<ConstantCompressibilityWaterPvt>();
             break;
         }
         case NoWaterPvt:
@@ -114,37 +114,9 @@ public:
                        const Evaluation& pressure) const
     { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure)); return 0; }
 
-    /*!
-     * \brief Returns the fugacity coefficient [-] of the oil component in the water phase given
-     *        a pressure and a temperature.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientOil(unsigned regionIdx,
-                                      const Evaluation& temperature,
-                                      const Evaluation& pressure) const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientOil(regionIdx, temperature, pressure)); return 0; }
-    /*!
-     * \brief Returns the fugacity coefficient [-] of the gas component in the water phase given
-     *        a pressure and a temperature.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientGas(unsigned regionIdx,
-                                      const Evaluation& temperature,
-                                      const Evaluation& pressure) const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientGas(regionIdx, temperature, pressure)); return 0; }
-    /*!
-     * \brief Returns the fugacity coefficient [-] of the water component in the water phase given
-     *        a pressure and a temperature.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientWater(unsigned regionIdx,
-                                        const Evaluation& temperature,
-                                        const Evaluation& pressure) const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.fugacityCoefficientWater(regionIdx, temperature, pressure)); return 0; }
-
-    void setApproach(WaterPvtApproach waterPvtApproach)
+    void setApproach(WaterPvtApproach approach)
     {
-        switch (waterPvtApproach) {
+        switch (approach) {
         case ConstantCompressibilityWaterPvt:
             realWaterPvt_ = new Opm::ConstantCompressibilityWaterPvt<Scalar>;
             break;
@@ -153,29 +125,34 @@ public:
             OPM_THROW(std::logic_error, "Not implemented: Water PVT of this deck!");
         }
 
-        waterPvtApproach_ = waterPvtApproach;
+        approach_ = approach;
     }
 
-    WaterPvtApproach waterPvtApproach() const
-    { return waterPvtApproach_; }
+    /*!
+     * \brief Returns the concrete approach for calculating the PVT relations.
+     *
+     * (This is only determined at runtime.)
+     */
+    WaterPvtApproach approach() const
+    { return approach_; }
 
-    // get the parameter object for the dry water case
+    // get the concrete parameter object for the water phase
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == ConstantCompressibilityWaterPvt, Opm::ConstantCompressibilityWaterPvt<Scalar> >::type& getRealWaterPvt()
+    typename std::enable_if<approachV == ConstantCompressibilityWaterPvt, Opm::ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt()
     {
-        assert(waterPvtApproach() == approachV);
+        assert(approach() == approachV);
         return *static_cast<Opm::ConstantCompressibilityWaterPvt<Scalar>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == ConstantCompressibilityWaterPvt, const Opm::ConstantCompressibilityWaterPvt<Scalar> >::type& getRealWaterPvt() const
+    typename std::enable_if<approachV == ConstantCompressibilityWaterPvt, const Opm::ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt() const
     {
-        assert(waterPvtApproach() == approachV);
+        assert(approach() == approachV);
         return *static_cast<Opm::ConstantCompressibilityWaterPvt<Scalar>* >(realWaterPvt_);
     }
 
 private:
-    WaterPvtApproach waterPvtApproach_;
+    WaterPvtApproach approach_;
     void *realWaterPvt_;
 };
 

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -114,9 +114,9 @@ public:
                        const Evaluation& pressure) const
     { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.density(regionIdx, temperature, pressure)); return 0; }
 
-    void setApproach(WaterPvtApproach approach)
+    void setApproach(WaterPvtApproach appr)
     {
-        switch (approach) {
+        switch (appr) {
         case ConstantCompressibilityWaterPvt:
             realWaterPvt_ = new Opm::ConstantCompressibilityWaterPvt<Scalar>;
             break;
@@ -125,7 +125,7 @@ public:
             OPM_THROW(std::logic_error, "Not implemented: Water PVT of this deck!");
         }
 
-        approach_ = approach;
+        approach_ = appr;
     }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -38,9 +38,6 @@
 
 namespace Opm {
 
-template <class Scalar>
-class OilPvtMultiplexer;
-
 /*!
  * \brief This class represents the Pressure-Volume-Temperature relations of the gas phas
  *        with vaporized oil.
@@ -48,8 +45,6 @@ class OilPvtMultiplexer;
 template <class Scalar>
 class WetGasPvt
 {
-    typedef Opm::OilPvtMultiplexer<Scalar> OilPvtMultiplexer;
-
     typedef Opm::UniformXTabulated2DFunction<Scalar> TabulatedTwoDFunction;
     typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
     typedef Opm::Spline<Scalar> Spline;
@@ -78,16 +73,6 @@ public:
             Scalar rhoRefW = densityKeyword->getRecord(regionIdx)->getItem("WATER")->getSIDouble(0);
 
             setReferenceDensities(regionIdx, rhoRefO, rhoRefG, rhoRefW);
-
-            // determine the molar masses of the components
-            Scalar p = 1.01325e5; // surface pressure, [Pa]
-            Scalar T = 273.15 + 15.56; // surface temperature, [K]
-            Scalar MO = 175e-3; // [kg/mol]
-            Scalar MG = Opm::Constants<Scalar>::R*T*rhoRefG / p; // [kg/mol], consequence of the ideal gas law
-            Scalar MW = 18.0e-3; // [kg/mol]
-            // TODO (?): the molar mass of the components can possibly specified
-            // explicitly in the deck.
-            setMolarMasses(regionIdx, MO, MG, MW);
         }
 
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
@@ -100,7 +85,7 @@ public:
             auto& invGasB = inverseGasB_[regionIdx];
             auto& invSatGasB = inverseSaturatedGasB_[regionIdx];
             auto& invSatGasBMu = inverseSaturatedGasBMu_[regionIdx];
-            auto& oilVaporizationFac = oilVaporizationFactorTable_[regionIdx];
+            auto& oilVaporizationFac = saturatedOilVaporizationFactorTable_[regionIdx];
 
             oilVaporizationFac.setXYArrays(saturatedTable->numRows(),
                                            saturatedTable->getPressureColumn(),
@@ -228,8 +213,6 @@ public:
 
     void setNumRegions(size_t numRegions)
     {
-        oilMolarMass_.resize(numRegions);
-        gasMolarMass_.resize(numRegions);
         oilReferenceDensity_.resize(numRegions);
         gasReferenceDensity_.resize(numRegions);
         inverseGasB_.resize(numRegions);
@@ -237,7 +220,7 @@ public:
         inverseSaturatedGasB_.resize(numRegions);
         inverseSaturatedGasBMu_.resize(numRegions);
         gasMu_.resize(numRegions);
-        oilVaporizationFactorTable_.resize(numRegions);
+        saturatedOilVaporizationFactorTable_.resize(numRegions);
         saturationPressureSpline_.resize(numRegions);
     }
 
@@ -254,24 +237,12 @@ public:
     }
 
     /*!
-     * \brief Initialize the reference densities of all fluids for a given PVT region
-     */
-    void setMolarMasses(unsigned regionIdx,
-                        Scalar MOil,
-                        Scalar MGas,
-                        Scalar /*MWater*/)
-    {
-        oilMolarMass_[regionIdx] = MOil;
-        gasMolarMass_[regionIdx] = MGas;
-    }
-
-    /*!
      * \brief Initialize the function for the oil vaporization factor \f$R_v\f$
      *
      * \param samplePoints A container of (x,y) values.
      */
     void setSaturatedGasOilVaporizationFactor(unsigned regionIdx, const SamplingPoints &samplePoints)
-    { oilVaporizationFactorTable_[regionIdx].setContainerOfTuples(samplePoints); }
+    { saturatedOilVaporizationFactorTable_[regionIdx].setContainerOfTuples(samplePoints); }
 
     /*!
      * \brief Initialize the function for the gas formation volume factor
@@ -286,12 +257,12 @@ public:
     {
         auto& invGasB = inverseGasB_[regionIdx];
 
-        auto &RvTable = oilVaporizationFactorTable_[regionIdx];
+        auto &RvTable = saturatedOilVaporizationFactorTable_[regionIdx];
 
         Scalar T = 273.15 + 15.56; // [K]
 
         Scalar RvMin = 0.0;
-        Scalar RvMax = RvTable.eval(oilVaporizationFactorTable_[regionIdx].xMax(), /*extrapolate=*/true);
+        Scalar RvMax = RvTable.eval(saturatedOilVaporizationFactorTable_[regionIdx].xMax(), /*extrapolate=*/true);
 
         Scalar poMin = samplePoints.front().first;
         Scalar poMax = samplePoints.back().first;
@@ -319,7 +290,7 @@ public:
             for (size_t pIdx = 0; pIdx < nP; ++pIdx) {
                 Scalar pg = poMin + (poMax - poMin)*pIdx/nP;
 
-                Scalar poSat = gasSaturationPressure(regionIdx, T, Rv);
+                Scalar poSat = saturationPressure(regionIdx, T, Rv);
                 Scalar BgSat = gasFormationVolumeFactorSpline.eval(poSat, /*extrapolate=*/true);
                 Scalar drhoo_dp = (1.1200 - 1.1189)/((5000 - 4000)*6894.76);
                 Scalar rhoo = rhooRef/BgSat*(1 + drhoo_dp*(pg - poSat));
@@ -363,10 +334,10 @@ public:
      */
     void setSaturatedGasViscosity(unsigned regionIdx, const SamplingPoints &samplePoints  )
     {
-        auto& oilVaporizationFac = oilVaporizationFactorTable_[regionIdx];
+        auto& oilVaporizationFac = saturatedOilVaporizationFactorTable_[regionIdx];
 
         Scalar RvMin = 0.0;
-        Scalar RvMax = oilVaporizationFac.eval(oilVaporizationFactorTable_[regionIdx].xMax(), /*extrapolate=*/true);
+        Scalar RvMax = oilVaporizationFac.eval(saturatedOilVaporizationFactorTable_[regionIdx].xMax(), /*extrapolate=*/true);
 
         Scalar poMin = samplePoints.front().first;
         Scalar poMax = samplePoints.back().first;
@@ -396,10 +367,8 @@ public:
     /*!
      * \brief Finish initializing the gas phase PVT properties.
      */
-    void initEnd(const OilPvtMultiplexer *oilPvt)
+    void initEnd()
     {
-        oilPvt_ = oilPvt;
-
         // calculate the final 2D functions which are used for interpolation.
         size_t numRegions = gasMu_.size();
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
@@ -511,7 +480,7 @@ public:
         const Evaluation& Bg = saturatedFormationVolumeFactor(regionIdx, temperature, pressure);
 
         Evaluation rhog = rhogRef/Bg;
-        const Evaluation& RvSat = oilVaporizationFactor(regionIdx, temperature, pressure);
+        const Evaluation& RvSat = saturatedOilVaporizationFactor(regionIdx, temperature, pressure);
         rhog += (rhooRef*RvSat)/Bg;
 
         return rhog;
@@ -537,55 +506,13 @@ public:
     { return 1.0 / inverseSaturatedGasB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
-     * \brief Returns the fugacity coefficient [Pa] of a component in the fluid phase given
-     *        a set of parameters.
-     */
-    template <class Evaluation>
-    Evaluation fugacityCoefficientGas(unsigned /*regionIdx*/,
-                                      const Evaluation& /*temperature*/,
-                                      const Evaluation& /*pressure*/) const
-    {
-        // the fugacity coefficient of the gas component in the gas phase is assumed to
-        // be that of an ideal gas.
-        return 1.0;
-    }
-
-    template <class Evaluation>
-    Evaluation fugacityCoefficientOil(unsigned regionIdx,
-                                      const Evaluation& temperature,
-                                      const Evaluation& pressure) const
-    {
-        // the fugacity coefficient of the oil component in the wet gas phase:
-        //
-        // first, retrieve the mole fraction of gas a saturated oil would exhibit at the
-        // given pressure
-        const Evaluation& x_gOSat = saturatedOilMoleFraction(regionIdx, temperature, pressure);
-
-        // then, scale the oil component's gas phase fugacity coefficient, so that the
-        // gas phase ends up at the right composition if we were doing a flash experiment
-        const Evaluation& phi_oO = oilPvt_->fugacityCoefficientOil(regionIdx, temperature, pressure);
-
-        return phi_oO / x_gOSat;
-    }
-
-    template <class Evaluation>
-    Evaluation fugacityCoefficientWater(unsigned regionIdx,
-                                        const Evaluation& temperature,
-                                        const Evaluation& pressure) const
-    {
-        // assume that the affinity of the water component to the gas phase is much
-        // smaller than that of the gas component
-        return 1e8*fugacityCoefficientWater(regionIdx, temperature, pressure);
-    }
-
-    /*!
      * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
      */
     template <class Evaluation>
-    Evaluation oilVaporizationFactor(unsigned regionIdx,
-                                     const Evaluation& /*temperature*/,
-                                     const Evaluation& pressure) const
-    { return oilVaporizationFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true); }
+    Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
+                                              const Evaluation& /*temperature*/,
+                                              const Evaluation& pressure) const
+    { return saturatedOilVaporizationFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
      * \brief Returns the saturation pressure of the gas phase [Pa]
@@ -594,9 +521,9 @@ public:
      * \param Rv The surface volume of oil component dissolved in what will yield one cubic meter of gas at the surface [-]
      */
     template <class Evaluation>
-    Evaluation gasSaturationPressure(unsigned regionIdx,
-                                     const Evaluation& temperature,
-                                     const Evaluation& Rv) const
+    Evaluation saturationPressure(unsigned regionIdx,
+                                  const Evaluation& temperature,
+                                  const Evaluation& Rv) const
     {
         typedef Opm::MathToolbox<Evaluation> Toolbox;
 
@@ -608,8 +535,8 @@ public:
         // value is good, this should only take two to three
         // iterations...
         for (unsigned i = 0; i < 20; ++i) {
-            const Evaluation& f = oilVaporizationFactor(regionIdx, temperature, pSat) - Rv;
-            const Evaluation& fPrime = ((oilVaporizationFactor(regionIdx, temperature, pSat + eps) - Rv) - f)/eps;
+            const Evaluation& f = saturatedOilVaporizationFactor(regionIdx, temperature, pSat) - Rv;
+            const Evaluation& fPrime = ((saturatedOilVaporizationFactor(regionIdx, temperature, pSat + eps) - Rv) - f)/eps;
 
             const Evaluation& delta = f/fPrime;
             pSat -= delta;
@@ -621,46 +548,10 @@ public:
         OPM_THROW(NumericalProblem, "Could find the gas saturation pressure for X_g^O = " << Rv);
     }
 
-    template <class Evaluation>
-    Evaluation saturatedOilMassFraction(unsigned regionIdx,
-                                        const Evaluation& temperature,
-                                        const Evaluation& pressure) const
-    {
-        Scalar rho_gRef = gasReferenceDensity_[regionIdx];
-        Scalar rho_oRef = oilReferenceDensity_[regionIdx];
-
-        // calculate the mass of the oil component [kg/m^3] in the gas phase. This is
-        // equivalent to the oil vaporization factor [m^3/m^3] at current pressure times
-        // the oil density [kg/m^3] at standard pressure
-        const Evaluation& Rv = oilVaporizationFactor(regionIdx, temperature, pressure);
-        const Evaluation& rho_gO = Rv * rho_oRef;
-
-        // we now have the total density of saturated oil and the partial density of the
-        // oil component within it. The gas mass fraction is the ratio of these two.
-        return rho_gO/(rho_gRef + rho_gO);
-    }
-
-    template <class Evaluation>
-    Evaluation saturatedOilMoleFraction(unsigned regionIdx,
-                                        const Evaluation& temperature,
-                                        const Evaluation& pressure) const
-    {
-        // calculate the mass fractions of gas and oil
-        const Evaluation& Rv = saturatedOilMassFraction(regionIdx, temperature, pressure);
-
-        // which can be converted to mole fractions, given the
-        // components' molar masses
-        Scalar MG = gasMolarMass_[regionIdx];
-        Scalar MO = oilMolarMass_[regionIdx];
-
-        const Evaluation& avgMolarMass = MO/(1 + (1 - Rv)*(MO/MG - 1));
-        return Rv*avgMolarMass/MO;
-    }
-
 private:
     void updateSaturationPressureSpline_(unsigned regionIdx)
     {
-        auto& oilVaporizationFac = oilVaporizationFactorTable_[regionIdx];
+        auto& oilVaporizationFac = saturatedOilVaporizationFactorTable_[regionIdx];
 
         // create the spline representing saturation pressure
         // depending of the mass fraction in gas
@@ -671,7 +562,7 @@ private:
         Scalar Rv = 0;
         for (size_t i = 0; i <= n; ++ i) {
             Scalar pSat = oilVaporizationFac.xMin() + i*delta;
-            Rv = oilVaporizationFactor(regionIdx, /*temperature=*/Scalar(1e100), pSat);
+            Rv = saturatedOilVaporizationFactor(regionIdx, /*temperature=*/Scalar(1e100), pSat);
 
             std::pair<Scalar, Scalar> val(Rv, pSat);
             pSatSamplePoints.push_back(val);
@@ -680,10 +571,6 @@ private:
                                                                   /*type=*/Spline::Monotonic);
     }
 
-    const OilPvtMultiplexer *oilPvt_;
-
-    std::vector<Scalar> gasMolarMass_;
-    std::vector<Scalar> oilMolarMass_;
     std::vector<Scalar> gasReferenceDensity_;
     std::vector<Scalar> oilReferenceDensity_;
     std::vector<TabulatedTwoDFunction> inverseGasB_;
@@ -691,7 +578,7 @@ private:
     std::vector<TabulatedTwoDFunction> gasMu_;
     std::vector<TabulatedTwoDFunction> inverseGasBMu_;
     std::vector<TabulatedOneDFunction> inverseSaturatedGasBMu_;
-    std::vector<TabulatedOneDFunction> oilVaporizationFactorTable_;
+    std::vector<TabulatedOneDFunction> saturatedOilVaporizationFactorTable_;
     std::vector<Spline> saturationPressureSpline_;
 };
 

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -125,7 +125,7 @@ public:
             invSatGasBMu.setXYContainers(saturatedTable->getPressureColumn(), invSatGasBMuArray);
 
             // make sure to have at least two sample points per gas pressure value
-            for (size_t xIdx = 0; xIdx < invGasB.numX(); ++xIdx) {
+            for (unsigned xIdx = 0; xIdx < invGasB.numX(); ++xIdx) {
                // a single sample point is definitely needed
                 assert(invGasB.numY(xIdx) > 0);
 
@@ -159,8 +159,8 @@ public:
     }
 
 private:
-    void extendPvtgTable_(int regionIdx,
-                          int xIdx,
+    void extendPvtgTable_(unsigned regionIdx,
+                          unsigned xIdx,
                           const PvtgInnerTable& curTable,
                           const PvtgInnerTable& masterTable)
     {

--- a/tests/checkFluidSystem.hpp
+++ b/tests/checkFluidSystem.hpp
@@ -274,6 +274,10 @@ void checkFluidSystem()
     fs.allowComposition(true);
     fs.restrictToPhase(-1);
 
+    static_assert(std::is_same<typename FluidSystem::Scalar, Scalar>::value,
+                  "The type used for floating point used by the fluid system must be the same"
+                  " as the one passed to the checkFluidSystem() function");
+
     // check whether the parameter cache adheres to the API
     typedef typename FluidSystem::ParameterCache PC;
     PC paramCache;

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -136,7 +136,7 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         Evaluation pressure = 1e5;
         Evaluation Rs = 0.0;
         Evaluation Rv = 0.0;
-        Evaluation OPM_UNUSED tmp;
+        Evaluation tmp;
 
         /////
         // water PVT API
@@ -212,6 +212,9 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         tmp = gasPvt.saturatedOilVaporizationFactor(/*regionIdx=*/0,
                                                     temperature,
                                                     pressure);
+
+        // prevent GCC from producing a "variable assigned but unused" warning
+        tmp = 2.0*tmp;
     }
 }
 

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -147,15 +147,9 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         tmp = waterPvt.density(/*regionIdx=*/0,
                                temperature,
                                pressure);
-        tmp = waterPvt.fugacityCoefficientOil(/*regionIdx=*/0,
-                                              temperature,
-                                              pressure);
-        tmp = waterPvt.fugacityCoefficientGas(/*regionIdx=*/0,
-                                              temperature,
-                                              pressure);
-        tmp = waterPvt.fugacityCoefficientWater(/*regionIdx=*/0,
-                                                temperature,
-                                                pressure);
+        tmp = waterPvt.formationVolumeFactor(/*regionIdx=*/0,
+                                             temperature,
+                                             pressure);
 
         /////
         // oil PVT API
@@ -181,21 +175,12 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         tmp = oilPvt.saturatedFormationVolumeFactor(/*regionIdx=*/0,
                                                     temperature,
                                                     pressure);
-        tmp = oilPvt.saturatedGasMassFraction(/*regionIdx=*/0,
-                                              temperature,
-                                              pressure);
-        tmp = oilPvt.saturatedGasMoleFraction(/*regionIdx=*/0,
-                                              temperature,
-                                              pressure);
-        tmp = oilPvt.fugacityCoefficientOil(/*regionIdx=*/0,
-                                            temperature,
-                                            pressure);
-        tmp = oilPvt.fugacityCoefficientGas(/*regionIdx=*/0,
-                                            temperature,
-                                            pressure);
-        tmp = oilPvt.fugacityCoefficientWater(/*regionIdx=*/0,
-                                              temperature,
-                                              pressure);
+        tmp = oilPvt.saturationPressure(/*regionIdx=*/0,
+                                        temperature,
+                                        Rs);
+        tmp = oilPvt.saturatedGasDissolutionFactor(/*regionIdx=*/0,
+                                                   temperature,
+                                                   pressure);
 
         /////
         // gas PVT API
@@ -208,6 +193,10 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
                              temperature,
                              pressure,
                              Rv);
+        tmp = gasPvt.formationVolumeFactor(/*regionIdx=*/0,
+                                           temperature,
+                                           pressure,
+                                           Rv);
         tmp = gasPvt.saturatedViscosity(/*regionIdx=*/0,
                                         temperature,
                                         pressure);
@@ -217,26 +206,12 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         tmp = gasPvt.saturatedFormationVolumeFactor(/*regionIdx=*/0,
                                                     temperature,
                                                     pressure);
-        tmp = gasPvt.formationVolumeFactor(/*regionIdx=*/0,
-                                           temperature,
-                                           pressure,
-                                           Rv);
-        tmp = gasPvt.saturatedOilMassFraction(/*regionIdx=*/0,
-                                              temperature,
-                                              pressure);
-        tmp = gasPvt.saturatedOilMoleFraction(/*regionIdx=*/0,
-                                              temperature,
-                                              pressure);
-
-        tmp = gasPvt.fugacityCoefficientOil(/*regionIdx=*/0,
-                                            temperature,
-                                            pressure);
-        tmp = gasPvt.fugacityCoefficientGas(/*regionIdx=*/0,
-                                            temperature,
-                                            pressure);
-        tmp = gasPvt.fugacityCoefficientWater(/*regionIdx=*/0,
-                                              temperature,
-                                              pressure);
+        tmp = gasPvt.saturationPressure(/*regionIdx=*/0,
+                                        temperature,
+                                        Rv);
+        tmp = gasPvt.saturatedOilVaporizationFactor(/*regionIdx=*/0,
+                                                    temperature,
+                                                    pressure);
     }
 }
 
@@ -319,8 +294,8 @@ int main()
     oilPvt.initFromDeck(deck, eclState);
     waterPvt.initFromDeck(deck, eclState);
 
-    gasPvt.initEnd(&oilPvt);
-    oilPvt.initEnd(&gasPvt);
+    gasPvt.initEnd();
+    oilPvt.initEnd();
     waterPvt.initEnd();
 
     struct Foo;

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -93,10 +93,15 @@ void ensureBlackoilApi()
         Evaluation XoG;
         OPM_UNUSED Evaluation dummy;
 
+        // some additional typedefs
+        typedef typename FluidSystem::OilPvt OilPvt;
+        typedef typename FluidSystem::GasPvt GasPvt;
+        typedef typename FluidSystem::WaterPvt WaterPvt;
+
         // check the non-parser initialization
-        std::shared_ptr<typename FluidSystem::GasPvt> gasPvt;
-        std::shared_ptr<typename FluidSystem::OilPvt> oilPvt;
-        std::shared_ptr<typename FluidSystem::WaterPvt> waterPvt;
+        std::shared_ptr<OilPvt> oilPvt;
+        std::shared_ptr<GasPvt> gasPvt;
+        std::shared_ptr<WaterPvt> waterPvt;
 
         unsigned numPvtRegions = 2;
         FluidSystem::initBegin(numPvtRegions);
@@ -138,6 +143,10 @@ void ensureBlackoilApi()
         dummy = FluidSystem::waterDensity(temperature, pressure, /*regionIdx=*/0);
         dummy = FluidSystem::convertXoGToRs(XoG, /*regionIdx=*/0);
         dummy = FluidSystem::convertXgOToRv(XgO, /*regionIdx=*/0);
+        dummy = FluidSystem::convertXoGToxoG(XoG, /*regionIdx=*/0);
+        dummy = FluidSystem::convertXgOToxgO(XgO, /*regionIdx=*/0);
+        dummy = FluidSystem::convertRsToXoG(Rs, /*regionIdx=*/0);
+        dummy = FluidSystem::convertRvToXgO(Rv, /*regionIdx=*/0);
     }
 }
 

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -122,9 +122,6 @@ void ensureBlackoilApi()
         dummy = FluidSystem::waterFormationVolumeFactor(temperature, pressure, /*regionIdx=*/0);
         dummy = FluidSystem::gasDissolutionFactor(temperature, pressure, /*regionIdx=*/0);
         dummy = FluidSystem::oilVaporizationFactor(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::fugCoefficientInWater(FluidSystem::gasCompIdx, temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::fugCoefficientInGas(FluidSystem::gasCompIdx, temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::fugCoefficientInOil(FluidSystem::gasCompIdx, temperature, pressure, /*regionIdx=*/0);
         dummy = FluidSystem::oilSaturationPressure(temperature, Rs, /*regionIdx=*/0);
         dummy = FluidSystem::saturatedOilGasMassFraction(temperature, pressure, /*regionIdx=*/0);
         dummy = FluidSystem::saturatedOilGasMoleFraction(temperature, pressure, /*regionIdx=*/0);

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -92,7 +92,7 @@ void ensureBlackoilApi()
         Evaluation XgO = 0.0;
         Evaluation Rs = 0.0;
         Evaluation Rv = 0.0;
-        OPM_UNUSED Evaluation dummy;
+        Evaluation dummy;
 
         // some additional typedefs
         typedef typename FluidSystem::OilPvt OilPvt;
@@ -156,6 +156,10 @@ void ensureBlackoilApi()
                 dummy = FluidSystem::fugacityCoefficient(fluidState, phaseIdx, compIdx,  /*regionIdx=*/0);
             }
         }
+
+        // prevent GCC from producing a "variable assigned but unused" warning
+        dummy = 2.0*dummy;
+
 
         // the "not considered safe to use directly" API
         const OPM_UNUSED OilPvt &oilPvt2 = FluidSystem::oilPvt();

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -85,18 +85,31 @@ void ensureBlackoilApi()
         FluidSystem::initFromDeck(deck, eclState);
 #endif
 
-        Evaluation temperature;
-        Evaluation pressure;
-        Evaluation Rv;
-        Evaluation Rs;
-        Evaluation XgO;
-        Evaluation XoG;
+        typedef typename FluidSystem::Scalar Scalar;
+        typedef Opm::CompositionalFluidState<Evaluation, FluidSystem> FluidState;
+        FluidState fluidState;
+        Evaluation XoG = 0.0;
+        Evaluation XgO = 0.0;
+        Evaluation Rs = 0.0;
+        Evaluation Rv = 0.0;
         OPM_UNUSED Evaluation dummy;
 
         // some additional typedefs
         typedef typename FluidSystem::OilPvt OilPvt;
         typedef typename FluidSystem::GasPvt GasPvt;
         typedef typename FluidSystem::WaterPvt WaterPvt;
+
+        // check the black-oil specific enums
+        static_assert(FluidSystem::numPhases == 3, "");
+        static_assert(FluidSystem::numComponents == 3, "");
+
+        static_assert(0 <= FluidSystem::oilPhaseIdx && FluidSystem::oilPhaseIdx < 3, "");
+        static_assert(0 <= FluidSystem::gasPhaseIdx && FluidSystem::gasPhaseIdx < 3, "");
+        static_assert(0 <= FluidSystem::waterPhaseIdx && FluidSystem::waterPhaseIdx < 3, "");
+
+        static_assert(0 <= FluidSystem::oilCompIdx && FluidSystem::oilCompIdx < 3, "");
+        static_assert(0 <= FluidSystem::gasCompIdx && FluidSystem::gasCompIdx < 3, "");
+        static_assert(0 <= FluidSystem::waterCompIdx && FluidSystem::waterCompIdx < 3, "");
 
         // check the non-parser initialization
         std::shared_ptr<OilPvt> oilPvt;
@@ -117,36 +130,37 @@ void ensureBlackoilApi()
         FluidSystem::initEnd();
 
         // the molarMass() method has an optional argument for the PVT region
-        FluidSystem::molarMass(FluidSystem::gasCompIdx, /*regionIdx=*/0);
-        FluidSystem::enableDissolvedGas();
-        FluidSystem::enableVaporizedOil();
-        FluidSystem::referenceDensity(/*phaseIdx=*/FluidSystem::oilPhaseIdx, /*regionIdx=*/0);
-
-        dummy = FluidSystem::saturatedOilFormationVolumeFactor(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::saturatedGasFormationVolumeFactor(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::waterFormationVolumeFactor(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::gasDissolutionFactor(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::oilVaporizationFactor(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::oilSaturationPressure(temperature, Rs, /*regionIdx=*/0);
-        dummy = FluidSystem::saturatedOilGasMassFraction(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::saturatedOilGasMoleFraction(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::gasSaturationPressure(temperature, Rv, /*regionIdx=*/0);
-        dummy = FluidSystem::saturatedGasOilMassFraction(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::saturatedGasOilMoleFraction(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::oilFormationVolumeFactor(temperature, pressure, Rs, /*regionIdx=*/0);
-        dummy = FluidSystem::oilDensity(temperature, pressure, Rs, /*regionIdx=*/0);
-        dummy = FluidSystem::saturatedOilDensity(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::gasFormationVolumeFactor(temperature, pressure, Rv, /*regionIdx=*/0);
-        dummy = FluidSystem::gasDensity(temperature, pressure, Rv, /*regionIdx=*/0);
-        dummy = FluidSystem::saturatedGasDensity(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::waterFormationVolumeFactor(temperature, pressure, /*regionIdx=*/0);
-        dummy = FluidSystem::waterDensity(temperature, pressure, /*regionIdx=*/0);
+        unsigned OPM_UNUSED numRegions = FluidSystem::numRegions();
+        Scalar OPM_UNUSED Mg = FluidSystem::molarMass(FluidSystem::gasCompIdx,
+                                                      /*regionIdx=*/0);
+        bool OPM_UNUSED b1 = FluidSystem::enableDissolvedGas();
+        bool OPM_UNUSED b2 = FluidSystem::enableVaporizedOil();
+        Scalar OPM_UNUSED rhoRefOil = FluidSystem::referenceDensity(FluidSystem::oilPhaseIdx,
+                                                                    /*regionIdx=*/0);
         dummy = FluidSystem::convertXoGToRs(XoG, /*regionIdx=*/0);
         dummy = FluidSystem::convertXgOToRv(XgO, /*regionIdx=*/0);
         dummy = FluidSystem::convertXoGToxoG(XoG, /*regionIdx=*/0);
         dummy = FluidSystem::convertXgOToxgO(XgO, /*regionIdx=*/0);
         dummy = FluidSystem::convertRsToXoG(Rs, /*regionIdx=*/0);
         dummy = FluidSystem::convertRvToXgO(Rv, /*regionIdx=*/0);
+
+        for (unsigned phaseIdx = 0; phaseIdx < FluidSystem::numPhases; ++ phaseIdx) {
+            dummy = FluidSystem::density(fluidState, phaseIdx, /*regionIdx=*/0);
+            dummy = FluidSystem::saturatedDensity(fluidState, phaseIdx, /*regionIdx=*/0);
+            dummy = FluidSystem::formationVolumeFactor(fluidState, phaseIdx, /*regionIdx=*/0);
+            dummy = FluidSystem::saturatedFormationVolumeFactor(fluidState, phaseIdx, /*regionIdx=*/0);
+            dummy = FluidSystem::viscosity(fluidState, phaseIdx, /*regionIdx=*/0);
+            dummy = FluidSystem::saturatedDissolutionFactor(fluidState, phaseIdx, /*regionIdx=*/0);
+            dummy = FluidSystem::saturationPressure(fluidState, phaseIdx, /*regionIdx=*/0);
+            for (unsigned compIdx = 0; compIdx < FluidSystem::numComponents; ++ compIdx) {
+                dummy = FluidSystem::fugacityCoefficient(fluidState, phaseIdx, compIdx,  /*regionIdx=*/0);
+            }
+        }
+
+        // the "not considered safe to use directly" API
+        const OPM_UNUSED OilPvt &oilPvt2 = FluidSystem::oilPvt();
+        const OPM_UNUSED GasPvt &gasPvt2 = FluidSystem::gasPvt();
+        const OPM_UNUSED WaterPvt &waterPvt2 = FluidSystem::waterPvt();
     }
 }
 

--- a/tests/test_spline.cpp
+++ b/tests/test_spline.cpp
@@ -82,7 +82,9 @@ void testCommon(const Spline &sp,
     // make sure the derivatives are consistent with the curve
     size_t np = 3*n;
     for (size_t i = 0; i < np; ++i) {
-        double xval = sp.xMin() + (sp.xMax() - sp.xMin())*i/np;
+        double xMin = sp.xAt(0);
+        double xMax = sp.xAt(sp.numSamples() - 1);
+        double xval = xMin + (xMax - xMin)*i/np;
 
         // first derivative
         double y1 = sp.eval(xval+epsFD);


### PR DESCRIPTION
This is a quite large PR which implements most of the changes listed in #101, i.e., items  no. 2, 3a, 4, and probably 5. To keep it reviewable, all patches are (hopefully) self-contained and the PR is thus fully bisectable.

what this PR does not do is making the phases/components type safe. I thought about it a bit more though: type save "indices" might be a problem if phase/component specific quantities are stored in arrays. (note that is a _very_ common case.) This could be fixed by allowing these specifier objects to be implicitly converted to an integer (but not vice-versa), but the added complexity of this might not be worth type-safety in the first place. To find out, I'll probably have bang together a prototype implementation.

A particular issue I struggled with quite a while when doing this work is the discontinuity of the density and viscosity at the transition undersaturated<->saturated hydrocarbon phases. This PR fixes that issue by interpolating between the saturated and the undersaturated quantities using the phase saturation. looking further, this cannot be mapped with the current PVT interface in opm-core because the opm-core API does not provide derivatives w.r.t. saturations for PVT properties. (this could be changed but it would require to modify each and every consumer of the opm-core PVT API. If getting rid of the discontinuity is wanted in the opm-core/opm-autodiff contexts, it would thus probably be about the same amount of work to replace the current API with the fluid systems approach completely than applying more lipstick to the pig.)

Finally, note that this PR implies a few changes in eWoms so the PR eWoms and this one need to be merged synchronously.