### PR TITLE
fix the unit test for the blackoil PVT API

### DIFF
--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -263,10 +263,6 @@ inline void testAll()
     oilPvt.initFromDeck(deck, eclState);
     waterPvt.initFromDeck(deck, eclState);
 
-    gasPvt.initEnd();
-    oilPvt.initEnd();
-    waterPvt.initEnd();
-
     struct Foo;
     typedef Opm::LocalAd::Evaluation<Scalar, Foo, 1> FooEval;
     ensurePvtApi<Scalar>(oilPvt, gasPvt, waterPvt);


### PR DESCRIPTION
mea culpa, I forgot to remove the calls to the initEnd() method after
980e26a52d.