### PR TITLE
clean up the licensing preable of source files

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,391 @@
+If not stated otherwise in the respective source code files, opm-material is
+licensed under the terms and conditions of the GNU General Public
+License (GPL) version two or - at your option - any later version. At
+this point, we would like explicitly state the fact that this license
+also includes version three of the GPL.
+
+The following people have contributed non-merge commits and may for
+this reason hold part of the copyright of the opm-material module:
+
+Andreas Lauser (2008 - 2016)
+André Brodtkorb (2015)
+Arne Morten Kvarving (2013 - 2015)
+Atgeirr Flø Rasmussen (2014 - 2016)
+Benjamin Faigle (2010 - 2014)
+Bernd Flemisch (2008 - 2012)
+Bård Skaflestad (2013 - 2014)
+Christoph Grueninger (2012)
+Felix Bode (2010)
+Holger Class (2011 - 2012)
+Jean-Paul Balabanian (2016)
+Joakim Hove (2013 - 2016)
+Jochen Fritz (2008 - 2010)
+Jørgen Kvalsvik (2014 - 2016)
+Katherina Baber (2010 - 2012)
+Klaus Mosthaf (2008 - 2012)
+Kristian Flikka (2014)
+Lena Walter (2010)
+Liu Ming (2014)
+Markus Blatt (2013 - 2015)
+Markus Wolff (2008 - 2012)
+Melanie Darcis (2008 - 2010)
+Ove Sævareid (2015)
+Philipp Nuske (2010 - 2012)
+Robert Klöfkorn (2015 - 2016)
+Roland Kaufmann (2013 - 2014)
+Tor Harald Sandve (2015)
+Vishal Jambhekar (2012)
+
+The following institutions and companies have financially supported
+some of the contributions of the authors above and may thus also hold
+part of the copyright (depending on jurisdiction):
+
+IRIS A/S
+SINTEF
+Statoil ASA
+University of Bergen
+University of Stuttgart
+
+A copy of the legally binding license of the source code follows (as
+stated above, you may alternatively use any later version of the GPL
+provided that it has been published by the Free Software Foundation):
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/opm/material/Constants.hpp
+++ b/opm/material/Constants.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-  Copyright (C) 2011 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/IdealGas.hpp
+++ b/opm/material/IdealGas.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/binarycoefficients/Air_Mesitylene.hpp
+++ b/opm/material/binarycoefficients/Air_Mesitylene.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/binarycoefficients/Air_Xylene.hpp
+++ b/opm/material/binarycoefficients/Air_Xylene.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/binarycoefficients/Brine_CO2.hpp
+++ b/opm/material/binarycoefficients/Brine_CO2.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/binarycoefficients/FullerMethod.hpp
+++ b/opm/material/binarycoefficients/FullerMethod.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2010 by Benjamin Faigle
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/binarycoefficients/H2O_Air.hpp
+++ b/opm/material/binarycoefficients/H2O_Air.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2010 by Felix Bode
-  Copyright (C) 2010 by Benjamin Faigle
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/binarycoefficients/H2O_CO2.hpp
+++ b/opm/material/binarycoefficients/H2O_CO2.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/binarycoefficients/H2O_Mesitylene.hpp
+++ b/opm/material/binarycoefficients/H2O_Mesitylene.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/binarycoefficients/H2O_N2.hpp
+++ b/opm/material/binarycoefficients/H2O_N2.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2012 by Bernd Flemisch
-  Copyright (C) 2010 by Felix Bode
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/binarycoefficients/H2O_Xylene.hpp
+++ b/opm/material/binarycoefficients/H2O_Xylene.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/binarycoefficients/HenryIapws.hpp
+++ b/opm/material/binarycoefficients/HenryIapws.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2010 by Benjamin Faigle
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/checkFluidSystem.hpp
+++ b/opm/material/checkFluidSystem.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/HasMemberGeneratorMacros.hpp
+++ b/opm/material/common/HasMemberGeneratorMacros.hpp
@@ -15,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/MathToolbox.hpp
+++ b/opm/material/common/MathToolbox.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/Means.hpp
+++ b/opm/material/common/Means.hpp
@@ -1,13 +1,11 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright 2015 Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
+  the Free Software Foundation, either version 2 of the License, or
   (at your option) any later version.
 
   OPM is distributed in the hope that it will be useful,
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/OpmFinal.hpp
+++ b/opm/material/common/OpmFinal.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/PolynomialUtils.hpp
+++ b/opm/material/common/PolynomialUtils.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2010-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2010-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/TridiagonalMatrix.hpp
+++ b/opm/material/common/TridiagonalMatrix.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2010-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/Unused.hpp
+++ b/opm/material/common/Unused.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2010-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/common/Valgrind.hpp
+++ b/opm/material/common/Valgrind.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/Air.hpp
+++ b/opm/material/components/Air.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2010-2013 by Andreas Lauser
-  Copyright (C) 2011 by Benjamin Faigle
-  Copyright (C) 2010 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/Brine.hpp
+++ b/opm/material/components/Brine.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/CO2.hpp
+++ b/opm/material/components/CO2.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/Component.hpp
+++ b/opm/material/components/Component.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2010 by Felix Bode
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/Dnapl.hpp
+++ b/opm/material/components/Dnapl.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2010-2012 by Markus Wolff
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/H2O.hpp
+++ b/opm/material/components/H2O.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2010 by Jochen Fritz
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/Lnapl.hpp
+++ b/opm/material/components/Lnapl.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2010 by Felix Bode
-  Copyright (C) 2011-2013 by Andreas Lauser
-  Copyright (C) 2010-2012 by Markus Wolff
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/Mesitylene.hpp
+++ b/opm/material/components/Mesitylene.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2010 by Felix Bode
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/N2.hpp
+++ b/opm/material/components/N2.hpp
@@ -1,11 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2011 by Benjamin Faigle
-  Copyright (C) 2010 by Katherina Baber
-  Copyright (C) 2011-2012 by Philipp Nuske
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -20,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/NullComponent.hpp
+++ b/opm/material/components/NullComponent.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/SimpleCO2.hpp
+++ b/opm/material/components/SimpleCO2.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/SimpleH2O.hpp
+++ b/opm/material/components/SimpleH2O.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/Unit.hpp
+++ b/opm/material/components/Unit.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/Xylene.hpp
+++ b/opm/material/components/Xylene.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2012 by Vishal Jambhekar
-  Copyright (C) 2010 by Felix Bode
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/iapws/Common.hpp
+++ b/opm/material/components/iapws/Common.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2010-2013 by Andreas Lauser
-  Copyright (C) 2012 by Philipp Nuske
-  Copyright (C) 2010 by Felix Bode
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/iapws/Region1.hpp
+++ b/opm/material/components/iapws/Region1.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2010 by Felix Bode
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/iapws/Region2.hpp
+++ b/opm/material/components/iapws/Region2.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2010 by Felix Bode
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/components/iapws/Region4.hpp
+++ b/opm/material/components/iapws/Region4.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2012 by Benjamin Faigle
-  Copyright (C) 2010 by Felix Bode
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/constraintsolvers/CompositionFromFugacities.hpp
+++ b/opm/material/constraintsolvers/CompositionFromFugacities.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-  Copyright (C) 2012 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
+++ b/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/constraintsolvers/ImmiscibleFlash.hpp
+++ b/opm/material/constraintsolvers/ImmiscibleFlash.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
+++ b/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-  Copyright (C) 2011-2012 by Klaus Mosthaf
-  Copyright (C) 2012 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/eos/PengRobinson.hpp
+++ b/opm/material/eos/PengRobinson.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/eos/PengRobinsonMixture.hpp
+++ b/opm/material/eos/PengRobinsonMixture.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-  Copyright (C) 2012 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/eos/PengRobinsonParams.hpp
+++ b/opm/material/eos/PengRobinsonParams.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012 by Bernd Flemisch
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/eos/PengRobinsonParamsMixture.hpp
+++ b/opm/material/eos/PengRobinsonParamsMixture.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/BrooksCorey.hpp
+++ b/opm/material/fluidmatrixinteractions/BrooksCorey.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2011 by Holger Class
-  Copyright (C) 2010 by Philipp Nuske
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
+++ b/opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-  Copyright (C) 2011 by Holger Class
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-  Copyright (C) 2015 by IRIS AS
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-  Copyright (C) 2015 by IRIS AS
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/EffToAbsLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EffToAbsLawParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/LinearMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/LinearMaterial.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/LinearMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/LinearMaterialParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/MaterialTraits.hpp
+++ b/opm/material/fluidmatrixinteractions/MaterialTraits.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/NullMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/NullMaterial.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/NullMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/NullMaterialParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
+++ b/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-  Copyright (C) 2010 by Philipp Nuske
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/ParkerLenhardParams.hpp
+++ b/opm/material/fluidmatrixinteractions/ParkerLenhardParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2015 by IRIS AS
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-  Copyright (C) 2010 by Philipp Nuske
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/RegularizedBrooksCoreyParams.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedBrooksCoreyParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-  Copyright (C) 2010 by Philipp Nuske
-  Copyright (C) 2010 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/RegularizedVanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedVanGenuchtenParams.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012-2013 by Andreas Lauser
-  Copyright (C) 2010 by Philipp Nuske
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterialParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-  Copyright (C) 2012 by Holger Class
-  Copyright (C) 2012 by Vishal Jambhekar
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchtenParams.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2012 by Holger Class
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/VanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/VanGenuchten.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2010 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidmatrixinteractions/VanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/VanGenuchtenParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/CompositionalFluidState.hpp
+++ b/opm/material/fluidstates/CompositionalFluidState.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/FluidStateCompositionModules.hpp
+++ b/opm/material/fluidstates/FluidStateCompositionModules.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/FluidStateDensityModules.hpp
+++ b/opm/material/fluidstates/FluidStateDensityModules.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
+++ b/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/FluidStateFugacityModules.hpp
+++ b/opm/material/fluidstates/FluidStateFugacityModules.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/FluidStatePressureModules.hpp
+++ b/opm/material/fluidstates/FluidStatePressureModules.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/FluidStateSaturationModules.hpp
+++ b/opm/material/fluidstates/FluidStateSaturationModules.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/FluidStateTemperatureModules.hpp
+++ b/opm/material/fluidstates/FluidStateTemperatureModules.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-  Copyright (C) 2012 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/FluidStateViscosityModules.hpp
+++ b/opm/material/fluidstates/FluidStateViscosityModules.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012 by Bernd Flemisch
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/ImmiscibleFluidState.hpp
+++ b/opm/material/fluidstates/ImmiscibleFluidState.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/ModularFluidState.hpp
+++ b/opm/material/fluidstates/ModularFluidState.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/NonEquilibriumFluidState.hpp
+++ b/opm/material/fluidstates/NonEquilibriumFluidState.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/PressureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/PressureOverlayFluidState.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/SaturationOverlayFluidState.hpp
+++ b/opm/material/fluidstates/SaturationOverlayFluidState.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/SimpleModularFluidState.hpp
+++ b/opm/material/fluidstates/SimpleModularFluidState.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/BaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/BaseFluidSystem.hpp
@@ -1,10 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2012 by Philipp Nuske
-  Copyright (C) 2012 by Klaus Mosthaf
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -19,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/GasPhase.hpp
+++ b/opm/material/fluidsystems/GasPhase.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/H2OAirFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirFluidSystem.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2011 by Benjamin Faigle
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-  Copyright (C) 2011 by Benjamin Faigle
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/H2ON2FluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2FluidSystem.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2009-2013 by Andreas Lauser
-  Copyright (C) 2012 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/LiquidPhase.hpp
+++ b/opm/material/fluidsystems/LiquidPhase.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2010-2013 by Andreas Lauser
-  Copyright (C) 2010 by Markus Wolff
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/NullParameterCache.hpp
+++ b/opm/material/fluidsystems/NullParameterCache.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/ParameterCacheBase.hpp
+++ b/opm/material/fluidsystems/ParameterCacheBase.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-  Copyright (C) 2012 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-  Copyright (C) 2012 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/Spe5FluidSystem.hpp
+++ b/opm/material/fluidsystems/Spe5FluidSystem.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/Spe5ParameterCache.hpp
+++ b/opm/material/fluidsystems/Spe5ParameterCache.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -15,8 +13,12 @@
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
-  You should have received a copy o2f the GNU General Public License
+  You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
+++ b/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
@@ -1,9 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-  Copyright (C) 2011-2012 by Bernd Flemisch
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -15,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -15,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -15,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/heatconduction/DummyHeatConductionLaw.hpp
+++ b/opm/material/heatconduction/DummyHeatConductionLaw.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/heatconduction/FluidConduction.hpp
+++ b/opm/material/heatconduction/FluidConduction.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/heatconduction/FluidConductionParams.hpp
+++ b/opm/material/heatconduction/FluidConductionParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/heatconduction/Somerton.hpp
+++ b/opm/material/heatconduction/Somerton.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2008-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/heatconduction/SomertonParams.hpp
+++ b/opm/material/heatconduction/SomertonParams.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2012-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/localad/Evaluation.hpp
+++ b/opm/material/localad/Evaluation.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/opm/material/localad/Math.hpp
+++ b/opm/material/localad/Math.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/checkComponent.hpp
+++ b/tests/checkComponent.hpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_2dtables.cpp
+++ b/tests/test_2dtables.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2014 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_eclmateriallawmanager.cpp
+++ b/tests/test_eclmateriallawmanager.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_localad.cpp
+++ b/tests/test_localad.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2015 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2011-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file

--- a/tests/test_spline.cpp
+++ b/tests/test_spline.cpp
@@ -1,23 +1,25 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
-// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
-// vi: set et ts=4 sw=4 sts=4:
-/*****************************************************************************
- *   Copyright (C) 2010-2012 by Andreas Lauser                               *
- *                                                                           *
- *   This program is free software: you can redistribute it and/or modify    *
- *   it under the terms of the GNU General Public License as published by    *
- *   the Free Software Foundation, either version 2 of the License, or       *
- *   (at your option) any later version.                                     *
- *                                                                           *
- *   This program is distributed in the hope that it will be useful,         *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of          *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
- *   GNU General Public License for more details.                            *
- *                                                                           *
- *   You should have received a copy of the GNU General Public License       *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>.   *
- *****************************************************************************/
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
 /*!
  * \file
  *
@@ -29,23 +31,17 @@
 ----------- snip -----------
 ./test_spline > spline.csv
 gnuplot
-
 gnuplot> plot "spline.csv" using 1:2 w l ti "Curve", \
               "spline.csv" using 1:3 w l ti "Derivative", \
               "spline.csv" using 1:4 w p ti "Monotonical"
 ----------- snap -----------
-
-
 */
 #include "config.h"
-
 #include <array>
 #include <opm/material/common/Spline.hpp>
-
 #define GCC_VERSION (__GNUC__ * 10000 \
                + __GNUC_MINOR__ * 100 \
                + __GNUC_PATCHLEVEL__)
-
 template <class Spline>
 void testCommon(const Spline &sp,
                 const double *x,
@@ -53,77 +49,62 @@ void testCommon(const Spline &sp,
 {
     static double eps = 1e-10;
     static double epsFD = 1e-7;
-
     size_t n = sp.numSamples();
     for (size_t i = 0; i < n; ++i) {
         // sure that we hit all sampling points
         double y0 = (i>0)?sp.eval(x[i]-eps):y[0];
         double y1 = sp.eval(x[i]);
         double y2 = (i<n-1)?sp.eval(x[i]+eps):y[n-1];
-
         if (std::abs(y0 - y[i]) > 100*eps || std::abs(y2 - y[i]) > 100*eps)
             OPM_THROW(std::runtime_error,
                        "Spline seems to be discontinuous at sampling point " << i << "!");
         if (std::abs(y1 - y[i]) > eps)
             OPM_THROW(std::runtime_error,
                        "Spline does not capture sampling point " << i << "!");
-
         // make sure the derivative is continuous (assuming that the
         // second derivative is smaller than 1000)
         double d1 = sp.evalDerivative(x[i]);
         double d0 = (i>0)?sp.evalDerivative(x[i]-eps):d1;
         double d2 = (i<n-1)?sp.evalDerivative(x[i]+eps):d1;
-
         if (std::abs(d1 - d0) > 1000*eps || std::abs(d2 - d0) > 1000*eps)
             OPM_THROW(std::runtime_error,
                       "Spline seems to exhibit a discontinuous derivative at sampling point " << i << "!");
     }
-
     // make sure the derivatives are consistent with the curve
     size_t np = 3*n;
     for (size_t i = 0; i < np; ++i) {
         double xMin = sp.xAt(0);
         double xMax = sp.xAt(sp.numSamples() - 1);
         double xval = xMin + (xMax - xMin)*i/np;
-
         // first derivative
         double y1 = sp.eval(xval+epsFD);
         double y0 = sp.eval(xval);
-
         double mFD = (y1 - y0)/epsFD;
         double m = sp.evalDerivative(xval);
-
         if (std::abs( mFD - m ) > 1000*epsFD)
             OPM_THROW(std::runtime_error,
                       "Derivative of spline seems to be inconsistent with cuve"
                       " (" << mFD << " - " << m << " = " << mFD - m << ")!");
-
         // second derivative
         y1 = sp.evalDerivative(xval+epsFD);
         y0 = sp.evalDerivative(xval);
-
         mFD = (y1 - y0)/epsFD;
         m = sp.evalSecondDerivative(xval);
-
         if (std::abs( mFD - m ) > 1000*epsFD)
             OPM_THROW(std::runtime_error,
                       "Second derivative of spline seems to be inconsistent with cuve"
                       " (" << mFD << " - " << m << " = " << mFD - m << ")!");
-
         // Third derivative
         y1 = sp.evalSecondDerivative(xval+epsFD);
         y0 = sp.evalSecondDerivative(xval);
-
         mFD = (y1 - y0)/epsFD;
         m = sp.evalThirdDerivative(xval);
-
         if (std::abs( mFD - m ) > 1000*epsFD)
             OPM_THROW(std::runtime_error,
                       "Third derivative of spline seems to be inconsistent with cuve"
                       " (" << mFD << " - " << m << " = " << mFD - m << ")!");
     }
 }
-
 template <class Spline>
 void testFull(const Spline &sp,
               const double *x,
@@ -133,10 +114,8 @@ void testFull(const Spline &sp,
 {
     // test the common properties of splines
     testCommon(sp, x, y);
-
     static double eps = 1e-5;
     size_t n = sp.numSamples();
-
     // make sure the derivative at both end points is correct
     double d0 = sp.evalDerivative(x[0]);
     double d1 = sp.evalDerivative(x[n-1]);
@@ -149,7 +128,6 @@ void testFull(const Spline &sp,
                    "Invalid derivative at end of interval: is "
                    << d1 << " ought to be " << m1);
 }
-
 template <class Spline>
 void testNatural(const Spline &sp,
                  const double *x,
@@ -157,28 +135,22 @@ void testNatural(const Spline &sp,
 {
     // test the common properties of splines
     testCommon(sp, x, y);
-
     static double eps = 1e-5;
     size_t n = sp.numSamples();
-
     // make sure the second derivatives at both end points are 0
     double d0 = sp.evalDerivative(x[0]);
     double d1 = sp.evalDerivative(x[0] + eps);
-
     double d2 = sp.evalDerivative(x[n-1] - eps);
     double d3 = sp.evalDerivative(x[n-1]);
-
     if (std::abs(d1 - d0)/eps > 1000*eps)
         OPM_THROW(std::runtime_error,
                    "Invalid second derivative at beginning of interval: is "
                    << (d1 - d0)/eps << " ought to be 0");
-
     if (std::abs(d3 - d2)/eps > 1000*eps)
         OPM_THROW(std::runtime_error,
                    "Invalid second derivative at end of interval: is "
                    << (d3 - d2)/eps << " ought to be 0");
 }
-
 template <class Spline>
 void testMonotonic(const Spline &sp,
                    const double *x,
@@ -186,9 +158,7 @@ void testMonotonic(const Spline &sp,
 {
     // test the common properties of splines
     testCommon(sp, x, y);
-
     size_t n = sp.numSamples();
-
     for (size_t i = 0; i < n - 1; ++ i) {
         // make sure that the spline is monotonic for each interval
         // between sampling points
@@ -196,7 +166,6 @@ void testMonotonic(const Spline &sp,
             OPM_THROW(std::runtime_error,
                       "Spline says it is not monotonic in interval "
                       << i << " where it should be");
-
         // test the intersection methods
         double d = (y[i] + y[i+1])/2;
         double interX = sp.template intersectInterval<double>(x[i], x[i+1],
@@ -207,7 +176,6 @@ void testMonotonic(const Spline &sp,
                       "Spline::intersectInterval() seems to be broken: "
                       << sp.eval(interX) << " - " << d << " = " << sp.eval(interX) - d << "!");
     }
-
     // make sure the spline says to be monotonic on the (extrapolated)
     // left and right sides
     if (!sp.monotonic(x[0] - 1.0, (x[0] + x[1])/2, /*extrapolate=*/true))
@@ -216,7 +184,6 @@ void testMonotonic(const Spline &sp,
     if (!sp.monotonic((x[n - 2]+ x[n - 1])/2, x[n-1] + 1.0, /*extrapolate=*/true))
         OPM_THROW(std::runtime_error,
                   "Spline says it is not monotonic on right side where it should be");
-
     for (size_t i = 0; i < n - 2; ++ i) {
         // make sure that the spline says that it is non-monotonic for
         // if extrema are within the queried interval
@@ -226,10 +193,8 @@ void testMonotonic(const Spline &sp,
                       << i << " where it should not be");
     }
 }
-
 // function prototype to prevent some compilers producing a warning
 void testAll();
-
 void testAll()
 {
     double x[] = { 0, 5, 7.5, 8.75, 9.375 };
@@ -244,8 +209,6 @@ void testAll()
             {x[3], y[3]},
             {x[4], y[4]},
         };
-
-
 #if GCC_VERSION >= 40500
     std::initializer_list<const std::pair<double, double> > pointsInitList =
         {
@@ -256,7 +219,6 @@ void testAll()
             {x[4], y[4]},
         };
 #endif
-
     std::vector<double> xVec;
     std::vector<double> yVec;
     std::vector<double*> pointVec;
@@ -265,20 +227,16 @@ void testAll()
         yVec.push_back(y[i]);
         pointVec.push_back(points[i]);
     }
-
     /////////
     // test spline with two sampling points
     /////////
-
     // full spline
     { Opm::Spline<double> sp(x[0], x[1], y[0], y[1], m0, m1); sp.set(x[0],x[1],y[0],y[1],m0, m1); testFull(sp, x, y, m0, m1); };
     { Opm::Spline<double> sp(2, x, y, m0, m1); sp.setXYArrays(2, x, y, m0, m1); testFull(sp, x, y, m0, m1);  };
     { Opm::Spline<double> sp(static_cast<size_t>(2), points, m0, m1); sp.setArrayOfPoints(2, points, m0, m1); testFull(sp, x, y, m0, m1); };
-
     /////////
     // test variable length splines
     /////////
-
     // full spline
     { Opm::Spline<double> sp(5, x, y, m0, m1); sp.setXYArrays(5,x,y,m0, m1); testFull(sp, x, y, m0, m1);  };
     { Opm::Spline<double> sp(xVec, yVec, m0, m1); sp.setXYContainers(xVec,yVec,m0, m1); testFull(sp, x, y, m0, m1);  };
@@ -287,7 +245,6 @@ void testAll()
 #if GCC_VERSION >= 40500
     { Opm::Spline<double> sp; sp.setContainerOfTuples(pointsInitList,m0, m1); testFull(sp, x, y, m0, m1); };
 #endif
-
     // natural spline
     { Opm::Spline<double> sp(5, x, y); sp.setXYArrays(5,x,y); testNatural(sp, x, y);  };
     { Opm::Spline<double> sp(xVec, yVec); sp.setXYContainers(xVec,yVec); testNatural(sp, x, y); };
@@ -297,30 +254,24 @@ void testAll()
     { Opm::Spline<double> sp; sp.setContainerOfTuples(pointsInitList); testNatural(sp, x, y); };
 #endif
 }
-
 // function prototype to prevent some compilers producing a warning
 void plot();
-
 void plot()
 {
     const int numSamples = 5;
     const int n = numSamples - 1;
     typedef std::array<double, numSamples> FV;
-
     double x_[] = { 0, 5, 7.5, 8.75, 10 };
     double y_[] = { 10, 0, 10, 0, 10 };
     double m1 = 10;
     double m2 = -10;
     FV &xs = *reinterpret_cast<FV*>(x_);
     FV &ys = *reinterpret_cast<FV*>(y_);
-
     Opm::Spline<double> spFull(xs, ys, m1, m2);
     Opm::Spline<double> spNatural(xs, ys);
     Opm::Spline<double> spPeriodic(xs, ys, /*type=*/Opm::Spline<double>::Periodic);
     Opm::Spline<double> spMonotonic(xs, ys, /*type=*/Opm::Spline<double>::Monotonic);
-
     testMonotonic(spMonotonic, x_, y_);
-
     spFull.printCSV(x_[0] - 1.00001,
                     x_[n] + 1.00001,
                     1000);
@@ -329,28 +280,23 @@ void plot()
                        x_[n] + 1.00001,
                        1000);
     std::cout << "\n";
-
     spPeriodic.printCSV(x_[0] - 1.00001,
                         x_[n] + 1.00001,
                        1000);
     std::cout << "\n";
-
     spMonotonic.printCSV(x_[0] - 1.00001,
                          x_[n] + 1.00001,
                          1000);
     std::cout << "\n";
 }
-
 int main()
 {
     try {
         testAll();
-
         plot();
     }
     catch (const std::exception &e) {
         std::cout << "Caught OPM exception: " << e.what() << "\n";
     }
-
     return 0;
 }

--- a/tests/test_tabulation.cpp
+++ b/tests/test_tabulation.cpp
@@ -1,8 +1,6 @@
 // -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
-  Copyright (C) 2010-2013 by Andreas Lauser
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -17,6 +15,10 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
 */
 /*!
  * \file


### PR DESCRIPTION
this patch removes the in-file lists in favor of a global list of in
the COPYING file. this is done because (a) maintaining a list of
authors at the beginning of each source file is a major pain in the
a**, (b) for this reason, the list of authors was not accurate in
about 85% of all cases where more than one person was involved and (c)
this list is not legally binding in any way (the copyright is at the
person who authored a given change; if these lists had any legal
relevance, one could "aquire" the copyright of the module by forking
it and replacing the lists...)