### PR TITLE
black-oil PVT: bail out from trying to initialize PVT objects for inactive phases

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -116,6 +116,10 @@ public:
      */
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
+        bool enableGas = deck->hasKeyword("GAS");
+        if (!enableGas)
+            return;
+
         if (enableThermal
             && (deck->hasKeyword("TREF")
                 || deck->hasKeyword("GASVISCT")))

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -122,6 +122,10 @@ public:
      */
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
+        bool enableOil = deck->hasKeyword("OIL");
+        if (!enableOil)
+            return;
+
         if (enableThermal
             && (deck->hasKeyword("THERMEX1")
                 || deck->hasKeyword("VISCREF")))

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -91,6 +91,10 @@ public:
      */
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
+        bool enableWater = deck->hasKeyword("WATER");
+        if (!enableWater)
+            return;
+
         if (enableThermal
             && (deck->hasKeyword("WATDENT")
                 || deck->hasKeyword("VISCREF")))


### PR DESCRIPTION
this should fix twophase decks, see
https://github.com/OPM/opm-autodiff/pull/576#issuecomment-185770114.