### PR TITLE
Do not pass rvalue references

### DIFF
--- a/opm/material/checkFluidSystem.hpp
+++ b/opm/material/checkFluidSystem.hpp
@@ -98,118 +98,118 @@ public:
     const BaseFluidState& base() const
     { return *static_cast<const BaseFluidState*>(this); }
 
-    Scalar temperature(unsigned phaseIdx) const
+    auto temperature(unsigned phaseIdx) const
+        -> decltype(this->base().temperature(phaseIdx))
     {
         assert(allowTemperature_);
         assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
-        OPM_UNUSED Scalar tmp = BaseFluidState::temperature(phaseIdx);
-        return 1e100;
+        return this->base().temperature(phaseIdx);
     }
 
-    Scalar pressure(unsigned phaseIdx) const
+    auto pressure(unsigned phaseIdx) const
+        -> decltype(this->base().pressure(phaseIdx))
     {
         assert(allowPressure_);
         assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
-        OPM_UNUSED Scalar tmp = BaseFluidState::pressure(phaseIdx);
-        return 1e100;
+        return this->base().pressure(phaseIdx);
     }
 
-    Scalar moleFraction(unsigned phaseIdx, unsigned compIdx) const
+    auto moleFraction(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(this->base().moleFraction(phaseIdx, compIdx))
     {
         assert(allowComposition_);
         assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
-        OPM_UNUSED Scalar tmp = BaseFluidState::moleFraction(phaseIdx, compIdx);
-        return 1e100;
+        return this->base().moleFraction(phaseIdx, compIdx);
     }
 
-    Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
+    auto massFraction(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(this->base().massFraction(phaseIdx, compIdx))
     {
         assert(allowComposition_);
         assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
-        OPM_UNUSED Scalar tmp = BaseFluidState::massFraction(phaseIdx, compIdx);
-        return 1e100;
+        return this->base().massFraction(phaseIdx, compIdx);
     }
 
-    Scalar averageMolarMass(unsigned phaseIdx) const
+    auto averageMolarMass(unsigned phaseIdx) const
+        -> decltype(this->base().averageMolarMass(phaseIdx))
     {
         assert(allowComposition_);
         assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
-        OPM_UNUSED Scalar tmp = BaseFluidState::averageMolarMass(phaseIdx);
-        return 1e100;
+        return this->base().averageMolarMass(phaseIdx);
     }
 
-    Scalar molarity(unsigned phaseIdx, unsigned compIdx) const
+    auto molarity(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(this->base().molarity(phaseIdx, compIdx))
     {
         assert(allowDensity_ && allowComposition_);
         assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
-        OPM_UNUSED Scalar tmp = BaseFluidState::molarity(phaseIdx, compIdx);
-        return 1e100;
+        return this->base().molarity(phaseIdx, compIdx);
     }
 
-    Scalar molarDensity(unsigned phaseIdx) const
+    auto molarDensity(unsigned phaseIdx) const
+        -> decltype(this->base().molarDensity(phaseIdx))
     {
         assert(allowDensity_);
         assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
-        OPM_UNUSED Scalar tmp = BaseFluidState::molarDensity(phaseIdx);
-        return 1e100;
+        return this->base().molarDensity(phaseIdx);
     }
 
-    Scalar molarVolume(unsigned phaseIdx) const
+    auto molarVolume(unsigned phaseIdx) const
+        -> decltype(this->base().molarVolume(phaseIdx))
     {
         assert(allowDensity_);
         assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
-        OPM_UNUSED Scalar tmp = BaseFluidState::molarVolume(phaseIdx);
-        return 1e100;
+        return this->base().molarVolume(phaseIdx);
     }
 
-    Scalar density(unsigned phaseIdx) const
+    auto density(unsigned phaseIdx) const
+        -> decltype(this->base().density(phaseIdx))
     {
         assert(allowDensity_);
         assert(restrictPhaseIdx_ < 0 || restrictPhaseIdx_ == static_cast<int>(phaseIdx));
-        OPM_UNUSED Scalar tmp = BaseFluidState::density(phaseIdx);
-        return 1e100;
+        return this->base().density(phaseIdx);
     }
 
-    Scalar saturation(unsigned phaseIdx) const
+    auto saturation(unsigned phaseIdx) const
+        -> decltype(this->base().saturation(phaseIdx))
     {
         assert(false);
-        OPM_UNUSED Scalar tmp =  BaseFluidState::saturation(phaseIdx);
-        return 1e100;
+        return  this->base().saturation(phaseIdx);
     }
 
-    Scalar fugacity(unsigned phaseIdx, unsigned compIdx) const
+    auto fugacity(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(this->base().fugacity(phaseIdx, compIdx))
     {
         assert(false);
-        OPM_UNUSED Scalar tmp = BaseFluidState::fugacity(phaseIdx, compIdx);
-        return 1e100;
+        return this->base().fugacity(phaseIdx, compIdx);
     }
 
-    Scalar fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
+    auto fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(this->base().fugacityCoefficient(phaseIdx, compIdx))
     {
         assert(false);
-        OPM_UNUSED Scalar tmp = BaseFluidState::fugacityCoefficient(phaseIdx, compIdx);
-        return 1e100;
+        return this->base().fugacityCoefficient(phaseIdx, compIdx);
     }
 
-    Scalar enthalpy(unsigned phaseIdx) const
+    auto enthalpy(unsigned phaseIdx) const
+        -> decltype(this->base().enthalpy(phaseIdx))
     {
         assert(false);
-        OPM_UNUSED Scalar tmp = BaseFluidState::enthalpy(phaseIdx);
-        return 1e100;
+        return this->base().enthalpy(phaseIdx);
     }
 
-    Scalar internalEnergy(unsigned phaseIdx) const
+    auto internalEnergy(unsigned phaseIdx) const
+        -> decltype(this->base().internalEnergy(phaseIdx))
     {
         assert(false);
-        OPM_UNUSED Scalar tmp = BaseFluidState::internalEnergy(phaseIdx);
-        return 1e100;
+        return this->base().internalEnergy(phaseIdx);
     }
 
-    Scalar viscosity(unsigned phaseIdx) const
+    auto viscosity(unsigned phaseIdx) const
+        -> decltype(this->base().viscosity(phaseIdx))
     {
         assert(false);
-        OPM_UNUSED Scalar tmp = BaseFluidState::viscosity(phaseIdx);
-        return 1e100;
+        return this->base().viscosity(phaseIdx);
     }
 
 private:

--- a/opm/material/fluidstates/FluidStateCompositionModules.hpp
+++ b/opm/material/fluidstates/FluidStateCompositionModules.hpp
@@ -60,7 +60,7 @@ public:
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    const Scalar&  moleFraction(unsigned phaseIdx, unsigned compIdx) const
+    const Scalar& moleFraction(unsigned phaseIdx, unsigned compIdx) const
     { return moleFraction_[phaseIdx][compIdx]; }
 
     /*!
@@ -85,7 +85,7 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    const Scalar&  averageMolarMass(unsigned phaseIdx) const
+    const Scalar& averageMolarMass(unsigned phaseIdx) const
     { return averageMolarMass_[phaseIdx]; }
 
     /*!
@@ -105,7 +105,7 @@ public:
      *        and update the average molar mass [kg/mol] according
      *        to the current composition of the phase
      */
-    void setMoleFraction(unsigned phaseIdx, unsigned compIdx, const Scalar&  value)
+    void setMoleFraction(unsigned phaseIdx, unsigned compIdx, const Scalar& value)
     {
         Valgrind::CheckDefined(value);
         Valgrind::SetUndefined(sumMoleFractions_[phaseIdx]);

--- a/opm/material/fluidstates/FluidStateDensityModules.hpp
+++ b/opm/material/fluidstates/FluidStateDensityModules.hpp
@@ -129,13 +129,13 @@ public:
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
-    Scalar molarDensity(int /* phaseIdx */) const
+    const Scalar& molarDensity(int /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Molar density is not provided by this fluid state"); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
-    Scalar molarVolume(int /* phaseIdx */) const
+    const Scalar& molarVolume(int /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Molar volume is not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStateTemperatureModules.hpp
+++ b/opm/material/fluidstates/FluidStateTemperatureModules.hpp
@@ -54,7 +54,7 @@ public:
     /*!
      * \brief The temperature of a fluid phase [-]
      */
-    Scalar temperature(unsigned phaseIdx) const
+    const Scalar& temperature(unsigned phaseIdx) const
     { return temperature_[phaseIdx]; }
 
     /*!
@@ -108,7 +108,7 @@ public:
     /*!
      * \brief The temperature of a fluid phase [-]
      */
-    Scalar temperature(unsigned /*phaseIdx*/) const
+    const Scalar& temperature(unsigned /*phaseIdx*/) const
     { return temperature_; }
 
     /*!
@@ -168,7 +168,7 @@ public:
     /*!
      * \brief The temperature of a fluid phase [-]
      */
-    Scalar temperature(unsigned /* phaseIdx */) const
+    const Scalar& temperature(unsigned /* phaseIdx */) const
     { OPM_THROW(std::runtime_error, "Temperature is not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStateTemperatureModules.hpp
+++ b/opm/material/fluidstates/FluidStateTemperatureModules.hpp
@@ -60,7 +60,7 @@ public:
     /*!
      * \brief Set the temperature of a phase [-]
      */
-    void setTemperature(unsigned phaseIdx, Scalar value)
+    void setTemperature(unsigned phaseIdx, const Scalar& value)
     { temperature_[phaseIdx] = value; }
 
     /*!
@@ -114,7 +114,7 @@ public:
     /*!
      * \brief Set the temperature of a phase [-]
      */
-    void setTemperature(Scalar value)
+    void setTemperature(const Scalar& value)
     { temperature_ = value; }
 
     /*!

--- a/opm/material/fluidstates/FluidStateViscosityModules.hpp
+++ b/opm/material/fluidstates/FluidStateViscosityModules.hpp
@@ -52,7 +52,7 @@ public:
     /*!
      * \brief The viscosity of a fluid phase [-]
      */
-    Scalar viscosity(unsigned phaseIdx) const
+    const Scalar& viscosity(unsigned phaseIdx) const
     { return viscosity_[phaseIdx]; }
 
     /*!
@@ -108,7 +108,7 @@ public:
     /*!
      * \brief The viscosity of a fluid phase [-]
      */
-    Scalar viscosity(int /* phaseIdx */) const
+    const Scalar& viscosity(int /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Viscosity is not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/PressureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/PressureOverlayFluidState.hpp
@@ -28,6 +28,7 @@
 #include <opm/material/common/Valgrind.hpp>
 
 #include <array>
+#include <utility>
 
 namespace Opm {
 
@@ -81,19 +82,22 @@ public:
     /*!
      * \brief Returns the saturation of a phase []
      */
-    Scalar saturation(unsigned phaseIdx) const
+    auto saturation(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().saturation(phaseIdx))
     { return fs_->saturation(phaseIdx); }
 
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    Scalar moleFraction(unsigned phaseIdx, unsigned compIdx) const
+    auto moleFraction(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().moleFraction(phaseIdx, compIdx))
     { return fs_->moleFraction(phaseIdx, compIdx); }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
-    Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
+    auto massFraction(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().massFraction(phaseIdx, compIdx))
     { return fs_->massFraction(phaseIdx, compIdx); }
 
     /*!
@@ -104,7 +108,8 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    Scalar averageMolarMass(unsigned phaseIdx) const
+    auto averageMolarMass(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().averageMolarMass(phaseIdx))
     { return fs_->averageMolarMass(phaseIdx); }
 
     /*!
@@ -116,67 +121,78 @@ public:
      *
      * http://en.wikipedia.org/wiki/Concentration
      */
-    Scalar molarity(unsigned phaseIdx, unsigned compIdx) const
+    auto molarity(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().molarity(phaseIdx, compIdx))
     { return fs_->molarity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
-    Scalar fugacity(unsigned phaseIdx, unsigned compIdx) const
+    auto fugacity(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().fugacity(phaseIdx, compIdx))
     { return fs_->fugacity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity coefficient of a component in a phase [-]
      */
-    Scalar fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
+    auto fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().fugacityCoefficient(phaseIdx, compIdx))
     { return fs_->fugacityCoefficient(phaseIdx, compIdx); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
-    Scalar molarVolume(unsigned phaseIdx) const
+    auto molarVolume(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().molarVolume(phaseIdx))
     { return fs_->molarVolume(phaseIdx); }
 
     /*!
      * \brief The mass density of a fluid phase [kg/m^3]
      */
-    Scalar density(unsigned phaseIdx) const
+    auto density(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().density(phaseIdx))
     { return fs_->density(phaseIdx); }
 
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
-    Scalar molarDensity(unsigned phaseIdx) const
+    auto molarDensity(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().molarDensity(phaseIdx))
     { return fs_->molarDensity(phaseIdx); }
 
     /*!
      * \brief The temperature of a fluid phase [K]
      */
-    Scalar temperature(unsigned phaseIdx) const
+    auto temperature(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().temperature(phaseIdx))
     { return fs_->temperature(phaseIdx); }
 
     /*!
      * \brief The pressure of a fluid phase [Pa]
      */
-    Scalar pressure(unsigned phaseIdx) const
+    auto pressure(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().pressure(phaseIdx))
     { return pressure_[phaseIdx]; }
 
     /*!
      * \brief The specific enthalpy of a fluid phase [J/kg]
      */
-    Scalar enthalpy(unsigned phaseIdx) const
+    auto enthalpy(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().enthalpy(phaseIdx))
     { return fs_->enthalpy(phaseIdx); }
 
     /*!
      * \brief The specific internal energy of a fluid phase [J/kg]
      */
-    Scalar internalEnergy(unsigned phaseIdx) const
+    auto internalEnergy(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().internalEnergy(phaseIdx))
     { return fs_->internalEnergy(phaseIdx); }
 
     /*!
      * \brief The dynamic viscosity of a fluid phase [Pa s]
      */
-    Scalar viscosity(unsigned phaseIdx) const
+    auto viscosity(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().viscosity(phaseIdx))
     { return fs_->viscosity(phaseIdx); }
 
 
@@ -188,7 +204,7 @@ public:
     /*!
      * \brief Set the pressure [Pa] of a fluid phase
      */
-    void setPressure(unsigned phaseIdx, Scalar value)
+    void setPressure(unsigned phaseIdx, const Scalar& value)
     { pressure_[phaseIdx] = value; }
 
     /*!

--- a/opm/material/fluidstates/SaturationOverlayFluidState.hpp
+++ b/opm/material/fluidstates/SaturationOverlayFluidState.hpp
@@ -28,6 +28,7 @@
 #include <opm/material/common/Valgrind.hpp>
 
 #include <array>
+#include <utility>
 
 namespace Opm {
 
@@ -80,19 +81,22 @@ public:
     /*!
      * \brief Returns the saturation of a phase []
      */
-    Scalar saturation(unsigned phaseIdx) const
+    auto saturation(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().saturation(phaseIdx))
     { return saturation_[phaseIdx]; }
 
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    Scalar moleFraction(unsigned phaseIdx, unsigned compIdx) const
+    auto moleFraction(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().moleFraction(phaseIdx, compIdx))
     { return fs_->moleFraction(phaseIdx, compIdx); }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
-    Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
+    auto massFraction(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().massFraction(phaseIdx, compIdx))
     { return fs_->massFraction(phaseIdx, compIdx); }
 
     /*!
@@ -103,7 +107,8 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    Scalar averageMolarMass(unsigned phaseIdx) const
+    auto averageMolarMass(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().averageMolarMass(phaseIdx))
     { return fs_->averageMolarMass(phaseIdx); }
 
     /*!
@@ -115,67 +120,78 @@ public:
      *
      * http://en.wikipedia.org/wiki/Concentration
      */
-    Scalar molarity(unsigned phaseIdx, unsigned compIdx) const
+    auto molarity(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().molarity(phaseIdx, compIdx))
     { return fs_->molarity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
-    Scalar fugacity(unsigned phaseIdx, unsigned compIdx) const
+    auto fugacity(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().fugacity(phaseIdx, compIdx))
     { return fs_->fugacity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity coefficient of a component in a phase [-]
      */
-    Scalar fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
+    auto fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().fugacityCoefficient(phaseIdx, compIdx))
     { return fs_->fugacityCoefficient(phaseIdx, compIdx); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
-    Scalar molarVolume(unsigned phaseIdx) const
+    auto molarVolume(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().molarVolume(phaseIdx))
     { return fs_->molarVolume(phaseIdx); }
 
     /*!
      * \brief The mass density of a fluid phase [kg/m^3]
      */
-    Scalar density(unsigned phaseIdx) const
+    auto density(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().density(phaseIdx))
     { return fs_->density(phaseIdx); }
 
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
-    Scalar molarDensity(unsigned phaseIdx) const
+    auto molarDensity(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().molarDensity(phaseIdx))
     { return fs_->molarDensity(phaseIdx); }
 
     /*!
      * \brief The temperature of a fluid phase [K]
      */
-    Scalar temperature(unsigned phaseIdx) const
+    auto temperature(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().temperature(phaseIdx))
     { return fs_->temperature(phaseIdx); }
 
     /*!
      * \brief The pressure of a fluid phase [Pa]
      */
-    Scalar pressure(unsigned phaseIdx) const
+    auto pressure(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().pressure(phaseIdx))
     { return fs_->pressure(phaseIdx); }
 
     /*!
      * \brief The specific enthalpy of a fluid phase [J/kg]
      */
-    Scalar enthalpy(unsigned phaseIdx) const
+    auto enthalpy(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().enthalpy(phaseIdx))
     { return fs_->enthalpy(phaseIdx); }
 
     /*!
      * \brief The specific internal energy of a fluid phase [J/kg]
      */
-    Scalar internalEnergy(unsigned phaseIdx) const
+    auto internalEnergy(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().internalEnergy(phaseIdx))
     { return fs_->internalEnergy(phaseIdx); }
 
     /*!
      * \brief The dynamic viscosity of a fluid phase [Pa s]
      */
-    Scalar viscosity(unsigned phaseIdx) const
+    auto viscosity(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().viscosity(phaseIdx))
     { return fs_->viscosity(phaseIdx); }
 
 
@@ -187,7 +203,7 @@ public:
     /*!
      * \brief Set the saturation [-] of a fluid phase
      */
-    void setSaturation(unsigned phaseIdx, Scalar value)
+    void setSaturation(unsigned phaseIdx, const Scalar& value)
     { saturation_[phaseIdx] = value; }
 
     /*!

--- a/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
@@ -27,6 +27,8 @@
 
 #include <opm/material/common/Valgrind.hpp>
 
+#include <utility>
+
 namespace Opm {
 
 /*!
@@ -82,19 +84,22 @@ public:
     /*!
      * \brief Returns the saturation of a phase []
      */
-    Scalar saturation(unsigned phaseIdx) const
+    auto saturation(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().saturation(phaseIdx))
     { return fs_->saturation(phaseIdx); }
 
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    Scalar moleFraction(unsigned phaseIdx, unsigned compIdx) const
+    auto moleFraction(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().moleFraction(phaseIdx, compIdx))
     { return fs_->moleFraction(phaseIdx, compIdx); }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
-    Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
+    auto massFraction(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().massFraction(phaseIdx, compIdx))
     { return fs_->massFraction(phaseIdx, compIdx); }
 
     /*!
@@ -105,7 +110,8 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    Scalar averageMolarMass(unsigned phaseIdx) const
+    auto averageMolarMass(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().averageMolarMass(phaseIdx))
     { return fs_->averageMolarMass(phaseIdx); }
 
     /*!
@@ -117,67 +123,77 @@ public:
      *
      * http://en.wikipedia.org/wiki/Concentration
      */
-    Scalar molarity(unsigned phaseIdx, unsigned compIdx) const
+    auto molarity(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().molarity(phaseIdx, compIdx))
     { return fs_->molarity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
-    Scalar fugacity(unsigned phaseIdx, unsigned compIdx) const
+    auto fugacity(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().fugacity(phaseIdx, compIdx))
     { return fs_->fugacity(phaseIdx, compIdx); }
 
     /*!
      * \brief The fugacity coefficient of a component in a phase []
      */
-    Scalar fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
+    auto fugacityCoefficient(unsigned phaseIdx, unsigned compIdx) const
+        -> decltype(std::declval<FluidState>().fugacityCoefficient(phaseIdx, compIdx))
     { return fs_->fugacityCoefficient(phaseIdx, compIdx); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
-    Scalar molarVolume(unsigned phaseIdx) const
+    auto molarVolume(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().molarVolume(phaseIdx))
     { return fs_->molarVolume(phaseIdx); }
 
     /*!
      * \brief The mass density of a fluid phase [kg/m^3]
      */
-    Scalar density(unsigned phaseIdx) const
+    auto density(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().density(phaseIdx))
     { return fs_->density(phaseIdx); }
 
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
-    Scalar molarDensity(unsigned phaseIdx) const
+    auto molarDensity(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().molarDensity(phaseIdx))
     { return fs_->molarDensity(phaseIdx); }
 
     /*!
      * \brief The temperature of a fluid phase [K]
      */
-    Scalar temperature(int /*phaseIdx*/) const
+    const Scalar& temperature(int /*phaseIdx*/) const
     { return temperature_; }
 
     /*!
      * \brief The pressure of a fluid phase [Pa]
      */
-    Scalar pressure(unsigned phaseIdx) const
+    auto pressure(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().pressure(phaseIdx))
     { return fs_->pressure(phaseIdx); }
 
     /*!
      * \brief The specific enthalpy of a fluid phase [J/kg]
      */
-    Scalar enthalpy(unsigned phaseIdx) const
+    auto enthalpy(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().enthalpy(phaseIdx))
     { return fs_->enthalpy(phaseIdx); }
 
     /*!
      * \brief The specific internal energy of a fluid phase [J/kg]
      */
-    Scalar internalEnergy(unsigned phaseIdx) const
+    auto internalEnergy(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().internalEnergy(phaseIdx))
     { return fs_->internalEnergy(phaseIdx); }
 
     /*!
      * \brief The dynamic viscosity of a fluid phase [Pa s]
      */
-    Scalar viscosity(unsigned phaseIdx) const
+    auto viscosity(unsigned phaseIdx) const
+        -> decltype(std::declval<FluidState>().viscosity(phaseIdx))
     { return fs_->viscosity(phaseIdx); }
 
 
@@ -189,7 +205,7 @@ public:
     /*!
      * \brief Set the temperature [K] of a fluid phase
      */
-    void setTemperature(Scalar value)
+    void setTemperature(const Scalar& value)
     { temperature_ = value; }
 
     /*!

--- a/opm/material/localad/Math.hpp
+++ b/opm/material/localad/Math.hpp
@@ -385,7 +385,7 @@ Evaluation<Scalar, VarSetTag, numVars> log(const Evaluation<Scalar, VarSetTag, n
 // a kind of traits class for the automatic differentiation case. (The toolbox for the
 // scalar case is provided by the MathToolbox.hpp header file.)
 template <class ScalarT, class VariableSetTag, int numVars>
-struct MathToolbox<Opm::LocalAd::Evaluation<ScalarT, VariableSetTag, numVars>, false>
+struct MathToolbox<Opm::LocalAd::Evaluation<ScalarT, VariableSetTag, numVars>>
 {
 private:
 public:
@@ -402,9 +402,22 @@ public:
     { return Evaluation::createVariable(value, varIdx); }
 
     template <class LhsEval>
-    static auto toLhs(const Evaluation& eval)
-        -> decltype(ToLhsEvalHelper<LhsEval, Evaluation>::exec(eval))
-    { return ToLhsEvalHelper<LhsEval, Evaluation>::exec(eval); }
+    static typename std::enable_if<std::is_same<Evaluation, LhsEval>::value,
+                                   const LhsEval&>::type
+    toLhs(const Evaluation& eval)
+    { return eval; }
+
+    template <class LhsEval>
+    static typename std::enable_if<std::is_same<Evaluation, LhsEval>::value,
+                                   LhsEval>::type
+    toLhs(const Evaluation&& eval)
+    { return eval; }
+
+    template <class LhsEval>
+    static typename std::enable_if<std::is_floating_point<LhsEval>::value,
+                                   LhsEval>::type
+    toLhs(const Evaluation& eval)
+    { return eval.value; }
 
     static const Evaluation passThroughOrCreateConstant(Scalar value)
     { return createConstant(value); }

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -232,7 +232,7 @@ void testAllFluidStates()
         checkFluidState<Scalar>(fs); }
 }
 
-template <class Scalar, class Evaluation, class LhsEval = Evaluation>
+template <class Scalar, class FluidStateEval, class LhsEval>
 void testAllFluidSystems()
 {
     typedef Opm::LiquidPhase<Scalar, Opm::H2O<Scalar>> Liquid;
@@ -241,7 +241,7 @@ void testAllFluidSystems()
     // black-oil
     {
         typedef Opm::FluidSystems::BlackOil<Scalar> FluidSystem;
-        if (false) checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>();
+        if (false) checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>();
 
         struct BlackoilDummyEvalTag;
         typedef Opm::LocalAd::Evaluation<Scalar, BlackoilDummyEvalTag, 1> BlackoilDummyEval;
@@ -251,67 +251,67 @@ void testAllFluidSystems()
 
     // Brine -- CO2
     {   typedef Opm::FluidSystems::BrineCO2<Scalar, Opm::FluidSystemsTest::CO2Tables> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- N2
     {   typedef Opm::FluidSystems::H2ON2<Scalar, /*enableComplexRelations=*/false> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     {   typedef Opm::FluidSystems::H2ON2<Scalar, /*enableComplexRelations=*/true> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- N2 -- liquid phase
     {   typedef Opm::FluidSystems::H2ON2LiquidPhase<Scalar, /*enableComplexRelations=*/false> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     {   typedef Opm::FluidSystems::H2ON2LiquidPhase<Scalar, /*enableComplexRelations=*/true> FluidSystem;
-         checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- Air
     {   typedef Opm::SimpleH2O<Scalar> H2O;
         const bool enableComplexRelations=false;
         typedef Opm::FluidSystems::H2OAir<Scalar, H2O, enableComplexRelations> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     {   typedef Opm::SimpleH2O<Scalar> H2O;
         const bool enableComplexRelations=true;
         typedef Opm::FluidSystems::H2OAir<Scalar, H2O, enableComplexRelations> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     {   typedef Opm::H2O<Scalar> H2O;
         const bool enableComplexRelations=false;
         typedef Opm::FluidSystems::H2OAir<Scalar, H2O, enableComplexRelations> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     {   typedef Opm::H2O<Scalar> H2O;
         const bool enableComplexRelations=true;
         typedef Opm::FluidSystems::H2OAir<Scalar, H2O, enableComplexRelations> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- Air -- Mesitylene
     {   typedef Opm::FluidSystems::H2OAirMesitylene<Scalar> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- Air -- Xylene
     {   typedef Opm::FluidSystems::H2OAirXylene<Scalar> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // 2p-immiscible
     {   typedef Opm::FluidSystems::TwoPhaseImmiscible<Scalar, Liquid, Liquid> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     {   typedef Opm::FluidSystems::TwoPhaseImmiscible<Scalar, Liquid, Gas> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     {  typedef Opm::FluidSystems::TwoPhaseImmiscible<Scalar, Gas, Liquid> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // 1p
     {   typedef Opm::FluidSystems::SinglePhase<Scalar, Liquid> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     {   typedef Opm::FluidSystems::SinglePhase<Scalar, Gas> FluidSystem;
-        checkFluidSystem<Scalar, FluidSystem, Evaluation, LhsEval>(); }
+        checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 }
 
 class TestAdTag;
@@ -328,9 +328,9 @@ inline void testAll()
     // ensure that all fluid systems are API-compliant: Each fluid system must be usable
     // for both, scalars and function evaluations. The fluid systems for function
     // evaluations must also be usable for scalars.
-    testAllFluidSystems<Scalar, Scalar>();
-    testAllFluidSystems<Scalar, Evaluation>();
-    testAllFluidSystems<Scalar, Evaluation, Scalar>();
+    testAllFluidSystems<Scalar, /*FluidStateEval=*/Scalar, /*LhsEval=*/Scalar>();
+    testAllFluidSystems<Scalar, /*FluidStateEval=*/Evaluation, /*LhsEval=*/Evaluation>();
+    testAllFluidSystems<Scalar, /*FluidStateEval=*/Evaluation, /*LhsEval=*/Scalar>();
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
the problem is that references to lvalues can be just passed through,
whilst the objects the rvalue references point are to temporary and thus
need need to be copied. Fixing this issue forced me to venture into the
rabbit hole of the c++ memory model, but at least I guess I now know
what rvalue references ('Foo&&' instead of 'Foo&') are good for...

I guess that this fixes #123. I'll merge myself if the jenkins server agrees.