### PR TITLE
 fix the table handling code for live oil

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -628,7 +628,7 @@ private:
         std::vector<double> SoSamples(sgofTable.numRows());
         std::vector<double> SoKroSamples(sgofTable.numRows());
         for (size_t sampleIdx = 0; sampleIdx < sgofTable.numRows(); ++ sampleIdx) {
-            SoSamples[sampleIdx] = 1 - sgofTable.get("SG" , sampleIdx);
+            SoSamples[sampleIdx] = 1 - sgofTable.get("SG", sampleIdx);
             SoKroSamples[sampleIdx] = SoSamples[sampleIdx] - Swco;
         }
 
@@ -646,8 +646,8 @@ private:
         std::vector<double> SoSamples(slgofTable.numRows());
         std::vector<double> SoKroSamples(slgofTable.numRows());
         for (size_t sampleIdx = 0; sampleIdx < slgofTable.numRows(); ++ sampleIdx) {
-            SoSamples[sampleIdx] = slgofTable.get("SL" , sampleIdx);
-            SoKroSamples[sampleIdx] = slgofTable.get("SL" , sampleIdx) - Swco;
+            SoSamples[sampleIdx] = slgofTable.get("SL", sampleIdx);
+            SoKroSamples[sampleIdx] = slgofTable.get("SL", sampleIdx) - Swco;
         }
 
         effParams.setKrwSamples(SoKroSamples, slgofTable.getColumn("KROG").vectorCopy());
@@ -665,7 +665,7 @@ private:
         std::vector<double> SoSamples(sgfnTable.numRows());
         std::vector<double> SoColumn = sof3Table.getColumn("SO").vectorCopy();
         for (size_t sampleIdx = 0; sampleIdx < sgfnTable.numRows(); ++ sampleIdx) {
-            SoSamples[sampleIdx] = 1 - sgfnTable.get("SG" , sampleIdx);
+            SoSamples[sampleIdx] = 1 - sgfnTable.get("SG", sampleIdx);
         }
 
         effParams.setKrwSamples(SoColumn, sof3Table.getColumn("KROG").vectorCopy());
@@ -731,7 +731,7 @@ private:
             // convert the saturations of the SOF3 keyword from oil to water saturations
             std::vector<double> SwSamples(sof3Table.numRows());
             for (size_t sampleIdx = 0; sampleIdx < sof3Table.numRows(); ++ sampleIdx)
-                SwSamples[sampleIdx] = 1 - sof3Table.get("SO" , sampleIdx);
+                SwSamples[sampleIdx] = 1 - sof3Table.get("SO", sampleIdx);
 
             effParams.setKrwSamples(SwColumn, swfnTable.getColumn("KRW").vectorCopy());
             effParams.setKrnSamples(SwSamples, sof3Table.getColumn("KROW").vectorCopy());

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -37,8 +37,6 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #endif
 
-
-
 namespace Opm {
 /*!
  * \brief This class represents the Pressure-Volume-Temperature relations of the oil phas
@@ -54,7 +52,6 @@ class LiveOilPvt
 
 public:
 #if HAVE_OPM_PARSER
-
     /*!
      * \brief Initialize the oil parameters via the data specified by the PVTO ECL keyword.
      */
@@ -80,7 +77,7 @@ public:
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
             const auto& pvtoTable = pvtoTables[regionIdx];
 
-            const auto saturatedTable = pvtoTable.getSaturatedTable( );
+            const auto saturatedTable = pvtoTable.getSaturatedTable();
             assert(saturatedTable.numRows() > 1);
 
             auto& oilMu = oilMuTable_[regionIdx];
@@ -93,9 +90,9 @@ public:
 
             // extract the table for the gas dissolution and the oil formation volume factors
             for (unsigned outerIdx = 0; outerIdx < saturatedTable.numRows(); ++ outerIdx) {
-                Scalar Rs    = saturatedTable.get("RS" , outerIdx);
-                Scalar BoSat = saturatedTable.get("BO" , outerIdx);
-                Scalar muoSat = saturatedTable.get("MU" , outerIdx);
+                Scalar Rs    = saturatedTable.get("RS", outerIdx);
+                Scalar BoSat = saturatedTable.get("BO", outerIdx);
+                Scalar muoSat = saturatedTable.get("MU", outerIdx);
 
                 satOilMuArray.push_back(muoSat);
                 invSatOilBArray.push_back(1.0/BoSat);
@@ -109,9 +106,9 @@ public:
                 const auto& underSaturatedTable = pvtoTable.getUnderSaturatedTable(outerIdx);
                 size_t numRows = underSaturatedTable.numRows();
                 for (unsigned innerIdx = 0; innerIdx < numRows; ++ innerIdx) {
-                    Scalar po = underSaturatedTable.get("P" , innerIdx);
-                    Scalar Bo = underSaturatedTable.get("BO" , innerIdx);
-                    Scalar muo = underSaturatedTable.get("MU" , innerIdx);
+                    Scalar po = underSaturatedTable.get("P", innerIdx);
+                    Scalar Bo = underSaturatedTable.get("BO", innerIdx);
+                    Scalar muo = underSaturatedTable.get("MU", innerIdx);
 
                     invOilB.appendSamplePoint(outerIdx, po, 1.0/Bo);
                     oilMu.appendSamplePoint(outerIdx, po, muo);
@@ -123,7 +120,7 @@ public:
             {
                 std::vector<Scalar> tmpPressureColumn = saturatedTable.getColumn("P").vectorCopy();
                 std::vector<Scalar> tmpGasSolubilityColumn = saturatedTable.getColumn("RS").vectorCopy();
-                std::vector<Scalar> tmpMuColumn = saturatedTable.getColumn("MU").vectorCopy( );
+                std::vector<Scalar> tmpMuColumn = saturatedTable.getColumn("MU").vectorCopy();
 
                 invSatOilB.setXYContainers(tmpPressureColumn, invSatOilBArray);
                 satOilMu.setXYContainers(tmpPressureColumn, satOilMuArray);
@@ -171,9 +168,9 @@ private:
                           const SimpleTable& curTable,
                           const SimpleTable& masterTable)
     {
-        std::vector<Scalar> pressuresArray = curTable.getColumn("P").vectorCopy( );
-        std::vector<Scalar> oilBArray = curTable.getColumn("BO").vectorCopy( );
-        std::vector<Scalar> oilMuArray = curTable.getColumn("MU").vectorCopy( );
+        std::vector<Scalar> pressuresArray = curTable.getColumn("P").vectorCopy();
+        std::vector<Scalar> oilBArray = curTable.getColumn("BO").vectorCopy();
+        std::vector<Scalar> oilMuArray = curTable.getColumn("MU").vectorCopy();
 
         auto& invOilB = inverseOilBTable_[regionIdx];
         auto& oilMu = oilMuTable_[regionIdx];

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -95,7 +95,7 @@ public:
             for (unsigned outerIdx = 0; outerIdx < saturatedTable.numRows(); ++ outerIdx) {
                 Scalar Rs    = saturatedTable.get("RS" , outerIdx);
                 Scalar BoSat = saturatedTable.get("BO" , outerIdx);
-                Scalar muoSat = saturatedTable.get("MUO" , outerIdx);
+                Scalar muoSat = saturatedTable.get("MU" , outerIdx);
 
                 satOilMuArray.push_back(muoSat);
                 invSatOilBArray.push_back(1.0/BoSat);
@@ -121,13 +121,13 @@ public:
             // update the tables for the formation volume factor and for the gas
             // dissolution factor of saturated oil
             {
-                std::vector<Scalar> tmpPressureColumn = saturatedTable.getColumn("RS").vectorCopy();
-                std::vector<Scalar> tmpGasSolubilityColumn = saturatedTable.getColumn("P").vectorCopy();
-                std::vector<Scalar> tmpMuColumn = saturatedTable.getColumn("MUO").vectorCopy( );
+                std::vector<Scalar> tmpPressureColumn = saturatedTable.getColumn("P").vectorCopy();
+                std::vector<Scalar> tmpGasSolubilityColumn = saturatedTable.getColumn("RS").vectorCopy();
+                std::vector<Scalar> tmpMuColumn = saturatedTable.getColumn("MU").vectorCopy( );
 
-                satOilMu.setXYContainers(tmpMuColumn , satOilMuArray);
-                invSatOilB.setXYContainers(tmpPressureColumn , invSatOilBArray);
-                gasDissolutionFac.setXYContainers(tmpPressureColumn , tmpGasSolubilityColumn);
+                invSatOilB.setXYContainers(tmpPressureColumn, invSatOilBArray);
+                satOilMu.setXYContainers(tmpPressureColumn, satOilMuArray);
+                gasDissolutionFac.setXYContainers(tmpPressureColumn, tmpGasSolubilityColumn);
             }
 
             updateSaturationPressureSpline_(regionIdx);


### PR DESCRIPTION
the recent table refactoring replaced the compile-time-safe approach
to columns (i.e., table.getFooColumn()) by a generic method which
requires a magic cookie (i.e., table.getColumn("FOO")). Unfortunately,
this went belly-up with the viscosity column of the PVTO table (here
the magic constant is "MU" and not "MUO". Note that in this respect,
opm-parser is inconsistent w.r.t. the column of the formation volume
factor which is called "BO" and not "B".)

there were also some additional typos: the gas dissolution factor is
"RS" and the pressure of oil is "P".

It probably gets time to make the opm-core/opm-autodiff PVT code use
the stuff from opm-material so that this receives some run-time
testing with `flow` during development. (currently this is only used
by `ebos`...)