### PR TITLE
Add test with Scalar float. 

### DIFF
--- a/opm/material/eos/PengRobinsonMixture.hpp
+++ b/opm/material/eos/PengRobinsonMixture.hpp
@@ -130,7 +130,7 @@ public:
         Scalar expo =  Astar/(Bstar*std::sqrt(u*u - 4*w))*(bi_b - deltai);
 
         Scalar fugCoeff =
-            std::exp(bi_b*(Z - 1))/std::max(1e-9, Z - Bstar) *
+            std::exp(bi_b*(Z - 1))/std::max(Scalar(1e-9), Z - Bstar) *
             std::pow(base, expo);
 
         ////////
@@ -139,12 +139,12 @@ public:
         // on one side, we want the mole fraction to be at
         // least 10^-3 if the fugacity is at the current pressure
         //
-        fugCoeff = std::min(1e10, fugCoeff);
+        fugCoeff = std::min(Scalar(1e10), fugCoeff);
         //
         // on the other hand, if the mole fraction of the component is 100%, we want the
         // fugacity to be at least 10^-3 Pa
         //
-        fugCoeff = std::max(1e-10, fugCoeff);
+        fugCoeff = std::max(Scalar(1e-10), fugCoeff);
         ///////////
 
         return fugCoeff;

--- a/opm/material/eos/PengRobinsonParamsMixture.hpp
+++ b/opm/material/eos/PengRobinsonParamsMixture.hpp
@@ -135,7 +135,7 @@ public:
         Scalar sumx = 0.0;
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             sumx += fs.moleFraction(phaseIdx, compIdx);
-        sumx = std::max(1e-10, sumx);
+        sumx = std::max(Scalar(1e-10), sumx);
 
         // Calculate the Peng-Robinson parameters of the mixture
         //
@@ -144,11 +144,13 @@ public:
         Scalar newA = 0;
         Scalar newB = 0;
         for (unsigned compIIdx = 0; compIIdx < numComponents; ++compIIdx) {
-            Scalar xi = std::max(0.0, std::min(1.0, fs.moleFraction(phaseIdx, compIIdx)));
+            const Scalar moleFracJ = fs.moleFraction(phaseIdx, compIIdx);
+            Scalar xi = std::max(Scalar(0), std::min(Scalar(1), moleFracJ));
             Valgrind::CheckDefined(xi);
 
             for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
-                Scalar xj = std::max(0.0, std::min(1.0, fs.moleFraction(phaseIdx, compJIdx)));
+                const Scalar moleFracJ = fs.moleFraction(phaseIdx, compJIdx );
+                Scalar xj = std::max(Scalar(0), std::min(Scalar(1), moleFracJ));
                 Valgrind::CheckDefined(xj);
 
                 // mixing rule from Reid, page 82
@@ -158,7 +160,7 @@ public:
             }
 
             // mixing rule from Reid, page 82
-            newB += std::max(0.0, xi) * this->pureParams_[compIIdx].b();
+            newB += std::max(Scalar(0), xi) * this->pureParams_[compIIdx].b();
             assert(std::isfinite(newB));
         }
 

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -121,9 +121,9 @@ public:
             // update the tables for the formation volume factor and for the gas
             // dissolution factor of saturated oil
             {
-                std::vector<Scalar> tmpPressureColumn = saturatedTable.getColumn("RS").vectorCopy();
-                std::vector<Scalar> tmpGasSolubilityColumn = saturatedTable.getColumn("P").vectorCopy();
-                std::vector<Scalar> tmpMuColumn = saturatedTable.getColumn("MUO").vectorCopy( );
+                std::vector<double> tmpPressureColumn = saturatedTable.getColumn("RS").vectorCopy();
+                std::vector<double> tmpGasSolubilityColumn = saturatedTable.getColumn("P").vectorCopy();
+                std::vector<double> tmpMuColumn = saturatedTable.getColumn("MUO").vectorCopy( );
 
                 satOilMu.setXYContainers(tmpMuColumn , satOilMuArray);
                 invSatOilB.setXYContainers(tmpPressureColumn , invSatOilBArray);
@@ -171,9 +171,9 @@ private:
                           const SimpleTable& curTable,
                           const SimpleTable& masterTable)
     {
-        std::vector<Scalar> pressuresArray = curTable.getColumn("P").vectorCopy( );
-        std::vector<Scalar> oilBArray = curTable.getColumn("BO").vectorCopy( );
-        std::vector<Scalar> oilMuArray = curTable.getColumn("MU").vectorCopy( );
+        std::vector<double> pressuresArray = curTable.getColumn("P").vectorCopy( );
+        std::vector<double> oilBArray = curTable.getColumn("BO").vectorCopy( );
+        std::vector<double> oilMuArray = curTable.getColumn("MU").vectorCopy( );
 
         auto& invOilB = inverseOilBTable_[regionIdx];
         auto& oilMu = oilMuTable_[regionIdx];

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -88,8 +88,8 @@ public:
             auto& oilVaporizationFac = saturatedOilVaporizationFactorTable_[regionIdx];
 
             {
-                std::vector<Scalar> pressure = saturatedTable.getColumn("PG").vectorCopy( );
-                std::vector<Scalar> rv = saturatedTable.getColumn("RV").vectorCopy( );
+                std::vector<double> pressure = saturatedTable.getColumn("PG").vectorCopy( );
+                std::vector<double> rv = saturatedTable.getColumn("RV").vectorCopy( );
                 oilVaporizationFac.setXYArrays(saturatedTable.numRows(),
                                                pressure , rv );
             }
@@ -125,7 +125,7 @@ public:
             }
 
             {
-                std::vector<Scalar> tmpPressure =  saturatedTable.getColumn("PG").vectorCopy( );
+                std::vector<double> tmpPressure =  saturatedTable.getColumn("PG").vectorCopy( );
 
                 invSatGasB.setXYContainers(tmpPressure, invSatGasBArray);
                 invSatGasBMu.setXYContainers(tmpPressure, invSatGasBMuArray);
@@ -172,9 +172,9 @@ private:
                           const SimpleTable& curTable,
                           const SimpleTable& masterTable)
     {
-        std::vector<Scalar> RvArray = curTable.getColumn("RV").vectorCopy();
-        std::vector<Scalar> gasBArray = curTable.getColumn("BG").vectorCopy();
-        std::vector<Scalar> gasMuArray = curTable.getColumn("MUG").vectorCopy();
+        std::vector<double> RvArray = curTable.getColumn("RV").vectorCopy();
+        std::vector<double> gasBArray = curTable.getColumn("BG").vectorCopy();
+        std::vector<double> gasMuArray = curTable.getColumn("MUG").vectorCopy();
 
         auto& invGasB = inverseGasB_[regionIdx];
         auto& gasMu = gasMu_[regionIdx];

--- a/tests/test_2dtables.cpp
+++ b/tests/test_2dtables.cpp
@@ -34,20 +34,22 @@
 #include <cmath>
 #include <iostream>
 
-typedef double Scalar;
 
-// prototypes
-Scalar testFn1(Scalar x, Scalar y);
-Scalar testFn2(Scalar x, Scalar y);
-Scalar testFn3(Scalar x, Scalar y);
+//typedef double Scalar;
+//typedef float Scalar;
 
-Scalar testFn1(Scalar x, Scalar /* y */)
+template <class ScalarT>
+struct Test
+{
+typedef ScalarT  Scalar;
+
+static Scalar testFn1(Scalar x, Scalar /* y */)
 { return x; }
 
-Scalar testFn2(Scalar /* x */, Scalar y)
+static Scalar testFn2(Scalar /* x */, Scalar y)
 { return y; }
 
-Scalar testFn3(Scalar x, Scalar y)
+static Scalar testFn3(Scalar x, Scalar y)
 { return x*y; }
 
 template <class Fn>
@@ -166,11 +168,11 @@ bool compareTables(const UniformTablePtr uTable,
                    Scalar tolerance = 1e-8)
 {
     // make sure the uniform and the non-uniform tables exhibit the same dimensions
-    if (std::abs(uTable->xMin() - uXTable->xMin()) > 1e-8) {
+    if (std::abs(uTable->xMin() - uXTable->xMin()) > tolerance) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->xMin() != uXTable->xMin(): " << uTable->xMin() << " != " << uXTable->xMin() << "\n";
         return false;
     }
-    if (std::abs(uTable->xMax() - uXTable->xMax()) > 1e-8) {
+    if (std::abs(uTable->xMax() - uXTable->xMax()) > tolerance) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->xMax() != uXTable->xMax(): " << uTable->xMax() << " != " << uXTable->xMax() << "\n";
         return false;
     }
@@ -180,12 +182,12 @@ bool compareTables(const UniformTablePtr uTable,
     }
 
     for (unsigned i = 0; i < uTable->numX(); ++i) {
-        if (std::abs(uTable->yMin() - uXTable->yMin(i)) > 1e-8) {
+        if (std::abs(uTable->yMin() - uXTable->yMin(i)) > tolerance) {
             std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->yMin() != uXTable->yMin("<<i<<"): " << uTable->yMin() << " != " << uXTable->yMin(i) << "\n";
             return false;
         }
 
-        if (std::abs(uTable->yMax() - uXTable->yMax(i)) > 1e-8) {
+        if (std::abs(uTable->yMax() - uXTable->yMax(i)) > tolerance) {
             std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->yMax() != uXTable->yMax("<<i<<"): " << uTable->yMax() << " != " << uXTable->yMax(i) << "\n";
             return false;
         }
@@ -198,13 +200,13 @@ bool compareTables(const UniformTablePtr uTable,
 
     // make sure that the x and y values are identical
     for (unsigned i = 0; i < uTable->numX(); ++i) {
-        if (std::abs(uTable->iToX(i) - uXTable->iToX(i)) > 1e-8) {
+        if (std::abs(uTable->iToX(i) - uXTable->iToX(i)) > tolerance) {
             std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->iToX("<<i<<") != uXTable->iToX("<<i<<"): " << uTable->iToX(i) << " != " << uXTable->iToX(i) << "\n";
             return false;
         }
 
         for (unsigned j = 0; j < uTable->numY(); ++j) {
-            if (std::abs(uTable->jToY(j) - uXTable->jToY(i, j)) > 1e-8) {
+            if (std::abs(uTable->jToY(j) - uXTable->jToY(i, j)) > tolerance) {
                 std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->jToY("<<j<<") != uXTable->jToY("<<i<<","<<j<<"): " << uTable->jToY(i) << " != " << uXTable->jToY(i, j) << "\n";
                 return false;
             }
@@ -218,8 +220,8 @@ bool compareTables(const UniformTablePtr uTable,
     Scalar xMax = uTable->xMax();
     Scalar yMax = uTable->yMax();
 
-    Scalar x = xMin - 1e-8;
-    Scalar y = yMin - 1e-8;
+    Scalar x = xMin - tolerance;
+    Scalar y = yMin - tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -229,8 +231,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMin - 1e-8;
-    y = yMin + 1e-8;
+    x = xMin - tolerance;
+    y = yMin + tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -240,8 +242,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMin + 1e-8;
-    y = yMin - 1e-8;
+    x = xMin + tolerance;
+    y = yMin - tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -251,8 +253,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMin + 1e-8;
-    y = yMin + 1e-8;
+    x = xMin + tolerance;
+    y = yMin + tolerance;
     if (!uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": !uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -262,8 +264,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMax + 1e-8;
-    y = yMax + 1e-8;
+    x = xMax + tolerance;
+    y = yMax + tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -273,8 +275,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMax - 1e-8;
-    y = yMax + 1e-8;
+    x = xMax - tolerance;
+    y = yMax + tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -284,8 +286,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMax + 1e-8;
-    y = yMax - 1e-8;
+    x = xMax + tolerance;
+    y = yMax - tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -295,8 +297,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMax - 1e-8;
-    y = yMax - 1e-8;
+    x = xMax - tolerance;
+    y = yMax - tolerance;
     if (!uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": !uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -325,29 +327,33 @@ bool compareTables(const UniformTablePtr uTable,
 
     return true;
 }
+};
 
-int main()
+
+template <class TestType>
+inline int testAll( const typename TestType::Scalar tolerance = 1e-6 )
 {
-    auto uniformTab = createUniformTabulatedFunction(testFn1);
-    auto uniformXTab = createUniformXTabulatedFunction(testFn1);
-    if (!compareTables(uniformTab, uniformXTab, testFn1, /*tolerance=*/1e-12))
+    TestType test;
+    auto uniformTab = test.createUniformTabulatedFunction(TestType::testFn1);
+    auto uniformXTab = test.createUniformXTabulatedFunction(TestType::testFn1);
+    if (!test.compareTables(uniformTab, uniformXTab, TestType::testFn1, tolerance))
         return 1;
 
-    uniformTab = createUniformTabulatedFunction(testFn2);
-    uniformXTab = createUniformXTabulatedFunction(testFn2);
-    if (!compareTables(uniformTab, uniformXTab, testFn2, /*tolerance=*/1e-12))
+    uniformTab = test.createUniformTabulatedFunction(TestType::testFn2);
+    uniformXTab = test.createUniformXTabulatedFunction(TestType::testFn2);
+    if (!test.compareTables(uniformTab, uniformXTab, TestType::testFn2, tolerance))
         return 1;
 
-    uniformTab = createUniformTabulatedFunction(testFn3);
-    uniformXTab = createUniformXTabulatedFunction(testFn3);
-    if (!compareTables(uniformTab, uniformXTab, testFn3, /*tolerance=*/1e-2))
+    uniformTab = test.createUniformTabulatedFunction(TestType::testFn3);
+    uniformXTab = test.createUniformXTabulatedFunction(TestType::testFn3);
+    if (!test.compareTables(uniformTab, uniformXTab, TestType::testFn3, /*tolerance=*/1e-2))
         return 1;
 
-    uniformXTab = createUniformXTabulatedFunction2(testFn3);
-    if (!compareTableWithAnalyticFn(uniformXTab,
+    uniformXTab = test.createUniformXTabulatedFunction2(TestType::testFn3);
+    if (!test.compareTableWithAnalyticFn(uniformXTab,
                                     -2.0, 3.0, 100,
                                     -4.0, 5.0, 100,
-                                    testFn3,
+                                    TestType::testFn3,
                                     /*tolerance=*/1e-2))
         return 1;
 
@@ -373,6 +379,15 @@ int main()
         std::cout << "\n";
     }
 #endif
+    return 0;
+}
 
+
+int main()
+{
+    if( testAll< Test<double> >( 1e-12 ) )
+        return 1;
+    if( testAll< Test<float> >( 1e-6 ) )
+        return 1;
     return 0;
 }

--- a/tests/test_2dtables.cpp
+++ b/tests/test_2dtables.cpp
@@ -35,9 +35,6 @@
 #include <iostream>
 
 
-//typedef double Scalar;
-//typedef float Scalar;
-
 template <class ScalarT>
 struct Test
 {

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -95,16 +95,22 @@ void testAllComponents()
 
 class TestAdTag;
 
-int main(int argc, char **argv)
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
-
-    Dune::MPIHelper::instance(argc, argv);
 
     // ensure that all components are API-compliant
     testAllComponents<Scalar, Scalar>();
     testAllComponents<Scalar, Evaluation>();
+}
 
+
+int main(int argc, char **argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+
+    testAll< double >();
+    testAll< float  >();
     return 0;
 }

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -218,10 +218,9 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
     }
 }
 
-int main()
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
-
     Opm::Parser parser;
     Opm::ParseMode parseMode;
 
@@ -309,6 +308,12 @@ int main()
     // make sure that the BlackOil fluid system's initFromDeck() method compiles.
     typedef Opm::FluidSystems::BlackOil<Scalar> BlackOilFluidSystem;
     BlackOilFluidSystem::initFromDeck(deck, eclState);
+}
 
+
+int main()
+{
+    testAll< double >();
+    testAll< float  >();
     return 0;
 }

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -314,6 +314,6 @@ inline void testAll()
 int main()
 {
     testAll< double >();
-    testAll< float  >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_eclmateriallawmanager.cpp
+++ b/tests/test_eclmateriallawmanager.cpp
@@ -205,14 +205,13 @@ static const char* fam2DeckString =
     "    0.88     1        1    /  \n"
     "\n";
 
-
-int main()
+template <class Scalar>
+inline void testAll()
 {
     enum { numPhases = 3 };
     enum { waterPhaseIdx = 0 };
     enum { oilPhaseIdx = 1 };
     enum { gasPhaseIdx = 2 };
-    typedef double Scalar;
     typedef Opm::ThreePhaseMaterialTraits<Scalar,
                                           /*wettingPhaseIdx=*/waterPhaseIdx,
                                           /*nonWettingPhaseIdx=*/oilPhaseIdx,
@@ -236,7 +235,7 @@ int main()
 
     {
         typedef Opm::EclMaterialLawManager<MaterialTraits> MaterialLawManager;
-        typedef MaterialLawManager::MaterialLaw MaterialLaw;
+        typedef typename MaterialLawManager::MaterialLaw MaterialLaw;
 
         const auto deck = parser.parseString(fam1DeckString, parseMode);
         const auto eclState = std::make_shared<Opm::EclipseState>(deck, parseMode);
@@ -317,6 +316,12 @@ int main()
             }
         }
     }
+}
 
+
+int main()
+{
+    testAll< double >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -269,9 +269,9 @@ void testThreePhaseSatApi()
 
 class TestAdTag;
 
-int main(int argc, char **argv)
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::SimpleH2O<Scalar> H2O;
     typedef Opm::N2<Scalar> N2;
 
@@ -293,8 +293,6 @@ int main(int argc, char **argv)
     typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
     typedef Opm::ImmiscibleFluidState<Evaluation, TwoPFluidSystem> TwoPhaseFluidState;
     typedef Opm::ImmiscibleFluidState<Evaluation, ThreePFluidSystem> ThreePhaseFluidState;
-
-    Dune::MPIHelper::instance(argc, argv);
 
     // test conformance to the capillary pressure APIs
     {
@@ -438,6 +436,12 @@ int main(int argc, char **argv)
         testTwoPhaseApi<MaterialLaw, TwoPhaseFluidState>();
         testTwoPhaseSatApi<MaterialLaw, TwoPhaseFluidState>();
     }
+}
 
+int main(int argc, char **argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    testAll< double >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -317,12 +317,10 @@ void testAllFluidSystems()
 
 class TestAdTag;
 
-int main(int argc, char **argv)
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
-
-    Dune::MPIHelper::instance(argc, argv);
 
     // ensure that all fluid states are API-compliant
     testAllFluidStates<Scalar>();
@@ -334,6 +332,12 @@ int main(int argc, char **argv)
     testAllFluidSystems<Scalar, Scalar>();
     testAllFluidSystems<Scalar, Evaluation>();
     testAllFluidSystems<Scalar, Evaluation, Scalar>();
+}
 
+int main(int argc, char **argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    testAll< double > ();
+    // testAll< float >  ();
     return 0;
 }

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -144,10 +144,9 @@ void completeReferenceFluidState(FluidState &fs,
     }
 }
 
-
-int main()
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::FluidSystems::H2ON2<Scalar> FluidSystem;
     typedef Opm::ImmiscibleFluidState<Scalar, FluidSystem> ImmiscibleFluidState;
 
@@ -162,7 +161,7 @@ int main()
     typedef Opm::TwoPhaseMaterialTraits<Scalar, liquidPhaseIdx, gasPhaseIdx> MaterialLawTraits;
     typedef Opm::RegularizedBrooksCorey<MaterialLawTraits> EffMaterialLaw;
     typedef Opm::EffToAbsLaw<EffMaterialLaw> MaterialLaw;
-    typedef MaterialLaw::Params MaterialLawParams;
+    typedef typename MaterialLaw::Params MaterialLawParams;
 
     Scalar T = 273.15 + 25;
 
@@ -260,6 +259,11 @@ int main()
 
     // check the flash calculation
     checkImmiscibleFlash<Scalar, FluidSystem, MaterialLaw>(fsRef, matParams2);
+}
 
+int main()
+{
+    testAll< double >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_localad.cpp
+++ b/tests/test_localad.cpp
@@ -53,8 +53,21 @@ struct TestVariables
     static const int saturationIdx = 2;
 };
 
+template <class Scalar>
+struct Tolerance
+{
+    static constexpr Scalar eps = 1e-10;
+};
+
+template <>
+struct Tolerance< float >
+{
+    static constexpr  float eps = 1e-6;
+};
+
+
 template <class Scalar, class VariablesDescriptor>
-void testOperators()
+void testOperators(const Scalar tolerance )
 {
     typedef Opm::LocalAd::Evaluation<Scalar, VariablesDescriptor, VariablesDescriptor::size> Eval;
 
@@ -70,57 +83,57 @@ void testOperators()
     // test the non-inplace operators
     {
         Eval a = xEval + yEval;
-        if (std::abs(a.value - (x + y)) > 1e-10)
+        if (std::abs(a.value - (x + y)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval b = xEval + c;
-        if (std::abs(b.value - (x + c)) > 1e-10)
+        if (std::abs(b.value - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval d = xEval + cEval;
-        if (std::abs(d.value - (x + c)) > 1e-10)
+        if (std::abs(d.value - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
     }
 
     {
         Eval a = xEval - yEval;
-        if (std::abs(a.value - (x - y)) > 1e-10)
+        if (std::abs(a.value - (x - y)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval b = xEval - c;
-        if (std::abs(b.value - (x - c)) > 1e-10)
+        if (std::abs(b.value - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval d = xEval - cEval;
-        if (std::abs(d.value - (x - c)) > 1e-10)
+        if (std::abs(d.value - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
     }
 
     {
         Eval a = xEval*yEval;
-        if (std::abs(a.value - (x*y)) > 1e-10)
+        if (std::abs(a.value - (x*y)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval b = xEval*c;
-        if (std::abs(b.value - (x*c)) > 1e-10)
+        if (std::abs(b.value - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval d = xEval*cEval;
-        if (std::abs(d.value - (x*c)) > 1e-10)
+        if (std::abs(d.value - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
     }
 
     {
         Eval a = xEval/yEval;
-        if (std::abs(a.value - (x/y)) > 1e-10)
+        if (std::abs(a.value - (x/y)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval b = xEval/c;
-        if (std::abs(b.value - (x/c)) > 1e-10)
+        if (std::abs(b.value - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval d = xEval/cEval;
-        if (std::abs(d.value - (x/c)) > 1e-10)
+        if (std::abs(d.value - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
     }
 
@@ -128,68 +141,68 @@ void testOperators()
     {
         Eval a = xEval;
         a += yEval;
-        if (std::abs(a.value - (x + y)) > 1e-10)
+        if (std::abs(a.value - (x + y)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval b = xEval;
         b += c;
-        if (std::abs(b.value - (x + c)) > 1e-10)
+        if (std::abs(b.value - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval d = xEval;
         d += cEval;
-        if (std::abs(d.value - (x + c)) > 1e-10)
+        if (std::abs(d.value - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
     }
 
     {
         Eval a = xEval;
         a -= yEval;
-        if (std::abs(a.value - (x - y)) > 1e-10)
+        if (std::abs(a.value - (x - y)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval b = xEval;
         b -= c;
-        if (std::abs(b.value - (x - c)) > 1e-10)
+        if (std::abs(b.value - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval d = xEval;
         d -= cEval;
-        if (std::abs(d.value - (x - c)) > 1e-10)
+        if (std::abs(d.value - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
     }
 
     {
         Eval a = xEval;
         a *= yEval;
-        if (std::abs(a.value - (x*y)) > 1e-10)
+        if (std::abs(a.value - (x*y)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval b = xEval;
         b *= c;
-        if (std::abs(b.value - (x*c)) > 1e-10)
+        if (std::abs(b.value - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval d = xEval;
         d *= cEval;
-        if (std::abs(d.value - (x*c)) > 1e-10)
+        if (std::abs(d.value - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
     }
 
     {
         Eval a = xEval;
         a /= yEval;
-        if (std::abs(a.value - (x/y)) > 1e-10)
+        if (std::abs(a.value - (x/y)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval b = xEval;
         b /= c;
-        if (std::abs(b.value - (x/c)) > 1e-10)
+        if (std::abs(b.value - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval d = xEval;
         d /= cEval;
-        if (std::abs(d.value - (x/c)) > 1e-10)
+        if (std::abs(d.value - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
     }
 
@@ -241,7 +254,7 @@ void test1DFunction(AdFn* adFn, ClassicFn* classicFn, Scalar xMin = 1e-6, Scalar
         const auto& xEval = Eval::createVariable(x, 0);
         const Eval& yEval = adFn(xEval);
 
-        const Scalar eps = 1e-10;
+        const Scalar eps = Tolerance< Scalar > :: eps;
         Scalar y = classicFn(x);
         Scalar yStar1 = classicFn(x - eps);
         Scalar yStar2 = classicFn(x + eps);
@@ -276,11 +289,11 @@ void test2DFunction1(AdFn* adFn, ClassicFn* classicFn, Scalar xMin, Scalar xMax,
         const auto& yEval = Eval::createConstant(y);
         const Eval& zEval = adFn(xEval, yEval);
 
-        const Scalar eps = 1e-10;
+        const Scalar eps = Tolerance< Scalar > :: eps;
         Scalar z = classicFn(x, y);
         Scalar zStar1 = classicFn(x - eps, y);
         Scalar zStar2 = classicFn(x + eps, y);
-        Scalar zPrime = (zStar2 - zStar1)/(2*eps);
+        Scalar zPrime = (zStar2 - zStar1)/(2.*eps);
 
         if (z != zEval.value)
             throw std::logic_error("oops: value");
@@ -311,7 +324,7 @@ void test2DFunction2(AdFn* adFn, ClassicFn* classicFn, Scalar x, Scalar yMin, Sc
         const auto& yEval = Eval::createVariable(y, 1);
         const Eval& zEval = adFn(xEval, yEval);
 
-        const Scalar eps = 1e-10;
+        const Scalar eps = Tolerance< Scalar > :: eps;
         Scalar z = classicFn(x, y);
         Scalar zStar1 = classicFn(x, y - eps);
         Scalar zStar2 = classicFn(x, y + eps);
@@ -473,7 +486,7 @@ inline void testAll()
     //const auto& result2 = Opm::LocalAd::sqrt(TemperatureEval::createVariable<Pressure>(4.0));
 
     std::cout << "testing operators and constructors\n";
-    testOperators<Scalar, VarsDescriptor>();
+    testOperators<Scalar, VarsDescriptor>( Tolerance< Scalar > :: eps );
 
     std::cout << "testing min()\n";
     test2DFunction1<Scalar, VarsDescriptor>(Opm::LocalAd::min<Scalar, VarsDescriptor, VarsDescriptor::size>,
@@ -556,6 +569,6 @@ inline void testAll()
 int main()
 {
     testAll< double >();
-    testAll< float  >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_localad.cpp
+++ b/tests/test_localad.cpp
@@ -462,10 +462,9 @@ double myScalarMin(double a, double b)
 double myScalarMax(double a, double b)
 { return std::max(a, b); }
 
-int main()
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
-
     typedef TestVariables VarsDescriptor;
 
     // the following is commented out because it is supposed to produce a compiler
@@ -552,6 +551,11 @@ int main()
     test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::log<Scalar, VarsDescriptor, VarsDescriptor::size>,
                                            static_cast<Scalar (*)(Scalar)>(std::log),
                                            1e-6, 1e9);
+}
 
+int main()
+{
+    testAll< double >();
+    testAll< float  >();
     return 0;
 }

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -148,9 +148,9 @@ void completeReferenceFluidState(FluidState &fs,
 }
 
 
-int main()
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::FluidSystems::H2ON2<Scalar, false> FluidSystem;
     typedef Opm::CompositionalFluidState<Scalar, FluidSystem> CompositionalFluidState;
 
@@ -165,7 +165,7 @@ int main()
     typedef Opm::TwoPhaseMaterialTraits<Scalar, liquidPhaseIdx, gasPhaseIdx> MaterialTraits;
     typedef Opm::RegularizedBrooksCorey<MaterialTraits> EffMaterialLaw;
     typedef Opm::EffToAbsLaw<EffMaterialLaw> MaterialLaw;
-    typedef MaterialLaw::Params MaterialLawParams;
+    typedef typename MaterialLaw::Params MaterialLawParams;
 
     Scalar T = 273.15 + 25;
 
@@ -249,7 +249,7 @@ int main()
     fsRef.setPressure(liquidPhaseIdx, 1e6);
     fsRef.setPressure(gasPhaseIdx, 1e6);
 
-    FluidSystem::ParameterCache paramCache;
+    typename FluidSystem::ParameterCache paramCache;
     typedef Opm::MiscibleMultiPhaseComposition<Scalar, FluidSystem> MiscibleMultiPhaseComposition;
     MiscibleMultiPhaseComposition::solve(fsRef, paramCache,
                                          /*setViscosity=*/false,
@@ -291,6 +291,11 @@ int main()
 
     // check the flash calculation
     checkNcpFlash<Scalar, FluidSystem, MaterialLaw>(fsRef, matParams2);
+}
 
+int main()
+{
+    testAll< double >();
+    testAll< float  >();
     return 0;
 }

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -296,6 +296,6 @@ inline void testAll()
 int main()
 {
     testAll< double >();
-    testAll< float  >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -285,9 +285,9 @@ void printResult(const RawTable& rawTable,
     std::cout << "};\n";
 }
 
-int main(int /*argc*/, char** /*argv*/)
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::FluidSystems::Spe5<Scalar> FluidSystem;
 
     enum {
@@ -312,9 +312,9 @@ int main(int /*argc*/, char** /*argv*/)
 
     typedef Opm::ThreePhaseMaterialTraits<Scalar, waterPhaseIdx, oilPhaseIdx, gasPhaseIdx> MaterialTraits;
     typedef Opm::LinearMaterial<MaterialTraits> MaterialLaw;
-    typedef MaterialLaw::Params MaterialLawParams;
+    typedef typename MaterialLaw::Params MaterialLawParams;
 
-    typedef FluidSystem::ParameterCache ParameterCache;
+    typedef typename FluidSystem::ParameterCache ParameterCache;
 
     ////////////
     // Initialize the fluid system and create the capillary pressure
@@ -399,7 +399,7 @@ int main(int /*argc*/, char** /*argv*/)
     FluidState flashFluidState, surfaceFluidState;
     flashFluidState.assign(fluidState);
     //Flash::guessInitial(flashFluidState, paramCache, totalMolarities);
-    Flash::solve<MaterialLaw>(flashFluidState, paramCache, matParams, totalMolarities);
+    Flash::template solve<MaterialLaw>(flashFluidState, paramCache, matParams, totalMolarities);
 
     Scalar surfaceAlpha = 1;
     surfaceAlpha = bringOilToSurface<Scalar, FluidSystem>(surfaceFluidState, surfaceAlpha, flashFluidState, /*guessInitial=*/true);
@@ -422,7 +422,7 @@ int main(int /*argc*/, char** /*argv*/)
         curTotalMolarities /= alpha;
 
         // "flash" the modified reservoir oil
-        Flash::solve<MaterialLaw>(flashFluidState, paramCache, matParams, curTotalMolarities);
+        Flash::template solve<MaterialLaw>(flashFluidState, paramCache, matParams, curTotalMolarities);
 
         surfaceAlpha = bringOilToSurface<Scalar, FluidSystem>(surfaceFluidState,
                                                               surfaceAlpha,
@@ -471,7 +471,11 @@ int main(int /*argc*/, char** /*argv*/)
     printResult(resultTable,
                 "Rs", /*firstIdx=*/1, /*secondIdx=*/7,
                 /*hiresThreshold=*/hiresThresholdPressure);
+}
 
-
+int main(int /*argc*/, char** /*argv*/)
+{
+    testAll< double >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -476,6 +476,6 @@ inline void testAll()
 int main(int /*argc*/, char** /*argv*/)
 {
     testAll< double >();
-    // testAll< float  >();
+    //testAll< float  >();
     return 0;
 }

--- a/tests/test_tabulation.cpp
+++ b/tests/test_tabulation.cpp
@@ -45,9 +45,9 @@ void isSame(const char *str, Scalar v, Scalar vRef, Scalar tol=1e-3)
     }
 }
 
-int main()
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::H2O<Scalar> IapwsH2O;
     typedef Opm::TabulatedComponent<Scalar, IapwsH2O> TabulatedH2O;
 
@@ -78,7 +78,8 @@ int main()
         isSame("vaporPressure",
                TabulatedH2O::vaporPressure(T),
                IapwsH2O::vaporPressure(T),
-               1e-3);
+               Scalar(1e-3));
+
         for (unsigned j = 0; j < n; ++j) {
             Scalar p = pMin + (pMax - pMin)*Scalar(j)/n;
             if (p < IapwsH2O::vaporPressure(T) * 1.001) {
@@ -112,5 +113,12 @@ int main()
 
     if (success)
         std::cout << "\nsuccess\n";
+}
+
+
+int main()
+{
+    testAll< double >();
+    testAll< float  >();
     return 0;
 }


### PR DESCRIPTION
This PR revised all tests such that Scalar=double and Scalar=float is tested. All tests compile, some of the test do not work with float and are therefore disabled for now. 