### PR TITLE
handle the "viscosibility" of water with constant compressibility as documented by the ECL RM

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -180,9 +180,6 @@ public:
                                   const Evaluation& temperature,
                                   const Evaluation& pressure) const
     {
-        // Eclipse calculates the viscosity in a weird way: it
-        // calcultes the product of B_w and mu_w and then divides the
-        // result by B_w...
         Scalar BoMuoRef = oilViscosity_[regionIdx]*oilReferenceFormationVolumeFactor_[regionIdx];
         const Evaluation& bo = saturatedInverseFormationVolumeFactor(regionIdx, temperature, pressure);
 

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -162,21 +162,17 @@ public:
      */
     template <class Evaluation>
     Evaluation viscosity(unsigned regionIdx,
-                         const Evaluation& /*temperature*/,
+                         const Evaluation& temperature,
                          const Evaluation& pressure) const
     {
-        // Eclipse calculates the viscosity in a weird way: it
-        // calcultes the product of B_w and mu_w and then divides the
-        // result by B_w...
-        Scalar muwRef = waterViscosity_[regionIdx];
+        Scalar BwMuwRef = waterViscosity_[regionIdx]*waterReferenceFormationVolumeFactor_[regionIdx];
+        const Evaluation& bw = inverseFormationVolumeFactor(regionIdx, temperature, pressure);
 
-        // note: this is NOT equivalent to the equation given by the ECL RM. It is
-        // equivalent to the code which was used by opm-core at the time when this was
-        // written.
         Scalar pRef = waterReferencePressure_[regionIdx];
-        const Evaluation& x = (-waterViscosibility_[regionIdx])*(pressure - pRef);
-        const Evaluation& d = 1.0 + x*(1.0 + x/2.0);
-        return muwRef/d;
+        const Evaluation& Y =
+            (waterCompressibility_[regionIdx] - waterViscosibility_[regionIdx])
+            * (pressure - pRef);
+        return BwMuwRef*bw/(1 + Y*(1 + Y/2));
     }
 
     /*!


### PR DESCRIPTION
this is basically a revert of f5df2349653e60b0a1513ae9f754a0ddd14efc40.

Performance of flow (I tried the Norne and the SPE9_CP decks) seems be unaffected but some of the curves for Norne show *very* minor differences. That said, I'd not consider these differences to be serious (i.e., the results can still be considered to match the one of E100 equally well). @atgeirr and @totto82: please test this and merge the PR if you agree.