### PR TITLE
Change Deck access methods/types to references

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -158,9 +158,9 @@ public:
         // permeabilities
         if (deck->hasKeyword("SCALECRS")) {
             // if the deck features the SCALECRS keyword, it must be set to 'YES'
-            Opm::DeckKeywordConstPtr scalecrsKeyword = deck->getKeyword("SCALECRS");
+            const auto& scalecrsKeyword = deck->getKeyword("SCALECRS");
             std::string scalecrsValue =
-                scalecrsKeyword->getRecord(0)->getItem("VALUE")->getString(0);
+                scalecrsKeyword.getRecord(0).getItem("VALUE").get< std::string >(0);
             // convert the value of the SCALECRS keyword to upper case, just to be sure
             std::transform(scalecrsValue.begin(),
                            scalecrsValue.end(),

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -116,9 +116,9 @@ public:
         if (!deck->hasKeyword("SATOPTS"))
             return;
 
-        Opm::DeckItemConstPtr satoptsItem = deck->getKeyword("SATOPTS")->getRecord(0)->getItem(0);
-        for (unsigned i = 0; i < satoptsItem->size(); ++i) {
-            std::string satoptsValue = satoptsItem->getString(0);
+        const auto& satoptsItem = deck->getKeyword("SATOPTS").getRecord(0).getItem(0);
+        for (unsigned i = 0; i < satoptsItem.size(); ++i) {
+            std::string satoptsValue = satoptsItem.get< std::string >(0);
             std::transform(satoptsValue.begin(),
                            satoptsValue.end(),
                            satoptsValue.begin(),
@@ -140,11 +140,11 @@ public:
                       "Enabling hysteresis via the HYST parameter for SATOPTS requires the "
                       "presence of the EHYSTR keyword");
 
-        Opm::DeckKeywordConstPtr ehystrKeyword = deck->getKeyword("EHYSTR");
+        const auto& ehystrKeyword = deck->getKeyword("EHYSTR");
         if (deck->hasKeyword("NOHYKR"))
             krHysteresisModel_ = -1;
         else {
-            krHysteresisModel_ = ehystrKeyword->getRecord(0)->getItem("relative_perm_hyst")->getInt(0);
+            krHysteresisModel_ = ehystrKeyword.getRecord(0).getItem("relative_perm_hyst").get< int >(0);
             if (krHysteresisModel_ != 0)
                 OPM_THROW(std::runtime_error,
                           "Only the Carlson kr hystersis model (indicated by a 0 on the second item"

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -116,7 +116,7 @@ public:
                       const std::vector<int>& compressedToCartesianElemIdx)
     {
         // get the number of saturation regions and the number of cells in the deck
-        unsigned numSatRegions = static_cast<unsigned>(deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0));
+        unsigned numSatRegions = static_cast<unsigned>(deck->getKeyword("TABDIMS").getRecord(0).getItem("NTSFUN").get< int >(0));
         size_t numCompressedElems = compressedToCartesianElemIdx.size();
 
         // copy the SATNUM grid property. in some cases this is not necessary, but it
@@ -256,10 +256,10 @@ private:
 
         if (enableEndPointScaling()) {
             // sift through the options of the ENDSCALE keyword
-            Opm::DeckKeywordConstPtr endscaleKeyword = deck->getKeyword("ENDSCALE");
-            Opm::DeckRecordConstPtr endscaleRecord = endscaleKeyword->getRecord(0);
-            for (unsigned itemIdx = 0; itemIdx < endscaleRecord->size() && itemIdx < 2; ++ itemIdx) {
-                std::string optionValue = endscaleRecord->getItem(itemIdx)->getTrimmedString(0);
+            const auto& endscaleKeyword = deck->getKeyword("ENDSCALE");
+            const auto& endscaleRecord = endscaleKeyword.getRecord(0);
+            for (unsigned itemIdx = 0; itemIdx < endscaleRecord.size() && itemIdx < 2; ++ itemIdx) {
+                std::string optionValue = endscaleRecord.getItem(itemIdx).getTrimmedString(0);
 
                 // convert the value of the option to upper case, just to be sure
                 std::transform(optionValue.begin(),
@@ -326,7 +326,7 @@ private:
                                 const std::vector<int>& compressedToCartesianElemIdx,
                                 const std::vector<int>& satnumRegionArray)
     {
-        unsigned numSatRegions = static_cast<unsigned>(deck->getKeyword("TABDIMS")->getRecord(0)->getItem("NTSFUN")->getInt(0));
+        unsigned numSatRegions = static_cast<unsigned>(deck->getKeyword("TABDIMS").getRecord(0).getItem("NTSFUN").get< int >(0));
         unsigned numCompressedElems = static_cast<unsigned>(compressedToCartesianElemIdx.size());
 
         // read the end point scaling configuration. this needs to be done only once per
@@ -823,7 +823,7 @@ private:
 
             if (deck->hasKeyword("STONE1EX")) {
                 Scalar eta =
-                    deck->getKeyword("STONE1EX")->getRecord(satnumIdx)->getItem(0)->getSIDouble(0);
+                    deck->getKeyword("STONE1EX").getRecord(satnumIdx).getItem(0).getSIDouble(0);
                 realParams.setEta(eta);
             }
             else

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -151,7 +151,7 @@ public:
     static void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
         auto densityKeyword = deck->getKeyword("DENSITY");
-        size_t numRegions = densityKeyword->size();
+        size_t numRegions = densityKeyword.size();
         initBegin(numRegions);
 
         setEnableDissolvedGas(deck->hasKeyword("DISGAS"));
@@ -159,10 +159,10 @@ public:
 
         // set the reference densities of all PVT regions
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-            Opm::DeckRecordConstPtr densityRecord = densityKeyword->getRecord(regionIdx);
-            setReferenceDensities(densityRecord->getItem("OIL")->getSIDouble(0),
-                                  densityRecord->getItem("WATER")->getSIDouble(0),
-                                  densityRecord->getItem("GAS")->getSIDouble(0),
+            const auto& densityRecord = densityKeyword.getRecord(regionIdx);
+            setReferenceDensities(densityRecord.getItem("OIL").getSIDouble(0),
+                                  densityRecord.getItem("WATER").getSIDouble(0),
+                                  densityRecord.getItem("GAS").getSIDouble(0),
                                   regionIdx);
         }
 

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -60,32 +60,32 @@ public:
      */
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr /*eclState*/)
     {
-        DeckKeywordConstPtr pvcdoKeyword = deck->getKeyword("PVCDO");
-        DeckKeywordConstPtr densityKeyword = deck->getKeyword("DENSITY");
+        const auto& pvcdoKeyword = deck->getKeyword("PVCDO");
+        const auto& densityKeyword = deck->getKeyword("DENSITY");
 
-        assert(pvcdoKeyword->size() == densityKeyword->size());
+        assert(pvcdoKeyword.size() == densityKeyword.size());
 
-        size_t numRegions = pvcdoKeyword->size();
+        size_t numRegions = pvcdoKeyword.size();
         setNumRegions(numRegions);
 
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-            Scalar rhoRefO = densityKeyword->getRecord(regionIdx)->getItem("OIL")->getSIDouble(0);
-            Scalar rhoRefG = densityKeyword->getRecord(regionIdx)->getItem("GAS")->getSIDouble(0);
-            Scalar rhoRefW = densityKeyword->getRecord(regionIdx)->getItem("WATER")->getSIDouble(0);
+            Scalar rhoRefO = densityKeyword.getRecord(regionIdx).getItem("OIL").getSIDouble(0);
+            Scalar rhoRefG = densityKeyword.getRecord(regionIdx).getItem("GAS").getSIDouble(0);
+            Scalar rhoRefW = densityKeyword.getRecord(regionIdx).getItem("WATER").getSIDouble(0);
 
             setReferenceDensities(regionIdx, rhoRefO, rhoRefG, rhoRefW);
 
-            auto pvcdoRecord = pvcdoKeyword->getRecord(regionIdx);
+            auto pvcdoRecord = pvcdoKeyword.getRecord(regionIdx);
             oilReferencePressure_[regionIdx] =
-                pvcdoRecord->getItem("P_REF")->getSIDouble(0);
+                pvcdoRecord.getItem("P_REF").getSIDouble(0);
             oilReferenceFormationVolumeFactor_[regionIdx] =
-                pvcdoRecord->getItem("OIL_VOL_FACTOR")->getSIDouble(0);
+                pvcdoRecord.getItem("OIL_VOL_FACTOR").getSIDouble(0);
             oilCompressibility_[regionIdx] =
-                pvcdoRecord->getItem("OIL_COMPRESSIBILITY")->getSIDouble(0);
+                pvcdoRecord.getItem("OIL_COMPRESSIBILITY").getSIDouble(0);
             oilViscosity_[regionIdx] =
-                pvcdoRecord->getItem("OIL_VISCOSITY")->getSIDouble(0);
+                pvcdoRecord.getItem("OIL_VISCOSITY").getSIDouble(0);
             oilViscosibility_[regionIdx] =
-                pvcdoRecord->getItem("OIL_VISCOSIBILITY")->getSIDouble(0);
+                pvcdoRecord.getItem("OIL_VISCOSIBILITY").getSIDouble(0);
         }
 
         initEnd();

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -56,31 +56,31 @@ public:
      */
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr /*eclState*/)
     {
-        DeckKeywordConstPtr pvtwKeyword = deck->getKeyword("PVTW");
-        DeckKeywordConstPtr densityKeyword = deck->getKeyword("DENSITY");
+        const auto& pvtwKeyword = deck->getKeyword("PVTW");
+        const auto& densityKeyword = deck->getKeyword("DENSITY");
 
-        assert(pvtwKeyword->size() == densityKeyword->size());
+        assert(pvtwKeyword.size() == densityKeyword.size());
 
-        size_t numRegions = pvtwKeyword->size();
+        size_t numRegions = pvtwKeyword.size();
         setNumRegions(numRegions);
 
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-            auto pvtwRecord = pvtwKeyword->getRecord(regionIdx);
-            auto densityRecord = densityKeyword->getRecord(regionIdx);
+            auto pvtwRecord = pvtwKeyword.getRecord(regionIdx);
+            auto densityRecord = densityKeyword.getRecord(regionIdx);
 
             waterReferenceDensity_[regionIdx] =
-                densityRecord->getItem("WATER")->getSIDouble(0);
+                densityRecord.getItem("WATER").getSIDouble(0);
 
             waterReferencePressure_[regionIdx] =
-                pvtwRecord->getItem("P_REF")->getSIDouble(0);
+                pvtwRecord.getItem("P_REF").getSIDouble(0);
             waterReferenceFormationVolumeFactor_[regionIdx] =
-                pvtwRecord->getItem("WATER_VOL_FACTOR")->getSIDouble(0);
+                pvtwRecord.getItem("WATER_VOL_FACTOR").getSIDouble(0);
             waterCompressibility_[regionIdx] =
-                pvtwRecord->getItem("WATER_COMPRESSIBILITY")->getSIDouble(0);
+                pvtwRecord.getItem("WATER_COMPRESSIBILITY").getSIDouble(0);
             waterViscosity_[regionIdx] =
-                pvtwRecord->getItem("WATER_VISCOSITY")->getSIDouble(0);
+                pvtwRecord.getItem("WATER_VISCOSITY").getSIDouble(0);
             waterViscosibility_[regionIdx] =
-                pvtwRecord->getItem("WATER_VISCOSIBILITY")->getSIDouble(0);
+                pvtwRecord.getItem("WATER_VISCOSIBILITY").getSIDouble(0);
         }
 
         initEnd();

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -54,17 +54,17 @@ public:
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
         const auto& pvdoTables = eclState->getTableManager()->getPvdoTables();
-        DeckKeywordConstPtr densityKeyword = deck->getKeyword("DENSITY");
+        const auto& densityKeyword = deck->getKeyword("DENSITY");
 
-        assert(pvdoTables.size() == densityKeyword->size());
+        assert(pvdoTables.size() == densityKeyword.size());
 
         size_t numRegions = pvdoTables.size();
         setNumRegions(numRegions);
 
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-            Scalar rhoRefO = densityKeyword->getRecord(regionIdx)->getItem("OIL")->getSIDouble(0);
-            Scalar rhoRefG = densityKeyword->getRecord(regionIdx)->getItem("GAS")->getSIDouble(0);
-            Scalar rhoRefW = densityKeyword->getRecord(regionIdx)->getItem("WATER")->getSIDouble(0);
+            Scalar rhoRefO = densityKeyword.getRecord(regionIdx).getItem("OIL").getSIDouble(0);
+            Scalar rhoRefG = densityKeyword.getRecord(regionIdx).getItem("GAS").getSIDouble(0);
+            Scalar rhoRefW = densityKeyword.getRecord(regionIdx).getItem("WATER").getSIDouble(0);
 
             setReferenceDensities(regionIdx, rhoRefO, rhoRefG, rhoRefW);
 

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -61,17 +61,17 @@ public:
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
         const auto& pvdgTables = eclState->getTableManager()->getPvdgTables();
-        DeckKeywordConstPtr densityKeyword = deck->getKeyword("DENSITY");
+        const auto& densityKeyword = deck->getKeyword("DENSITY");
 
-        assert(pvdgTables.size() == densityKeyword->size());
+        assert(pvdgTables.size() == densityKeyword.size());
 
         size_t numRegions = pvdgTables.size();
         setNumRegions(numRegions);
 
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-            Scalar rhoRefO = densityKeyword->getRecord(regionIdx)->getItem("OIL")->getSIDouble(0);
-            Scalar rhoRefG = densityKeyword->getRecord(regionIdx)->getItem("GAS")->getSIDouble(0);
-            Scalar rhoRefW = densityKeyword->getRecord(regionIdx)->getItem("WATER")->getSIDouble(0);
+            Scalar rhoRefO = densityKeyword.getRecord(regionIdx).getItem("OIL").getSIDouble(0);
+            Scalar rhoRefG = densityKeyword.getRecord(regionIdx).getItem("GAS").getSIDouble(0);
+            Scalar rhoRefW = densityKeyword.getRecord(regionIdx).getItem("WATER").getSIDouble(0);
 
             setReferenceDensities(regionIdx, rhoRefO, rhoRefG, rhoRefW);
 

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -84,8 +84,7 @@ public:
         // viscosity
         if (enableThermalViscosity_) {
             const auto& gasvisctTables = tables->getGasvisctTables();
-            Opm::DeckKeywordConstPtr viscrefKeyword = deck->getKeyword("VISCREF");
-            int gasCompIdx = deck->getKeyword("GCOMPIDX")->getRecord(0)->getItem("GAS_COMPONENT_INDEX")->getInt(0) - 1;
+            int gasCompIdx = deck->getKeyword("GCOMPIDX").getRecord(0).getItem("GAS_COMPONENT_INDEX").get< int >(0) - 1;
             std::string gasvisctColumnName = "Viscosity"+std::to_string(static_cast<long long>(gasCompIdx));
 
             for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
@@ -99,7 +98,7 @@ public:
         // for the first EOS. (since EOS != PVT region.)
         refTemp_ = 0.0;
         if (enableThermalDensity_) {
-            refTemp_ = deck->getKeyword("TREF")->getRecord(0)->getItem("TEMPERATURE")->getSIDouble(0);
+            refTemp_ = deck->getKeyword("TREF").getRecord(0).getItem("TEMPERATURE").getSIDouble(0);
         }
     }
 #endif // HAVE_OPM_PARSER

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -60,17 +60,17 @@ public:
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
         const auto& pvtoTables = eclState->getTableManager()->getPvtoTables();
-        DeckKeywordConstPtr densityKeyword = deck->getKeyword("DENSITY");
+        const auto& densityKeyword = deck->getKeyword("DENSITY");
 
-        assert(pvtoTables.size() == densityKeyword->size());
+        assert(pvtoTables.size() == densityKeyword.size());
 
         size_t numRegions = pvtoTables.size();
         setNumRegions(numRegions);
 
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-            Scalar rhoRefO = densityKeyword->getRecord(regionIdx)->getItem("OIL")->getSIDouble(0);
-            Scalar rhoRefG = densityKeyword->getRecord(regionIdx)->getItem("GAS")->getSIDouble(0);
-            Scalar rhoRefW = densityKeyword->getRecord(regionIdx)->getItem("WATER")->getSIDouble(0);
+            Scalar rhoRefO = densityKeyword.getRecord(regionIdx).getItem("OIL").getSIDouble(0);
+            Scalar rhoRefG = densityKeyword.getRecord(regionIdx).getItem("GAS").getSIDouble(0);
+            Scalar rhoRefW = densityKeyword.getRecord(regionIdx).getItem("WATER").getSIDouble(0);
 
             setReferenceDensities(regionIdx, rhoRefO, rhoRefG, rhoRefW);
         }

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -84,19 +84,19 @@ public:
         // viscosity
         if (deck->hasKeyword("VISCREF")) {
             const auto& oilvisctTables = tables->getOilvisctTables();
-            Opm::DeckKeywordConstPtr viscrefKeyword = deck->getKeyword("VISCREF");
+            const auto& viscrefKeyword = deck->getKeyword("VISCREF");
 
             assert(oilvisctTables.size() == numRegions);
-            assert(viscrefKeyword->size() == numRegions);
+            assert(viscrefKeyword.size() == numRegions);
 
             for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
                 const auto& TCol = oilvisctTables[regionIdx].getColumn("Temperature").vectorCopy();
                 const auto& muCol = oilvisctTables[regionIdx].getColumn("Viscosity").vectorCopy();
                 oilvisctCurves_[regionIdx].setXYContainers(TCol, muCol);
 
-                DeckRecordConstPtr viscrefRecord = viscrefKeyword->getRecord(regionIdx);
-                viscrefPress_[regionIdx] = viscrefRecord->getItem("REFERENCE_PRESSURE")->getSIDouble(0);
-                viscrefRs_[regionIdx] = viscrefRecord->getItem("REFERENCE_RS")->getSIDouble(0);
+                const auto& viscrefRecord = viscrefKeyword.getRecord(regionIdx);
+                viscrefPress_[regionIdx] = viscrefRecord.getItem("REFERENCE_PRESSURE").getSIDouble(0);
+                viscrefRs_[regionIdx] = viscrefRecord.getItem("REFERENCE_RS").getSIDouble(0);
 
                 // temperature used to calculate the reference viscosity [K]. the
                 // value does not really matter if the underlying PVT object really
@@ -116,13 +116,13 @@ public:
         // for the first EOS. (since EOS != PVT region.)
         refTemp_ = 0.0;
         if (deck->hasKeyword("THERMEX1")) {
-            int oilCompIdx = deck->getKeyword("OCOMPIDX")->getRecord(0)->getItem("OIL_COMPONENT_INDEX")->getInt(0) - 1;
+            int oilCompIdx = deck->getKeyword("OCOMPIDX").getRecord(0).getItem("OIL_COMPONENT_INDEX").get< int >(0) - 1;
 
             // always use the values of the first EOS
-            refTemp_ = deck->getKeyword("TREF")->getRecord(0)->getItem("TEMPERATURE")->getSIDouble(oilCompIdx);
-            refPress_ = deck->getKeyword("PREF")->getRecord(0)->getItem("PRESSURE")->getSIDouble(oilCompIdx);
-            refC_ = deck->getKeyword("CREF")->getRecord(0)->getItem("COMPRESSIBILITY")->getSIDouble(oilCompIdx);
-            thermex1_ = deck->getKeyword("THERMEX1")->getRecord(0)->getItem("EXPANSION_COEFF")->getSIDouble(oilCompIdx);
+            refTemp_ = deck->getKeyword("TREF").getRecord(0).getItem("TEMPERATURE").getSIDouble(oilCompIdx);
+            refPress_ = deck->getKeyword("PREF").getRecord(0).getItem("PRESSURE").getSIDouble(oilCompIdx);
+            refC_ = deck->getKeyword("CREF").getRecord(0).getItem("COMPRESSIBILITY").getSIDouble(oilCompIdx);
+            thermex1_ = deck->getKeyword("THERMEX1").getRecord(0).getItem("EXPANSION_COEFF").getSIDouble(oilCompIdx);
         }
     }
 #endif // HAVE_OPM_PARSER

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -82,33 +82,33 @@ public:
         setNumRegions(numRegions);
 
         if (enableThermalDensity_) {
-            DeckKeywordConstPtr watdentKeyword = deck->getKeyword("WATDENT");
+            const auto& watdentKeyword = deck->getKeyword("WATDENT");
 
-            assert(watdentKeyword->size() == numRegions);
+            assert(watdentKeyword.size() == numRegions);
             for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-                Opm::DeckRecordConstPtr watdentRecord = watdentKeyword->getRecord(regionIdx);
+                const auto& watdentRecord = watdentKeyword.getRecord(regionIdx);
 
-                watdentRefTemp_[regionIdx] = watdentRecord->getItem("REFERENCE_TEMPERATURE")->getSIDouble(0);
-                watdentCT1_[regionIdx] = watdentRecord->getItem("EXPANSION_COEFF_LINEAR")->getSIDouble(0);
-                watdentCT2_[regionIdx] = watdentRecord->getItem("EXPANSION_COEFF_QUADRATIC")->getSIDouble(0);
+                watdentRefTemp_[regionIdx] = watdentRecord.getItem("REFERENCE_TEMPERATURE").getSIDouble(0);
+                watdentCT1_[regionIdx] = watdentRecord.getItem("EXPANSION_COEFF_LINEAR").getSIDouble(0);
+                watdentCT2_[regionIdx] = watdentRecord.getItem("EXPANSION_COEFF_QUADRATIC").getSIDouble(0);
             }
         }
 
         if (enableThermalViscosity_) {
-            Opm::DeckKeywordConstPtr viscrefKeyword = deck->getKeyword("VISCREF");
+            const auto& viscrefKeyword = deck->getKeyword("VISCREF");
 
             const auto& watvisctTables = tables->getWatvisctTables();
 
             assert(watvisctTables.size() == numRegions);
-            assert(viscrefKeyword->size() == numRegions);
+            assert(viscrefKeyword.size() == numRegions);
 
             for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
                 const auto& T = watvisctTables[regionIdx].getColumn("Temperature").vectorCopy();
                 const auto& mu = watvisctTables[regionIdx].getColumn("Viscosity").vectorCopy();
                 watvisctCurves_[regionIdx].setXYContainers(T, mu);
 
-                Opm::DeckRecordConstPtr viscrefRecord = viscrefKeyword->getRecord(regionIdx);
-                viscrefPress_[regionIdx] = viscrefRecord->getItem("REFERENCE_PRESSURE")->getSIDouble(0);
+                const auto& viscrefRecord = viscrefKeyword.getRecord(regionIdx);
+                viscrefPress_[regionIdx] = viscrefRecord.getItem("REFERENCE_PRESSURE").getSIDouble(0);
             }
         }
     }

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -61,17 +61,17 @@ public:
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
         const auto& pvtgTables = eclState->getTableManager()->getPvtgTables();
-        DeckKeywordConstPtr densityKeyword = deck->getKeyword("DENSITY");
+        const auto& densityKeyword = deck->getKeyword("DENSITY");
 
-        assert(pvtgTables.size() == densityKeyword->size());
+        assert(pvtgTables.size() == densityKeyword.size());
 
         size_t numRegions = pvtgTables.size();
         setNumRegions(numRegions);
 
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-            Scalar rhoRefO = densityKeyword->getRecord(regionIdx)->getItem("OIL")->getSIDouble(0);
-            Scalar rhoRefG = densityKeyword->getRecord(regionIdx)->getItem("GAS")->getSIDouble(0);
-            Scalar rhoRefW = densityKeyword->getRecord(regionIdx)->getItem("WATER")->getSIDouble(0);
+            Scalar rhoRefO = densityKeyword.getRecord(regionIdx).getItem("OIL").getSIDouble(0);
+            Scalar rhoRefG = densityKeyword.getRecord(regionIdx).getItem("GAS").getSIDouble(0);
+            Scalar rhoRefW = densityKeyword.getRecord(regionIdx).getItem("WATER").getSIDouble(0);
 
             setReferenceDensities(regionIdx, rhoRefO, rhoRefG, rhoRefW);
         }

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -214,8 +214,8 @@ inline void testAll()
     const auto eclState = std::make_shared<Opm::EclipseState>(deck, parseMode);
     const auto eclGrid = eclState->getEclipseGrid();
 
-    const auto pvtwKeyword = deck->getKeyword("PVTW");
-    size_t numPvtRegions = pvtwKeyword->size();
+    const auto& pvtwKeyword = deck->getKeyword("PVTW");
+    size_t numPvtRegions = pvtwKeyword.size();
 
     if (numPvtRegions != 2)
         OPM_THROW(std::logic_error,


### PR DESCRIPTION
opm-parser#677 changes the return types for the Deck family of classes.
This patch fixes all broken code from that patch set.

https://github.com/OPM/opm-parser/pull/677