### PR TITLE
Add tests using Scalar=float (try 2).

### DIFF
--- a/opm/material/components/Mesitylene.hpp
+++ b/opm/material/components/Mesitylene.hpp
@@ -129,7 +129,8 @@ public:
         //                = 0.5 T * (cp(0.2113 T) + cp(0.7887 T) )
 
         // enthalpy may have arbitrary reference state, but the empirical/fitted heatCapacity function needs Kelvin as input
-        return 0.5*temperature*(liquidHeatCapacity(0.2113*temperature, pressure) + liquidHeatCapacity(0.7887*temperature, pressure));
+        return 0.5*temperature*(liquidHeatCapacity(Evaluation(0.2113*temperature), pressure)
+                                + liquidHeatCapacity(Evaluation(0.7887*temperature), pressure));
     }
 
     /*!

--- a/opm/material/components/Xylene.hpp
+++ b/opm/material/components/Xylene.hpp
@@ -161,8 +161,8 @@ public:
         //                = 0.5 T * (cp(0.2113 T) + cp(0.7887 T) )
 
         // enthalpy may have arbitrary reference state, but the empirical/fitted heatCapacity function needs Kelvin as input
-        return 0.5*temperature*(spHeatCapLiquidPhase(0.2113*temperature,pressure)
-                                + spHeatCapLiquidPhase(0.7887*temperature,pressure));
+        return 0.5*temperature*(spHeatCapLiquidPhase(Evaluation(0.2113*temperature),pressure)
+                                + spHeatCapLiquidPhase(Evaluation(0.7887*temperature),pressure));
     }
 
     /*!

--- a/opm/material/constraintsolvers/ImmiscibleFlash.hpp
+++ b/opm/material/constraintsolvers/ImmiscibleFlash.hpp
@@ -287,7 +287,7 @@ protected:
             const Scalar eps = 1e-10/quantityWeight_(fluidState, pvIdx);
             setQuantity_<MaterialLaw>(fluidState, paramCache, matParams, pvIdx, xI + eps);
             assert(std::abs(getQuantity_(fluidState, pvIdx) - (xI + eps))
-                   <= std::max(1.0, std::abs(xI))*std::numeric_limits<Scalar>::epsilon()*100);
+                   <= std::max<Scalar>(1.0, std::abs(xI))*std::numeric_limits<Scalar>::epsilon()*100);
 
             // compute derivative of the defect
             calculateDefect_(tmp, origFluidState, fluidState, globalMolarities);
@@ -338,12 +338,13 @@ protected:
             if (isSaturationIdx_(pvIdx)) {
                 // dampen to at most 20% change in saturation per
                 // iteration
-                delta = std::min(0.2, std::max(-0.2, delta));
+                delta = std::min<Scalar>(0.2, std::max<Scalar>(-0.2, delta));
             }
             else if (isPressureIdx_(pvIdx)) {
                 // dampen to at most 30% change in pressure per
                 // iteration
-                delta = std::min(0.30*fluidState.pressure(0), std::max(-0.30*fluidState.pressure(0), delta));
+                delta = std::min<Scalar>(0.30*fluidState.pressure(0),
+                                         std::max<Scalar>(-0.30*fluidState.pressure(0), delta));
             };
 
             setQuantityRaw_(fluidState, pvIdx, tmp - delta);
@@ -498,7 +499,7 @@ protected:
 
             // make sure that the first M-1 saturations does not get
             // negative
-            value = std::max(0.0, value);
+            value = std::max<Scalar>(0.0, value);
             fs.setSaturation(phaseIdx, value);
         }
     }

--- a/opm/material/eos/PengRobinsonMixture.hpp
+++ b/opm/material/eos/PengRobinsonMixture.hpp
@@ -130,7 +130,7 @@ public:
         Scalar expo =  Astar/(Bstar*std::sqrt(u*u - 4*w))*(bi_b - deltai);
 
         Scalar fugCoeff =
-            std::exp(bi_b*(Z - 1))/std::max(1e-9, Z - Bstar) *
+            std::exp(bi_b*(Z - 1))/std::max(Scalar(1e-9), Z - Bstar) *
             std::pow(base, expo);
 
         ////////
@@ -139,12 +139,12 @@ public:
         // on one side, we want the mole fraction to be at
         // least 10^-3 if the fugacity is at the current pressure
         //
-        fugCoeff = std::min(1e10, fugCoeff);
+        fugCoeff = std::min(Scalar(1e10), fugCoeff);
         //
         // on the other hand, if the mole fraction of the component is 100%, we want the
         // fugacity to be at least 10^-3 Pa
         //
-        fugCoeff = std::max(1e-10, fugCoeff);
+        fugCoeff = std::max(Scalar(1e-10), fugCoeff);
         ///////////
 
         return fugCoeff;

--- a/opm/material/eos/PengRobinsonParamsMixture.hpp
+++ b/opm/material/eos/PengRobinsonParamsMixture.hpp
@@ -135,7 +135,7 @@ public:
         Scalar sumx = 0.0;
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             sumx += fs.moleFraction(phaseIdx, compIdx);
-        sumx = std::max(1e-10, sumx);
+        sumx = std::max(Scalar(1e-10), sumx);
 
         // Calculate the Peng-Robinson parameters of the mixture
         //
@@ -144,11 +144,13 @@ public:
         Scalar newA = 0;
         Scalar newB = 0;
         for (unsigned compIIdx = 0; compIIdx < numComponents; ++compIIdx) {
-            Scalar xi = std::max(0.0, std::min(1.0, fs.moleFraction(phaseIdx, compIIdx)));
+            const Scalar moleFracJ = fs.moleFraction(phaseIdx, compIIdx);
+            Scalar xi = std::max(Scalar(0), std::min(Scalar(1), moleFracJ));
             Valgrind::CheckDefined(xi);
 
             for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
-                Scalar xj = std::max(0.0, std::min(1.0, fs.moleFraction(phaseIdx, compJIdx)));
+                const Scalar moleFracJ = fs.moleFraction(phaseIdx, compJIdx );
+                Scalar xj = std::max(Scalar(0), std::min(Scalar(1), moleFracJ));
                 Valgrind::CheckDefined(xj);
 
                 // mixing rule from Reid, page 82
@@ -158,7 +160,7 @@ public:
             }
 
             // mixing rule from Reid, page 82
-            newB += std::max(0.0, xi) * this->pureParams_[compIIdx].b();
+            newB += std::max(Scalar(0), xi) * this->pureParams_[compIIdx].b();
             assert(std::isfinite(newB));
         }
 

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -118,9 +118,9 @@ public:
             // update the tables for the formation volume factor and for the gas
             // dissolution factor of saturated oil
             {
-                std::vector<Scalar> tmpPressureColumn = saturatedTable.getColumn("P").vectorCopy();
-                std::vector<Scalar> tmpGasSolubilityColumn = saturatedTable.getColumn("RS").vectorCopy();
-                std::vector<Scalar> tmpMuColumn = saturatedTable.getColumn("MU").vectorCopy();
+                std::vector<double> tmpPressureColumn = saturatedTable.getColumn("P").vectorCopy();
+                std::vector<double> tmpGasSolubilityColumn = saturatedTable.getColumn("RS").vectorCopy();
+                std::vector<double> tmpMuColumn = saturatedTable.getColumn("MU").vectorCopy();
 
                 invSatOilB.setXYContainers(tmpPressureColumn, invSatOilBArray);
                 satOilMu.setXYContainers(tmpPressureColumn, satOilMuArray);
@@ -168,9 +168,9 @@ private:
                           const SimpleTable& curTable,
                           const SimpleTable& masterTable)
     {
-        std::vector<Scalar> pressuresArray = curTable.getColumn("P").vectorCopy();
-        std::vector<Scalar> oilBArray = curTable.getColumn("BO").vectorCopy();
-        std::vector<Scalar> oilMuArray = curTable.getColumn("MU").vectorCopy();
+        std::vector<double> pressuresArray = curTable.getColumn("P").vectorCopy();
+        std::vector<double> oilBArray = curTable.getColumn("BO").vectorCopy();
+        std::vector<double> oilMuArray = curTable.getColumn("MU").vectorCopy();
 
         auto& invOilB = inverseOilBTable_[regionIdx];
         auto& oilMu = oilMuTable_[regionIdx];

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -88,8 +88,8 @@ public:
             auto& oilVaporizationFac = saturatedOilVaporizationFactorTable_[regionIdx];
 
             {
-                std::vector<Scalar> pressure = saturatedTable.getColumn("PG").vectorCopy( );
-                std::vector<Scalar> rv = saturatedTable.getColumn("RV").vectorCopy( );
+                std::vector<double> pressure = saturatedTable.getColumn("PG").vectorCopy( );
+                std::vector<double> rv = saturatedTable.getColumn("RV").vectorCopy( );
                 oilVaporizationFac.setXYArrays(saturatedTable.numRows(),
                                                pressure , rv );
             }
@@ -125,7 +125,7 @@ public:
             }
 
             {
-                std::vector<Scalar> tmpPressure =  saturatedTable.getColumn("PG").vectorCopy( );
+                std::vector<double> tmpPressure =  saturatedTable.getColumn("PG").vectorCopy( );
 
                 invSatGasB.setXYContainers(tmpPressure, invSatGasBArray);
                 invSatGasBMu.setXYContainers(tmpPressure, invSatGasBMuArray);
@@ -172,9 +172,9 @@ private:
                           const SimpleTable& curTable,
                           const SimpleTable& masterTable)
     {
-        std::vector<Scalar> RvArray = curTable.getColumn("RV").vectorCopy();
-        std::vector<Scalar> gasBArray = curTable.getColumn("BG").vectorCopy();
-        std::vector<Scalar> gasMuArray = curTable.getColumn("MUG").vectorCopy();
+        std::vector<double> RvArray = curTable.getColumn("RV").vectorCopy();
+        std::vector<double> gasBArray = curTable.getColumn("BG").vectorCopy();
+        std::vector<double> gasMuArray = curTable.getColumn("MUG").vectorCopy();
 
         auto& invGasB = inverseGasB_[regionIdx];
         auto& gasMu = gasMu_[regionIdx];

--- a/tests/test_2dtables.cpp
+++ b/tests/test_2dtables.cpp
@@ -34,20 +34,19 @@
 #include <cmath>
 #include <iostream>
 
-typedef double Scalar;
 
-// prototypes
-Scalar testFn1(Scalar x, Scalar y);
-Scalar testFn2(Scalar x, Scalar y);
-Scalar testFn3(Scalar x, Scalar y);
+template <class ScalarT>
+struct Test
+{
+typedef ScalarT  Scalar;
 
-Scalar testFn1(Scalar x, Scalar /* y */)
+static Scalar testFn1(Scalar x, Scalar /* y */)
 { return x; }
 
-Scalar testFn2(Scalar /* x */, Scalar y)
+static Scalar testFn2(Scalar /* x */, Scalar y)
 { return y; }
 
-Scalar testFn3(Scalar x, Scalar y)
+static Scalar testFn3(Scalar x, Scalar y)
 { return x*y; }
 
 template <class Fn>
@@ -166,11 +165,11 @@ bool compareTables(const UniformTablePtr uTable,
                    Scalar tolerance = 1e-8)
 {
     // make sure the uniform and the non-uniform tables exhibit the same dimensions
-    if (std::abs(uTable->xMin() - uXTable->xMin()) > 1e-8) {
+    if (std::abs(uTable->xMin() - uXTable->xMin()) > tolerance) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->xMin() != uXTable->xMin(): " << uTable->xMin() << " != " << uXTable->xMin() << "\n";
         return false;
     }
-    if (std::abs(uTable->xMax() - uXTable->xMax()) > 1e-8) {
+    if (std::abs(uTable->xMax() - uXTable->xMax()) > tolerance) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->xMax() != uXTable->xMax(): " << uTable->xMax() << " != " << uXTable->xMax() << "\n";
         return false;
     }
@@ -180,12 +179,12 @@ bool compareTables(const UniformTablePtr uTable,
     }
 
     for (unsigned i = 0; i < uTable->numX(); ++i) {
-        if (std::abs(uTable->yMin() - uXTable->yMin(i)) > 1e-8) {
+        if (std::abs(uTable->yMin() - uXTable->yMin(i)) > tolerance) {
             std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->yMin() != uXTable->yMin("<<i<<"): " << uTable->yMin() << " != " << uXTable->yMin(i) << "\n";
             return false;
         }
 
-        if (std::abs(uTable->yMax() - uXTable->yMax(i)) > 1e-8) {
+        if (std::abs(uTable->yMax() - uXTable->yMax(i)) > tolerance) {
             std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->yMax() != uXTable->yMax("<<i<<"): " << uTable->yMax() << " != " << uXTable->yMax(i) << "\n";
             return false;
         }
@@ -198,13 +197,13 @@ bool compareTables(const UniformTablePtr uTable,
 
     // make sure that the x and y values are identical
     for (unsigned i = 0; i < uTable->numX(); ++i) {
-        if (std::abs(uTable->iToX(i) - uXTable->iToX(i)) > 1e-8) {
+        if (std::abs(uTable->iToX(i) - uXTable->iToX(i)) > tolerance) {
             std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->iToX("<<i<<") != uXTable->iToX("<<i<<"): " << uTable->iToX(i) << " != " << uXTable->iToX(i) << "\n";
             return false;
         }
 
         for (unsigned j = 0; j < uTable->numY(); ++j) {
-            if (std::abs(uTable->jToY(j) - uXTable->jToY(i, j)) > 1e-8) {
+            if (std::abs(uTable->jToY(j) - uXTable->jToY(i, j)) > tolerance) {
                 std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->jToY("<<j<<") != uXTable->jToY("<<i<<","<<j<<"): " << uTable->jToY(i) << " != " << uXTable->jToY(i, j) << "\n";
                 return false;
             }
@@ -218,8 +217,8 @@ bool compareTables(const UniformTablePtr uTable,
     Scalar xMax = uTable->xMax();
     Scalar yMax = uTable->yMax();
 
-    Scalar x = xMin - 1e-8;
-    Scalar y = yMin - 1e-8;
+    Scalar x = xMin - tolerance;
+    Scalar y = yMin - tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -229,8 +228,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMin - 1e-8;
-    y = yMin + 1e-8;
+    x = xMin - tolerance;
+    y = yMin + tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -240,8 +239,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMin + 1e-8;
-    y = yMin - 1e-8;
+    x = xMin + tolerance;
+    y = yMin - tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -251,8 +250,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMin + 1e-8;
-    y = yMin + 1e-8;
+    x = xMin + tolerance;
+    y = yMin + tolerance;
     if (!uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": !uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -262,8 +261,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMax + 1e-8;
-    y = yMax + 1e-8;
+    x = xMax + tolerance;
+    y = yMax + tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -273,8 +272,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMax - 1e-8;
-    y = yMax + 1e-8;
+    x = xMax - tolerance;
+    y = yMax + tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -284,8 +283,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMax + 1e-8;
-    y = yMax - 1e-8;
+    x = xMax + tolerance;
+    y = yMax - tolerance;
     if (uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -295,8 +294,8 @@ bool compareTables(const UniformTablePtr uTable,
         return false;
     }
 
-    x = xMax - 1e-8;
-    y = yMax - 1e-8;
+    x = xMax - tolerance;
+    y = yMax - tolerance;
     if (!uTable->applies(x, y)) {
         std::cerr << __FILE__ << ":" << __LINE__ << ": !uTable->applies("<<x<<","<<y<<")\n";
         return false;
@@ -325,29 +324,33 @@ bool compareTables(const UniformTablePtr uTable,
 
     return true;
 }
+};
 
-int main()
+
+template <class TestType>
+inline int testAll( const typename TestType::Scalar tolerance = 1e-6 )
 {
-    auto uniformTab = createUniformTabulatedFunction(testFn1);
-    auto uniformXTab = createUniformXTabulatedFunction(testFn1);
-    if (!compareTables(uniformTab, uniformXTab, testFn1, /*tolerance=*/1e-12))
+    TestType test;
+    auto uniformTab = test.createUniformTabulatedFunction(TestType::testFn1);
+    auto uniformXTab = test.createUniformXTabulatedFunction(TestType::testFn1);
+    if (!test.compareTables(uniformTab, uniformXTab, TestType::testFn1, tolerance))
         return 1;
 
-    uniformTab = createUniformTabulatedFunction(testFn2);
-    uniformXTab = createUniformXTabulatedFunction(testFn2);
-    if (!compareTables(uniformTab, uniformXTab, testFn2, /*tolerance=*/1e-12))
+    uniformTab = test.createUniformTabulatedFunction(TestType::testFn2);
+    uniformXTab = test.createUniformXTabulatedFunction(TestType::testFn2);
+    if (!test.compareTables(uniformTab, uniformXTab, TestType::testFn2, tolerance))
         return 1;
 
-    uniformTab = createUniformTabulatedFunction(testFn3);
-    uniformXTab = createUniformXTabulatedFunction(testFn3);
-    if (!compareTables(uniformTab, uniformXTab, testFn3, /*tolerance=*/1e-2))
+    uniformTab = test.createUniformTabulatedFunction(TestType::testFn3);
+    uniformXTab = test.createUniformXTabulatedFunction(TestType::testFn3);
+    if (!test.compareTables(uniformTab, uniformXTab, TestType::testFn3, /*tolerance=*/1e-2))
         return 1;
 
-    uniformXTab = createUniformXTabulatedFunction2(testFn3);
-    if (!compareTableWithAnalyticFn(uniformXTab,
+    uniformXTab = test.createUniformXTabulatedFunction2(TestType::testFn3);
+    if (!test.compareTableWithAnalyticFn(uniformXTab,
                                     -2.0, 3.0, 100,
                                     -4.0, 5.0, 100,
-                                    testFn3,
+                                    TestType::testFn3,
                                     /*tolerance=*/1e-2))
         return 1;
 
@@ -373,6 +376,15 @@ int main()
         std::cout << "\n";
     }
 #endif
+    return 0;
+}
 
+
+int main()
+{
+    if( testAll< Test<double> >( 1e-12 ) )
+        return 1;
+    if( testAll< Test<float> >( 1e-6 ) )
+        return 1;
     return 0;
 }

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -95,16 +95,22 @@ void testAllComponents()
 
 class TestAdTag;
 
-int main(int argc, char **argv)
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
-
-    Dune::MPIHelper::instance(argc, argv);
 
     // ensure that all components are API-compliant
     testAllComponents<Scalar, Scalar>();
     testAllComponents<Scalar, Evaluation>();
+}
 
+
+int main(int argc, char **argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+
+    testAll< double >();
+    testAll< float  >();
     return 0;
 }

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -218,10 +218,9 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
     }
 }
 
-int main()
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
-
     Opm::Parser parser;
     Opm::ParseMode parseMode;
 
@@ -309,6 +308,12 @@ int main()
     // make sure that the BlackOil fluid system's initFromDeck() method compiles.
     typedef Opm::FluidSystems::BlackOil<Scalar> BlackOilFluidSystem;
     BlackOilFluidSystem::initFromDeck(deck, eclState);
+}
 
+
+int main()
+{
+    testAll< double >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -221,6 +221,8 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
 template <class Scalar>
 inline void testAll()
 {
+    static const Scalar tolerance = std::numeric_limits<Scalar>::epsilon()*1e3;
+
     Opm::Parser parser;
     Opm::ParseMode parseMode;
 
@@ -250,7 +252,7 @@ inline void testAll()
     tmp = constCompWaterPvt.viscosity(/*regionIdx=*/0,
                                       /*temperature=*/273.15 + 20.0,
                                       /*pressure=*/1e5);
-    if (std::abs(tmp - refTmp)  > 1e-30)
+    if (std::abs(tmp - refTmp)  > tolerance)
         OPM_THROW(std::logic_error,
                   "The reference water viscosity at region 0 is supposed to be " << refTmp
                   << ". (is " << tmp << ")");
@@ -259,7 +261,7 @@ inline void testAll()
     tmp = constCompWaterPvt.viscosity(/*regionIdx=*/1,
                                       /*temperature=*/273.15 + 20.0,
                                       /*pressure=*/2e5);
-    if (std::abs(tmp - refTmp)  > 1e-30)
+    if (std::abs(tmp - refTmp)  > tolerance)
         OPM_THROW(std::logic_error,
                   "The reference water viscosity at region 1 is supposed to be " << refTmp
                   << ". (is " << tmp << ")");
@@ -268,7 +270,7 @@ inline void testAll()
     tmp = constCompWaterPvt.density(/*regionIdx=*/0,
                                     /*temperature=*/273.15 + 20.0,
                                     /*pressure=*/1e5);
-    if (std::abs(tmp - refTmp)  > 5e-14)
+    if (std::abs(tmp - refTmp)  > tolerance)
         OPM_THROW(std::logic_error,
                   "The reference water density at region 0 is supposed to be " << refTmp
                   << ". (is " << tmp << ")");
@@ -278,7 +280,7 @@ inline void testAll()
     tmp = constCompWaterPvt.density(/*regionIdx=*/1,
                                     /*temperature=*/273.15 + 20.0,
                                     /*pressure=*/2e5);
-    if (std::abs(tmp - refTmp)  > 5e-14)
+    if (std::abs(tmp - refTmp)  > tolerance)
         OPM_THROW(std::logic_error,
                   "The reference water density at region 1 is supposed to be " << refTmp
                   << ". (is " << tmp << ")");
@@ -314,6 +316,6 @@ inline void testAll()
 int main()
 {
     testAll< double >();
-    // testAll< float  >();
+    testAll< float  >();
     return 0;
 }

--- a/tests/test_eclmateriallawmanager.cpp
+++ b/tests/test_eclmateriallawmanager.cpp
@@ -205,14 +205,13 @@ static const char* fam2DeckString =
     "    0.88     1        1    /  \n"
     "\n";
 
-
-int main()
+template <class Scalar>
+inline void testAll()
 {
     enum { numPhases = 3 };
     enum { waterPhaseIdx = 0 };
     enum { oilPhaseIdx = 1 };
     enum { gasPhaseIdx = 2 };
-    typedef double Scalar;
     typedef Opm::ThreePhaseMaterialTraits<Scalar,
                                           /*wettingPhaseIdx=*/waterPhaseIdx,
                                           /*nonWettingPhaseIdx=*/oilPhaseIdx,
@@ -236,7 +235,7 @@ int main()
 
     {
         typedef Opm::EclMaterialLawManager<MaterialTraits> MaterialLawManager;
-        typedef MaterialLawManager::MaterialLaw MaterialLaw;
+        typedef typename MaterialLawManager::MaterialLaw MaterialLaw;
 
         const auto deck = parser.parseString(fam1DeckString, parseMode);
         const auto eclState = std::make_shared<Opm::EclipseState>(deck, parseMode);
@@ -317,6 +316,12 @@ int main()
             }
         }
     }
+}
 
+
+int main()
+{
+    testAll< double >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_eclmateriallawmanager.cpp
+++ b/tests/test_eclmateriallawmanager.cpp
@@ -322,6 +322,6 @@ inline void testAll()
 int main()
 {
     testAll< double >();
-    // testAll< float  >();
+    testAll< float  >();
     return 0;
 }

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -269,9 +269,9 @@ void testThreePhaseSatApi()
 
 class TestAdTag;
 
-int main(int argc, char **argv)
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::SimpleH2O<Scalar> H2O;
     typedef Opm::N2<Scalar> N2;
 
@@ -293,8 +293,6 @@ int main(int argc, char **argv)
     typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
     typedef Opm::ImmiscibleFluidState<Evaluation, TwoPFluidSystem> TwoPhaseFluidState;
     typedef Opm::ImmiscibleFluidState<Evaluation, ThreePFluidSystem> ThreePhaseFluidState;
-
-    Dune::MPIHelper::instance(argc, argv);
 
     // test conformance to the capillary pressure APIs
     {
@@ -438,6 +436,12 @@ int main(int argc, char **argv)
         testTwoPhaseApi<MaterialLaw, TwoPhaseFluidState>();
         testTwoPhaseSatApi<MaterialLaw, TwoPhaseFluidState>();
     }
+}
 
+int main(int argc, char **argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    testAll< double >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -442,6 +442,6 @@ int main(int argc, char **argv)
 {
     Dune::MPIHelper::instance(argc, argv);
     testAll< double >();
-    // testAll< float  >();
+    testAll< float  >();
     return 0;
 }

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -317,12 +317,10 @@ void testAllFluidSystems()
 
 class TestAdTag;
 
-int main(int argc, char **argv)
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
-
-    Dune::MPIHelper::instance(argc, argv);
 
     // ensure that all fluid states are API-compliant
     testAllFluidStates<Scalar>();
@@ -334,6 +332,12 @@ int main(int argc, char **argv)
     testAllFluidSystems<Scalar, Scalar>();
     testAllFluidSystems<Scalar, Evaluation>();
     testAllFluidSystems<Scalar, Evaluation, Scalar>();
+}
 
+int main(int argc, char **argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    testAll< double > ();
+    // testAll< float >  ();
     return 0;
 }

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -338,6 +338,6 @@ int main(int argc, char **argv)
 {
     Dune::MPIHelper::instance(argc, argv);
     testAll< double > ();
-    // testAll< float >  ();
+    testAll< float >  ();
     return 0;
 }

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -144,10 +144,9 @@ void completeReferenceFluidState(FluidState &fs,
     }
 }
 
-
-int main()
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::FluidSystems::H2ON2<Scalar> FluidSystem;
     typedef Opm::ImmiscibleFluidState<Scalar, FluidSystem> ImmiscibleFluidState;
 
@@ -162,7 +161,7 @@ int main()
     typedef Opm::TwoPhaseMaterialTraits<Scalar, liquidPhaseIdx, gasPhaseIdx> MaterialLawTraits;
     typedef Opm::RegularizedBrooksCorey<MaterialLawTraits> EffMaterialLaw;
     typedef Opm::EffToAbsLaw<EffMaterialLaw> MaterialLaw;
-    typedef MaterialLaw::Params MaterialLawParams;
+    typedef typename MaterialLaw::Params MaterialLawParams;
 
     Scalar T = 273.15 + 25;
 
@@ -260,6 +259,11 @@ int main()
 
     // check the flash calculation
     checkImmiscibleFlash<Scalar, FluidSystem, MaterialLaw>(fsRef, matParams2);
+}
 
+int main()
+{
+    testAll< double >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -264,6 +264,6 @@ inline void testAll()
 int main()
 {
     testAll< double >();
-    // testAll< float  >();
+    testAll< float  >();
     return 0;
 }

--- a/tests/test_localad.cpp
+++ b/tests/test_localad.cpp
@@ -53,8 +53,21 @@ struct TestVariables
     static const int saturationIdx = 2;
 };
 
+template <class Scalar>
+struct Tolerance
+{
+    static constexpr Scalar eps = 1e-10;
+};
+
+template <>
+struct Tolerance< float >
+{
+    static constexpr  float eps = 1e-6;
+};
+
+
 template <class Scalar, class VariablesDescriptor>
-void testOperators()
+void testOperators(const Scalar tolerance )
 {
     typedef Opm::LocalAd::Evaluation<Scalar, VariablesDescriptor, VariablesDescriptor::size> Eval;
 
@@ -70,57 +83,57 @@ void testOperators()
     // test the non-inplace operators
     {
         Eval a = xEval + yEval;
-        if (std::abs(a.value - (x + y)) > 1e-10)
+        if (std::abs(a.value - (x + y)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval b = xEval + c;
-        if (std::abs(b.value - (x + c)) > 1e-10)
+        if (std::abs(b.value - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval d = xEval + cEval;
-        if (std::abs(d.value - (x + c)) > 1e-10)
+        if (std::abs(d.value - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
     }
 
     {
         Eval a = xEval - yEval;
-        if (std::abs(a.value - (x - y)) > 1e-10)
+        if (std::abs(a.value - (x - y)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval b = xEval - c;
-        if (std::abs(b.value - (x - c)) > 1e-10)
+        if (std::abs(b.value - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval d = xEval - cEval;
-        if (std::abs(d.value - (x - c)) > 1e-10)
+        if (std::abs(d.value - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
     }
 
     {
         Eval a = xEval*yEval;
-        if (std::abs(a.value - (x*y)) > 1e-10)
+        if (std::abs(a.value - (x*y)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval b = xEval*c;
-        if (std::abs(b.value - (x*c)) > 1e-10)
+        if (std::abs(b.value - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval d = xEval*cEval;
-        if (std::abs(d.value - (x*c)) > 1e-10)
+        if (std::abs(d.value - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
     }
 
     {
         Eval a = xEval/yEval;
-        if (std::abs(a.value - (x/y)) > 1e-10)
+        if (std::abs(a.value - (x/y)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval b = xEval/c;
-        if (std::abs(b.value - (x/c)) > 1e-10)
+        if (std::abs(b.value - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval d = xEval/cEval;
-        if (std::abs(d.value - (x/c)) > 1e-10)
+        if (std::abs(d.value - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
     }
 
@@ -128,68 +141,68 @@ void testOperators()
     {
         Eval a = xEval;
         a += yEval;
-        if (std::abs(a.value - (x + y)) > 1e-10)
+        if (std::abs(a.value - (x + y)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval b = xEval;
         b += c;
-        if (std::abs(b.value - (x + c)) > 1e-10)
+        if (std::abs(b.value - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval d = xEval;
         d += cEval;
-        if (std::abs(d.value - (x + c)) > 1e-10)
+        if (std::abs(d.value - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
     }
 
     {
         Eval a = xEval;
         a -= yEval;
-        if (std::abs(a.value - (x - y)) > 1e-10)
+        if (std::abs(a.value - (x - y)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval b = xEval;
         b -= c;
-        if (std::abs(b.value - (x - c)) > 1e-10)
+        if (std::abs(b.value - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval d = xEval;
         d -= cEval;
-        if (std::abs(d.value - (x - c)) > 1e-10)
+        if (std::abs(d.value - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
     }
 
     {
         Eval a = xEval;
         a *= yEval;
-        if (std::abs(a.value - (x*y)) > 1e-10)
+        if (std::abs(a.value - (x*y)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval b = xEval;
         b *= c;
-        if (std::abs(b.value - (x*c)) > 1e-10)
+        if (std::abs(b.value - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval d = xEval;
         d *= cEval;
-        if (std::abs(d.value - (x*c)) > 1e-10)
+        if (std::abs(d.value - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
     }
 
     {
         Eval a = xEval;
         a /= yEval;
-        if (std::abs(a.value - (x/y)) > 1e-10)
+        if (std::abs(a.value - (x/y)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval b = xEval;
         b /= c;
-        if (std::abs(b.value - (x/c)) > 1e-10)
+        if (std::abs(b.value - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval d = xEval;
         d /= cEval;
-        if (std::abs(d.value - (x/c)) > 1e-10)
+        if (std::abs(d.value - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
     }
 
@@ -241,7 +254,7 @@ void test1DFunction(AdFn* adFn, ClassicFn* classicFn, Scalar xMin = 1e-6, Scalar
         const auto& xEval = Eval::createVariable(x, 0);
         const Eval& yEval = adFn(xEval);
 
-        const Scalar eps = 1e-10;
+        const Scalar eps = Tolerance< Scalar > :: eps;
         Scalar y = classicFn(x);
         Scalar yStar1 = classicFn(x - eps);
         Scalar yStar2 = classicFn(x + eps);
@@ -276,11 +289,11 @@ void test2DFunction1(AdFn* adFn, ClassicFn* classicFn, Scalar xMin, Scalar xMax,
         const auto& yEval = Eval::createConstant(y);
         const Eval& zEval = adFn(xEval, yEval);
 
-        const Scalar eps = 1e-10;
+        const Scalar eps = Tolerance< Scalar > :: eps;
         Scalar z = classicFn(x, y);
         Scalar zStar1 = classicFn(x - eps, y);
         Scalar zStar2 = classicFn(x + eps, y);
-        Scalar zPrime = (zStar2 - zStar1)/(2*eps);
+        Scalar zPrime = (zStar2 - zStar1)/(2.*eps);
 
         if (z != zEval.value)
             throw std::logic_error("oops: value");
@@ -311,7 +324,7 @@ void test2DFunction2(AdFn* adFn, ClassicFn* classicFn, Scalar x, Scalar yMin, Sc
         const auto& yEval = Eval::createVariable(y, 1);
         const Eval& zEval = adFn(xEval, yEval);
 
-        const Scalar eps = 1e-10;
+        const Scalar eps = Tolerance< Scalar > :: eps;
         Scalar z = classicFn(x, y);
         Scalar zStar1 = classicFn(x, y - eps);
         Scalar zStar2 = classicFn(x, y + eps);
@@ -462,10 +475,9 @@ double myScalarMin(double a, double b)
 double myScalarMax(double a, double b)
 { return std::max(a, b); }
 
-int main()
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
-
     typedef TestVariables VarsDescriptor;
 
     // the following is commented out because it is supposed to produce a compiler
@@ -474,7 +486,7 @@ int main()
     //const auto& result2 = Opm::LocalAd::sqrt(TemperatureEval::createVariable<Pressure>(4.0));
 
     std::cout << "testing operators and constructors\n";
-    testOperators<Scalar, VarsDescriptor>();
+    testOperators<Scalar, VarsDescriptor>( Tolerance< Scalar > :: eps );
 
     std::cout << "testing min()\n";
     test2DFunction1<Scalar, VarsDescriptor>(Opm::LocalAd::min<Scalar, VarsDescriptor, VarsDescriptor::size>,
@@ -552,6 +564,11 @@ int main()
     test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::log<Scalar, VarsDescriptor, VarsDescriptor::size>,
                                            static_cast<Scalar (*)(Scalar)>(std::log),
                                            1e-6, 1e9);
+}
 
+int main()
+{
+    testAll< double >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_localad.cpp
+++ b/tests/test_localad.cpp
@@ -53,19 +53,6 @@ struct TestVariables
     static const int saturationIdx = 2;
 };
 
-template <class Scalar>
-struct Tolerance
-{
-    static constexpr Scalar eps = 1e-10;
-};
-
-template <>
-struct Tolerance< float >
-{
-    static constexpr  float eps = 1e-6;
-};
-
-
 template <class Scalar, class VariablesDescriptor>
 void testOperators(const Scalar tolerance )
 {
@@ -254,7 +241,9 @@ void test1DFunction(AdFn* adFn, ClassicFn* classicFn, Scalar xMin = 1e-6, Scalar
         const auto& xEval = Eval::createVariable(x, 0);
         const Eval& yEval = adFn(xEval);
 
-        const Scalar eps = Tolerance< Scalar > :: eps;
+        Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e7;
+        eps = std::max(eps, eps*std::abs(x));
+
         Scalar y = classicFn(x);
         Scalar yStar1 = classicFn(x - eps);
         Scalar yStar2 = classicFn(x + eps);
@@ -265,7 +254,7 @@ void test1DFunction(AdFn* adFn, ClassicFn* classicFn, Scalar xMin = 1e-6, Scalar
 
         Scalar deltaAbs = std::abs(yPrime - yEval.derivatives[0]);
         Scalar deltaRel = std::abs(deltaAbs/yPrime);
-        if (deltaAbs > 1e-3 && deltaRel > 1e-3)
+        if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
             throw std::logic_error("oops: derivative @"+std::to_string((long double) x)+": "
                                    + std::to_string((long double) yPrime) + " vs "
                                    + std::to_string((long double) yEval.derivatives[0])
@@ -289,18 +278,21 @@ void test2DFunction1(AdFn* adFn, ClassicFn* classicFn, Scalar xMin, Scalar xMax,
         const auto& yEval = Eval::createConstant(y);
         const Eval& zEval = adFn(xEval, yEval);
 
-        const Scalar eps = Tolerance< Scalar > :: eps;
+        Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e7;
+        eps = std::max(eps, eps*std::abs(x));
+
         Scalar z = classicFn(x, y);
         Scalar zStar1 = classicFn(x - eps, y);
         Scalar zStar2 = classicFn(x + eps, y);
         Scalar zPrime = (zStar2 - zStar1)/(2.*eps);
 
-        if (z != zEval.value)
+        if (std::abs(z - zEval.value)/std::abs(z + zEval.value)
+            > std::numeric_limits<Scalar>::epsilon()*1e2)
             throw std::logic_error("oops: value");
 
         Scalar deltaAbs = std::abs(zPrime - zEval.derivatives[0]);
         Scalar deltaRel = std::abs(deltaAbs/zPrime);
-        if (deltaAbs > 1e-3 && deltaRel > 1e-3)
+        if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
             throw std::logic_error("oops: derivative @"+std::to_string((long double) x)+": "
                                    + std::to_string((long double) zPrime) + " vs "
                                    + std::to_string((long double) zEval.derivatives[0])
@@ -324,18 +316,21 @@ void test2DFunction2(AdFn* adFn, ClassicFn* classicFn, Scalar x, Scalar yMin, Sc
         const auto& yEval = Eval::createVariable(y, 1);
         const Eval& zEval = adFn(xEval, yEval);
 
-        const Scalar eps = Tolerance< Scalar > :: eps;
+        Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e7;
+        eps = std::max(eps, eps*std::abs(y));
+
         Scalar z = classicFn(x, y);
         Scalar zStar1 = classicFn(x, y - eps);
         Scalar zStar2 = classicFn(x, y + eps);
         Scalar zPrime = (zStar2 - zStar1)/(2*eps);
 
-        if (z != zEval.value)
+        if (std::abs(z - zEval.value)/std::abs(z + zEval.value)
+            > std::numeric_limits<Scalar>::epsilon()*1e2)
             throw std::logic_error("oops: value");
 
         Scalar deltaAbs = std::abs(zPrime - zEval.derivatives[1]);
         Scalar deltaRel = std::abs(deltaAbs/zPrime);
-        if (deltaAbs > 1e-3 && deltaRel > 1e-3)
+        if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
             throw std::logic_error("oops: derivative @"+std::to_string((long double) x)+": "
                                    + std::to_string((long double) zPrime) + " vs "
                                    + std::to_string((long double) zEval.derivatives[1])
@@ -359,24 +354,27 @@ void testPowBase(Scalar baseMin = 1e-2, Scalar baseMax = 100)
         const Eval& zEval1 = pow(baseEval, exp);
         const Eval& zEval2 = pow(baseEval, expEval);
 
-        const Scalar eps = 1e-5;
+        Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e7;
+        eps = std::max(eps, eps*std::abs(base));
+
         Scalar z = pow(base, exp);
         Scalar zStar1 = pow(base - eps, exp);
         Scalar zStar2 = pow(base + eps, exp);
         Scalar zPrime = (zStar2 - zStar1)/(2*eps);
 
-        if (z != zEval2.value)
+        if (std::abs(z - zEval2.value)/std::abs(z + zEval2.value)
+            > std::numeric_limits<Scalar>::epsilon()*1e2)
             throw std::logic_error("oops: value");
 
         Scalar deltaAbs = std::abs(zPrime - zEval1.derivatives[0]);
         Scalar deltaRel = std::abs(deltaAbs/zPrime);
-        if (deltaAbs > 1e-3 && deltaRel > 1e-3)
+        if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
             throw std::logic_error("oops: derivative @"+std::to_string((long double) base)+": "
                                    + std::to_string((long double) zPrime) + " vs "
                                    + std::to_string((long double) zEval1.derivatives[0])
                                    + " delta: " + std::to_string((long double) std::abs(zPrime - zEval1.derivatives[0])));
 
-        if (!zEval1.isSame(zEval2, /*tolerance=*/1e-9))
+        if (!zEval1.isSame(zEval2, /*tolerance=*/std::numeric_limits<Scalar>::epsilon()*1e3*zEval1.value))
             throw std::logic_error("oops: pow(Eval, Scalar) != pow(Eval, Eval)");
     }
 }
@@ -397,24 +395,27 @@ void testPowExp(Scalar expMin = -100, Scalar expMax = 100)
         const Eval& zEval1 = pow(base, expEval);
         const Eval& zEval2 = pow(baseEval, expEval);
 
-        const Scalar eps = 1e-8;
+        Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e7;
+        eps = std::max(eps, eps*std::abs(exp));
+
         Scalar z = pow(base, exp);
         Scalar zStar1 = pow(base, exp - eps);
         Scalar zStar2 = pow(base, exp + eps);
         Scalar zPrime = (zStar2 - zStar1)/(2*eps);
 
-        if (z != zEval2.value)
+        if (std::abs(z - zEval2.value)/std::abs(z + zEval2.value)
+            > std::numeric_limits<Scalar>::epsilon()*1e2)
             throw std::logic_error("oops: value");
 
         Scalar deltaAbs = std::abs(zPrime - zEval1.derivatives[1]);
         Scalar deltaRel = std::abs(deltaAbs/zPrime);
-        if (deltaAbs > 1e-3 && deltaRel > 1e-3)
+        if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
             throw std::logic_error("oops: derivative @"+std::to_string((long double) base)+": "
                                    + std::to_string((long double) zPrime) + " vs "
                                    + std::to_string((long double) zEval1.derivatives[1])
                                    + " delta: " + std::to_string((long double) std::abs(zPrime - zEval1.derivatives[1])));
 
-        if (!zEval1.isSame(zEval2, /*tolerance=*/1e-5))
+        if (!zEval1.isSame(zEval2, /*tolerance=*/std::numeric_limits<Scalar>::epsilon()*1e3*zEval1.value))
             throw std::logic_error("oops: pow(Eval, Scalar) != pow(Eval, Eval)");
     }
 }
@@ -444,18 +445,21 @@ void testAtan2()
             const Eval& yEval = Eval::createVariable(y, 0);
             const Eval& zEval = atan2(xEval, yEval);
 
-            const Scalar eps = 1e-8;
+            Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e7;
+            eps = std::max(eps, eps*std::abs(x));
+
             Scalar z = atan2(x, y);
             Scalar zStar1 = atan2(x - eps, y - eps);
             Scalar zStar2 = atan2(x + eps, y + eps);
             Scalar zPrime = (zStar2 - zStar1)/(2*eps);
 
-            if (z != zEval.value)
+            if (std::abs(z - zEval.value)/std::abs(z + zEval.value)
+                > std::numeric_limits<Scalar>::epsilon()*1e2)
                 throw std::logic_error("oops: value");
 
             Scalar deltaAbs = std::abs(zPrime - zEval.derivatives[0]);
             Scalar deltaRel = std::abs(deltaAbs/zPrime);
-            if (deltaAbs > 1e-3 && deltaRel > 1e-3)
+            if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
                 throw std::logic_error("oops: derivative @("+std::to_string((long double) x)+","+std::to_string((long double) y)+"): "
                                        + std::to_string((long double) zPrime) + " vs "
                                        + std::to_string((long double) zEval.derivatives[0])
@@ -486,7 +490,8 @@ inline void testAll()
     //const auto& result2 = Opm::LocalAd::sqrt(TemperatureEval::createVariable<Pressure>(4.0));
 
     std::cout << "testing operators and constructors\n";
-    testOperators<Scalar, VarsDescriptor>( Tolerance< Scalar > :: eps );
+    const Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e3;
+    testOperators<Scalar, VarsDescriptor>(eps);
 
     std::cout << "testing min()\n";
     test2DFunction1<Scalar, VarsDescriptor>(Opm::LocalAd::min<Scalar, VarsDescriptor, VarsDescriptor::size>,
@@ -569,6 +574,6 @@ inline void testAll()
 int main()
 {
     testAll< double >();
-    // testAll< float  >();
+    testAll< float  >();
     return 0;
 }

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -148,9 +148,9 @@ void completeReferenceFluidState(FluidState &fs,
 }
 
 
-int main()
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::FluidSystems::H2ON2<Scalar, false> FluidSystem;
     typedef Opm::CompositionalFluidState<Scalar, FluidSystem> CompositionalFluidState;
 
@@ -165,7 +165,7 @@ int main()
     typedef Opm::TwoPhaseMaterialTraits<Scalar, liquidPhaseIdx, gasPhaseIdx> MaterialTraits;
     typedef Opm::RegularizedBrooksCorey<MaterialTraits> EffMaterialLaw;
     typedef Opm::EffToAbsLaw<EffMaterialLaw> MaterialLaw;
-    typedef MaterialLaw::Params MaterialLawParams;
+    typedef typename MaterialLaw::Params MaterialLawParams;
 
     Scalar T = 273.15 + 25;
 
@@ -249,7 +249,7 @@ int main()
     fsRef.setPressure(liquidPhaseIdx, 1e6);
     fsRef.setPressure(gasPhaseIdx, 1e6);
 
-    FluidSystem::ParameterCache paramCache;
+    typename FluidSystem::ParameterCache paramCache;
     typedef Opm::MiscibleMultiPhaseComposition<Scalar, FluidSystem> MiscibleMultiPhaseComposition;
     MiscibleMultiPhaseComposition::solve(fsRef, paramCache,
                                          /*setViscosity=*/false,
@@ -291,6 +291,11 @@ int main()
 
     // check the flash calculation
     checkNcpFlash<Scalar, FluidSystem, MaterialLaw>(fsRef, matParams2);
+}
 
+int main()
+{
+    testAll< double >();
+    // testAll< float  >();
     return 0;
 }

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -296,6 +296,6 @@ inline void testAll()
 int main()
 {
     testAll< double >();
-    // testAll< float  >();
+    while (false) testAll< float  >();
     return 0;
 }

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -285,9 +285,9 @@ void printResult(const RawTable& rawTable,
     std::cout << "};\n";
 }
 
-int main(int /*argc*/, char** /*argv*/)
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::FluidSystems::Spe5<Scalar> FluidSystem;
 
     enum {
@@ -312,9 +312,9 @@ int main(int /*argc*/, char** /*argv*/)
 
     typedef Opm::ThreePhaseMaterialTraits<Scalar, waterPhaseIdx, oilPhaseIdx, gasPhaseIdx> MaterialTraits;
     typedef Opm::LinearMaterial<MaterialTraits> MaterialLaw;
-    typedef MaterialLaw::Params MaterialLawParams;
+    typedef typename MaterialLaw::Params MaterialLawParams;
 
-    typedef FluidSystem::ParameterCache ParameterCache;
+    typedef typename FluidSystem::ParameterCache ParameterCache;
 
     ////////////
     // Initialize the fluid system and create the capillary pressure
@@ -399,7 +399,7 @@ int main(int /*argc*/, char** /*argv*/)
     FluidState flashFluidState, surfaceFluidState;
     flashFluidState.assign(fluidState);
     //Flash::guessInitial(flashFluidState, paramCache, totalMolarities);
-    Flash::solve<MaterialLaw>(flashFluidState, paramCache, matParams, totalMolarities);
+    Flash::template solve<MaterialLaw>(flashFluidState, paramCache, matParams, totalMolarities);
 
     Scalar surfaceAlpha = 1;
     surfaceAlpha = bringOilToSurface<Scalar, FluidSystem>(surfaceFluidState, surfaceAlpha, flashFluidState, /*guessInitial=*/true);
@@ -422,7 +422,7 @@ int main(int /*argc*/, char** /*argv*/)
         curTotalMolarities /= alpha;
 
         // "flash" the modified reservoir oil
-        Flash::solve<MaterialLaw>(flashFluidState, paramCache, matParams, curTotalMolarities);
+        Flash::template solve<MaterialLaw>(flashFluidState, paramCache, matParams, curTotalMolarities);
 
         surfaceAlpha = bringOilToSurface<Scalar, FluidSystem>(surfaceFluidState,
                                                               surfaceAlpha,
@@ -471,7 +471,11 @@ int main(int /*argc*/, char** /*argv*/)
     printResult(resultTable,
                 "Rs", /*firstIdx=*/1, /*secondIdx=*/7,
                 /*hiresThreshold=*/hiresThresholdPressure);
+}
 
-
+int main(int /*argc*/, char** /*argv*/)
+{
+    testAll< double >();
+    //testAll< float  >();
     return 0;
 }

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -476,6 +476,6 @@ inline void testAll()
 int main(int /*argc*/, char** /*argv*/)
 {
     testAll< double >();
-    //testAll< float  >();
+    while (0) testAll< float  >();
     return 0;
 }

--- a/tests/test_tabulation.cpp
+++ b/tests/test_tabulation.cpp
@@ -45,9 +45,9 @@ void isSame(const char *str, Scalar v, Scalar vRef, Scalar tol=1e-3)
     }
 }
 
-int main()
+template <class Scalar>
+inline void testAll()
 {
-    typedef double Scalar;
     typedef Opm::H2O<Scalar> IapwsH2O;
     typedef Opm::TabulatedComponent<Scalar, IapwsH2O> TabulatedH2O;
 
@@ -78,7 +78,8 @@ int main()
         isSame("vaporPressure",
                TabulatedH2O::vaporPressure(T),
                IapwsH2O::vaporPressure(T),
-               1e-3);
+               Scalar(1e-3));
+
         for (unsigned j = 0; j < n; ++j) {
             Scalar p = pMin + (pMax - pMin)*Scalar(j)/n;
             if (p < IapwsH2O::vaporPressure(T) * 1.001) {
@@ -112,5 +113,12 @@ int main()
 
     if (success)
         std::cout << "\nsuccess\n";
+}
+
+
+int main()
+{
+    testAll< double >();
+    testAll< float  >();
     return 0;
 }


### PR DESCRIPTION
This PR revised all tests such that Scalar=double and Scalar=float is tested. All tests compile, some of the test do not work with float and are therefore disabled for now. 