### PR TITLE
squelch extra-pedantic clang and GCC warnings and fix the headercheck

### DIFF
--- a/opm/material/eos/PengRobinsonParamsMixture.hpp
+++ b/opm/material/eos/PengRobinsonParamsMixture.hpp
@@ -144,8 +144,8 @@ public:
         Scalar newA = 0;
         Scalar newB = 0;
         for (unsigned compIIdx = 0; compIIdx < numComponents; ++compIIdx) {
-            const Scalar moleFracJ = fs.moleFraction(phaseIdx, compIIdx);
-            Scalar xi = std::max(Scalar(0), std::min(Scalar(1), moleFracJ));
+            const Scalar moleFracI = fs.moleFraction(phaseIdx, compIIdx);
+            Scalar xi = std::max(Scalar(0), std::min(Scalar(1.0), moleFracI));
             Valgrind::CheckDefined(xi);
 
             for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -27,6 +27,7 @@
 
 #if HAVE_OPM_PARSER
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #endif

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -44,8 +44,8 @@
 
 namespace Opm {
 namespace BlackOil {
-OPM_GENERATE_HAS_MEMBER(Rs) // Creates 'HasMember_Rs<T>'.
-OPM_GENERATE_HAS_MEMBER(Rv) // Creates 'HasMember_Rv<T>'.
+OPM_GENERATE_HAS_MEMBER(Rs, ) // Creates 'HasMember_Rs<T>'.
+OPM_GENERATE_HAS_MEMBER(Rv, ) // Creates 'HasMember_Rv<T>'.
 
 template <class FluidSystem, class LhsEval, class FluidState>
 LhsEval getRs_(typename std::enable_if<!HasMember_Rs<FluidState>::value, const FluidState&>::type fluidState,

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -29,7 +29,9 @@
 
 #if HAVE_OPM_PARSER
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #endif
 

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -97,7 +97,6 @@ public:
         if (enableThermalViscosity_) {
             Opm::DeckKeywordConstPtr viscrefKeyword = deck->getKeyword("VISCREF");
 
-            auto tables = eclState->getTableManager();
             const auto& watvisctTables = tables->getWatvisctTables();
 
             assert(watvisctTables.size() == numRegions);


### PR DESCRIPTION
once more, OPM/opm-parser#661 was the culprit for the headercheck issues.