### PR TITLE
make MathToolbox::toLhs() always return a copy again

### DIFF
--- a/opm/material/localad/Math.hpp
+++ b/opm/material/localad/Math.hpp
@@ -403,7 +403,7 @@ public:
 
     template <class LhsEval>
     static typename std::enable_if<std::is_same<Evaluation, LhsEval>::value,
-                                   const LhsEval&>::type
+                                   LhsEval>::type
     toLhs(const Evaluation& eval)
     { return eval; }
 


### PR DESCRIPTION
in my testing, the GCC SVN version from 4th of March causes problems
if lvalue references are just passed through and neither GCC-5 nor
clang 3.6 show any obvious differences in performance. (I guess that's
because of the copy elision compiler optimizations in conjunction with
inlining.)

It is also worthwhile to know that clang 3.6 is about 20% faster with
ebos than both, GCC-6 and GCC-5. I can only speculate why this is the
case, but since the performance improvement seems to evenly apply to
the linearization and linear-solve parts, the auto-vectorizer of clang
possibly works better for ebos than the one of GCC...