### PR TITLE
Use Eclipse3DProperties

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -177,31 +177,32 @@ public:
         else
             enableThreePointKrSatScaling_ = false;
 
+        auto& props = eclState->getEclipseProperties();
         // check if we are supposed to scale the Y axis of the capillary pressure
         if (twoPhaseSystemType == EclOilWaterSystem)
             enablePcScaling_ =
-                eclState->hasDeckDoubleGridProperty("PCW")
-                || eclState->hasDeckDoubleGridProperty("SWATINIT");
+                props.hasDeckDoubleGridProperty("PCW")
+                || props.hasDeckDoubleGridProperty("SWATINIT");
 
         else {
             assert(twoPhaseSystemType == EclGasOilSystem);
-            enablePcScaling_ = eclState->hasDeckDoubleGridProperty("PCG");
+            enablePcScaling_ = props.hasDeckDoubleGridProperty("PCG");
         }
 
         // check if we are supposed to scale the Y axis of the wetting phase relperm
         if (twoPhaseSystemType == EclOilWaterSystem)
-            enableKrwScaling_ = eclState->hasDeckDoubleGridProperty("KRW");
+            enableKrwScaling_ = props.hasDeckDoubleGridProperty("KRW");
         else {
             assert(twoPhaseSystemType == EclGasOilSystem);
-            enableKrwScaling_ = eclState->hasDeckDoubleGridProperty("KRO");
+            enableKrwScaling_ = props.hasDeckDoubleGridProperty("KRO");
         }
 
         // check if we are supposed to scale the Y axis of the non-wetting phase relperm
         if (twoPhaseSystemType == EclOilWaterSystem)
-            enableKrnScaling_ = eclState->hasDeckDoubleGridProperty("KRO");
+            enableKrnScaling_ = props.hasDeckDoubleGridProperty("KRO");
         else {
             assert(twoPhaseSystemType == EclGasOilSystem);
-            enableKrnScaling_ = eclState->hasDeckDoubleGridProperty("KRG");
+            enableKrnScaling_ = props.hasDeckDoubleGridProperty("KRG");
         }
     }
 #endif

--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -177,7 +177,7 @@ public:
         else
             enableThreePointKrSatScaling_ = false;
 
-        auto& props = eclState->getEclipseProperties();
+        auto& props = eclState->get3DProperties();
         // check if we are supposed to scale the Y axis of the capillary pressure
         if (twoPhaseSystemType == EclOilWaterSystem)
             enablePcScaling_ =

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -70,9 +70,9 @@ public:
         std::string kwPrefix = useImbibition?"I":"";
 
         if (useImbibition)
-            satnum = &eclState->getIntGridProperty("IMBNUM")->getData();
+            satnum = &eclState->getEclipseProperties().getIntGridProperty("IMBNUM").getData();
         else
-            satnum = &eclState->getIntGridProperty("SATNUM")->getData();
+            satnum = &eclState->getEclipseProperties().getIntGridProperty("SATNUM").getData();
 
         retrieveGridPropertyData_(&swl, eclState, kwPrefix+"SWL");
         retrieveGridPropertyData_(&sgl, eclState, kwPrefix+"SGL");
@@ -115,8 +115,8 @@ private:
                                    const std::string& properyName)
     {
         (*data) = 0;
-        if (eclState->hasDeckDoubleGridProperty(properyName))
-            (*data) = &eclState->getDoubleGridProperty(properyName)->getData();
+        if (eclState->getEclipseProperties().hasDeckDoubleGridProperty(properyName))
+            (*data) = &eclState->getEclipseProperties().getDoubleGridProperty(properyName).getData();
     }
 #endif
 };
@@ -193,13 +193,13 @@ struct EclEpsScalingPointsInfo
                          unsigned satRegionIdx)
     {
         // TODO: support for the SOF2/SOF3 keyword family
-        auto tables = eclState->getTableManager();
-        const TableContainer&  swofTables = tables->getSwofTables();
-        const TableContainer&  sgofTables = tables->getSgofTables();
-        const TableContainer& slgofTables = tables->getSlgofTables();
-        const TableContainer&  swfnTables = tables->getSwfnTables();
-        const TableContainer&  sgfnTables = tables->getSgfnTables();
-        const TableContainer&  sof3Tables = tables->getSof3Tables();
+        const auto& tables = eclState->getTableManager();
+        const TableContainer&  swofTables = tables.getSwofTables();
+        const TableContainer&  sgofTables = tables.getSgofTables();
+        const TableContainer& slgofTables = tables.getSlgofTables();
+        const TableContainer&  swfnTables = tables.getSwfnTables();
+        const TableContainer&  sgfnTables = tables.getSgfnTables();
+        const TableContainer&  sof3Tables = tables.getSof3Tables();
 
         bool hasWater = deck->hasKeyword("WATER");
         bool hasGas = deck->hasKeyword("GAS");

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -70,9 +70,9 @@ public:
         std::string kwPrefix = useImbibition?"I":"";
 
         if (useImbibition)
-            satnum = &eclState->getEclipseProperties().getIntGridProperty("IMBNUM").getData();
+            satnum = &eclState->get3DProperties().getIntGridProperty("IMBNUM").getData();
         else
-            satnum = &eclState->getEclipseProperties().getIntGridProperty("SATNUM").getData();
+            satnum = &eclState->get3DProperties().getIntGridProperty("SATNUM").getData();
 
         retrieveGridPropertyData_(&swl, eclState, kwPrefix+"SWL");
         retrieveGridPropertyData_(&sgl, eclState, kwPrefix+"SGL");
@@ -115,8 +115,8 @@ private:
                                    const std::string& properyName)
     {
         (*data) = 0;
-        if (eclState->getEclipseProperties().hasDeckDoubleGridProperty(properyName))
-            (*data) = &eclState->getEclipseProperties().getDoubleGridProperty(properyName).getData();
+        if (eclState->get3DProperties().hasDeckDoubleGridProperty(properyName))
+            (*data) = &eclState->get3DProperties().getDoubleGridProperty(properyName).getData();
     }
 #endif
 };

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -123,8 +123,8 @@ public:
         // copy the SATNUM grid property. in some cases this is not necessary, but it
         // should not require much memory anyway...
         std::vector<int> satnumRegionArray(numCompressedElems);
-        if (eclState->hasDeckIntGridProperty("SATNUM")) {
-            const auto& satnumRawData = eclState->getIntGridProperty("SATNUM")->getData();
+        if (eclState->getEclipseProperties().hasDeckIntGridProperty("SATNUM")) {
+            const auto& satnumRawData = eclState->getEclipseProperties().getIntGridProperty("SATNUM").getData();
             for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
                 unsigned cartesianElemIdx = static_cast<unsigned>(compressedToCartesianElemIdx[elemIdx]);
                 satnumRegionArray[elemIdx] = satnumRawData[cartesianElemIdx] - 1;
@@ -449,7 +449,7 @@ private:
             oilWaterImbParams.resize(numCompressedElems);
         }
 
-        const auto& imbnumData = eclState->getIntGridProperty("IMBNUM")->getData();
+        const auto& imbnumData = eclState->getEclipseProperties().getIntGridProperty("IMBNUM").getData();
         assert(numCompressedElems == satnumRegionArray.size());
         for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
             unsigned satnumIdx = static_cast<unsigned>(satnumRegionArray[elemIdx]);
@@ -541,12 +541,13 @@ private:
     SaturationFunctionFamily getSaturationFunctionFamily(Opm::EclipseStateConstPtr eclState) const
     {
         const auto& tableManager = eclState->getTableManager();
-        const TableContainer& swofTables = tableManager->getSwofTables();
-        const TableContainer& slgofTables= tableManager->getSlgofTables();
-        const TableContainer& sgofTables = tableManager->getSgofTables();
-        const TableContainer& swfnTables = tableManager->getSwfnTables();
-        const TableContainer& sgfnTables = tableManager->getSgfnTables();
-        const TableContainer& sof3Tables = tableManager->getSof3Tables();
+        const TableContainer& swofTables = tableManager.getSwofTables();
+        const TableContainer& slgofTables= tableManager.getSlgofTables();
+        const TableContainer& sgofTables = tableManager.getSgofTables();
+        const TableContainer& swfnTables = tableManager.getSwfnTables();
+        const TableContainer& sgfnTables = tableManager.getSgfnTables();
+        const TableContainer& sof3Tables = tableManager.getSof3Tables();
+
 
         bool family1 = (!sgofTables.empty() || !slgofTables.empty()) && !swofTables.empty();
         bool family2 = !swfnTables.empty() && !sgfnTables.empty() && !sof3Tables.empty();
@@ -590,8 +591,8 @@ private:
         // handle the twophase case
         const auto& tableManager = eclState->getTableManager();
         if (!hasWater) {
-            const TableContainer& sgofTables  = tableManager->getSgofTables();
-            const TableContainer& slgofTables = tableManager->getSlgofTables();
+            const TableContainer& sgofTables  = tableManager.getSgofTables();
+            const TableContainer& slgofTables = tableManager.getSlgofTables();
             if (!sgofTables.empty())
                 readGasOilEffectiveParametersSgof_(effParams,
                                                    Swco,
@@ -618,8 +619,8 @@ private:
         switch (getSaturationFunctionFamily(eclState)) {
         case FamilyI:
         {
-            const TableContainer& sgofTables = tableManager->getSgofTables();
-            const TableContainer& slgofTables = tableManager->getSlgofTables();
+            const TableContainer& sgofTables = tableManager.getSgofTables();
+            const TableContainer& slgofTables = tableManager.getSlgofTables();
             if (!sgofTables.empty())
                 readGasOilEffectiveParametersSgof_(effParams,
                                                    Swco,
@@ -633,8 +634,8 @@ private:
 
         case FamilyII:
         {
-            const Sof3Table& sof3Table = tableManager->getSof3Tables().getTable<Sof3Table>( satnumIdx );
-            const SgfnTable& sgfnTable = tableManager->getSgfnTables().getTable<SgfnTable>( satnumIdx );
+            const Sof3Table& sof3Table = tableManager.getSof3Tables().getTable<Sof3Table>( satnumIdx );
+            const SgfnTable& sgfnTable = tableManager.getSgfnTables().getTable<SgfnTable>( satnumIdx );
             readGasOilEffectiveParametersFamily2_(effParams,
                                                   Swco,
                                                   sof3Table,
@@ -715,7 +716,7 @@ private:
         bool hasGas = deck->hasKeyword("GAS");
         bool hasOil = deck->hasKeyword("OIL");
 
-        const auto tableManager = eclState->getTableManager();
+        const auto& tableManager = eclState->getTableManager();
         auto& effParams = *dest[satnumIdx];
 
         // handle the twophase case
@@ -723,7 +724,7 @@ private:
             return;
         }
         else if (!hasGas) {
-            const auto& swofTable = tableManager->getSwofTables().getTable<SwofTable>(satnumIdx);
+            const auto& swofTable = tableManager.getSwofTables().getTable<SwofTable>(satnumIdx);
             std::vector<double> SwColumn = swofTable.getColumn("SW").vectorCopy();
 
             effParams.setKrwSamples(SwColumn, swofTable.getColumn("KRW").vectorCopy());
@@ -742,7 +743,7 @@ private:
 
         switch (getSaturationFunctionFamily(eclState)) {
         case FamilyI: {
-            const auto& swofTable = tableManager->getSwofTables().getTable<SwofTable>(satnumIdx);
+            const auto& swofTable = tableManager.getSwofTables().getTable<SwofTable>(satnumIdx);
             std::vector<double> SwColumn = swofTable.getColumn("SW").vectorCopy();
 
             effParams.setKrwSamples(SwColumn, swofTable.getColumn("KRW").vectorCopy());
@@ -753,8 +754,8 @@ private:
         }
         case FamilyII:
         {
-            const auto& swfnTable = tableManager->getSwfnTables().getTable<SwfnTable>(satnumIdx);
-            const auto& sof3Table = tableManager->getSof3Tables().getTable<Sof3Table>(satnumIdx);
+            const auto& swfnTable = tableManager.getSwfnTables().getTable<SwfnTable>(satnumIdx);
+            const auto& sof3Table = tableManager.getSof3Tables().getTable<Sof3Table>(satnumIdx);
             std::vector<double> SwColumn = swfnTable.getColumn("SW").vectorCopy();
 
             // convert the saturations of the SOF3 keyword from oil to water saturations

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -123,8 +123,8 @@ public:
         // copy the SATNUM grid property. in some cases this is not necessary, but it
         // should not require much memory anyway...
         std::vector<int> satnumRegionArray(numCompressedElems);
-        if (eclState->getEclipseProperties().hasDeckIntGridProperty("SATNUM")) {
-            const auto& satnumRawData = eclState->getEclipseProperties().getIntGridProperty("SATNUM").getData();
+        if (eclState->get3DProperties().hasDeckIntGridProperty("SATNUM")) {
+            const auto& satnumRawData = eclState->get3DProperties().getIntGridProperty("SATNUM").getData();
             for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
                 unsigned cartesianElemIdx = static_cast<unsigned>(compressedToCartesianElemIdx[elemIdx]);
                 satnumRegionArray[elemIdx] = satnumRawData[cartesianElemIdx] - 1;
@@ -449,7 +449,7 @@ private:
             oilWaterImbParams.resize(numCompressedElems);
         }
 
-        const auto& imbnumData = eclState->getEclipseProperties().getIntGridProperty("IMBNUM").getData();
+        const auto& imbnumData = eclState->get3DProperties().getIntGridProperty("IMBNUM").getData();
         assert(numCompressedElems == satnumRegionArray.size());
         for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
             unsigned satnumIdx = static_cast<unsigned>(satnumRegionArray[elemIdx]);

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -55,7 +55,7 @@ public:
      */
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
-        const auto& pvdoTables = eclState->getTableManager()->getPvdoTables();
+        const auto& pvdoTables = eclState->getTableManager().getPvdoTables();
         const auto& densityKeyword = deck->getKeyword("DENSITY");
 
         assert(pvdoTables.size() == densityKeyword.size());

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -62,7 +62,7 @@ public:
      */
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
-        const auto& pvdgTables = eclState->getTableManager()->getPvdgTables();
+        const auto& pvdgTables = eclState->getTableManager().getPvdgTables();
         const auto& densityKeyword = deck->getKeyword("DENSITY");
 
         assert(pvdgTables.size() == densityKeyword.size());

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -77,7 +77,7 @@ public:
         //////
         // initialize the thermal part
         //////
-        auto tables = eclState->getTableManager();
+        const auto& tables = eclState->getTableManager();
 
         enableThermalDensity_ = deck->hasKeyword("TREF");
         enableThermalViscosity_ = deck->hasKeyword("GASVISCT");
@@ -87,7 +87,7 @@ public:
 
         // viscosity
         if (enableThermalViscosity_) {
-            const auto& gasvisctTables = tables->getGasvisctTables();
+            const auto& gasvisctTables = tables.getGasvisctTables();
             int gasCompIdx = deck->getKeyword("GCOMPIDX").getRecord(0).getItem("GAS_COMPONENT_INDEX").get< int >(0) - 1;
             std::string gasvisctColumnName = "Viscosity"+std::to_string(static_cast<long long>(gasCompIdx));
 

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -61,7 +61,7 @@ public:
      */
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
-        const auto& pvtoTables = eclState->getTableManager()->getPvtoTables();
+        const auto& pvtoTables = eclState->getTableManager().getPvtoTables();
         const auto& densityKeyword = deck->getKeyword("DENSITY");
 
         assert(pvtoTables.size() == densityKeyword.size());
@@ -81,7 +81,7 @@ public:
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
             const auto& pvtoTable = pvtoTables[regionIdx];
 
-            const auto saturatedTable = pvtoTable.getSaturatedTable();
+            const auto& saturatedTable = pvtoTable.getSaturatedTable();
             assert(saturatedTable.numRows() > 1);
 
             auto& oilMu = oilMuTable_[regionIdx];

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -77,7 +77,7 @@ public:
         //////
         // initialize the thermal part
         //////
-        auto tables = eclState->getTableManager();
+        const auto& tables = eclState->getTableManager();
 
         enableThermalDensity_ = deck->hasKeyword("THERMEX1");
         enableThermalViscosity_ = deck->hasKeyword("VISCREF");
@@ -87,7 +87,7 @@ public:
 
         // viscosity
         if (deck->hasKeyword("VISCREF")) {
-            const auto& oilvisctTables = tables->getOilvisctTables();
+            const auto& oilvisctTables = tables.getOilvisctTables();
             const auto& viscrefKeyword = deck->getKeyword("VISCREF");
 
             assert(oilvisctTables.size() == numRegions);

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -77,7 +77,7 @@ public:
         //////
         // initialize the thermal part
         //////
-        auto tables = eclState->getTableManager();
+        const auto& tables = eclState->getTableManager();
 
         enableThermalDensity_ = deck->hasKeyword("WATDENT");
         enableThermalViscosity_ = deck->hasKeyword("VISCREF");
@@ -101,7 +101,7 @@ public:
         if (enableThermalViscosity_) {
             const auto& viscrefKeyword = deck->getKeyword("VISCREF");
 
-            const auto& watvisctTables = tables->getWatvisctTables();
+            const auto& watvisctTables = tables.getWatvisctTables();
 
             assert(watvisctTables.size() == numRegions);
             assert(viscrefKeyword.size() == numRegions);

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -29,6 +29,7 @@
 
 #include <opm/material/Constants.hpp>
 
+
 #include <opm/material/common/OpmFinal.hpp>
 #include <opm/material/common/UniformXTabulated2DFunction.hpp>
 #include <opm/material/common/Tabulated1DFunction.hpp>
@@ -62,7 +63,7 @@ public:
      */
     void initFromDeck(DeckConstPtr deck, EclipseStateConstPtr eclState)
     {
-        const auto& pvtgTables = eclState->getTableManager()->getPvtgTables();
+        const auto& pvtgTables = eclState->getTableManager().getPvtgTables();
         const auto& densityKeyword = deck->getKeyword("DENSITY");
 
         assert(pvtgTables.size() == densityKeyword.size());
@@ -81,7 +82,7 @@ public:
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
             const auto& pvtgTable = pvtgTables[regionIdx];
 
-            const auto saturatedTable = pvtgTable.getSaturatedTable();
+            const auto& saturatedTable = pvtgTable.getSaturatedTable();
             assert(saturatedTable.numRows() > 1);
 
             auto& gasMu = gasMu_[regionIdx];
@@ -115,7 +116,7 @@ public:
                 assert(invGasB.numX() == outerIdx + 1);
                 assert(gasMu.numX() == outerIdx + 1);
 
-                const auto underSaturatedTable = pvtgTable.getUnderSaturatedTable(outerIdx);
+                const auto& underSaturatedTable = pvtgTable.getUnderSaturatedTable(outerIdx);
                 size_t numRows = underSaturatedTable.numRows();
                 for (size_t innerIdx = 0; innerIdx < numRows; ++ innerIdx) {
                     Scalar Rv = underSaturatedTable.get("RV" , innerIdx);

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -212,9 +212,8 @@ inline void testAll()
     Opm::Parser parser;
     Opm::ParseContext parseContext;
 
-    const auto deck = parser.parseString(deckString1, parseContext);
-    const auto eclState = std::make_shared<Opm::EclipseState>(deck, parseContext);
-    const auto eclGrid = eclState->getEclipseGrid();
+    auto deck = parser.parseString(deckString1, parseContext);
+    auto eclState = std::make_shared<Opm::EclipseState>(deck, parseContext);
 
     const auto& pvtwKeyword = deck->getKeyword("PVTW");
     size_t numPvtRegions = pvtwKeyword.size();


### PR DESCRIPTION
This PR changes the use of EclipseState's API in opm-parser, see PR [Introduce Eclipse3DProperties #751](https://github.com/OPM/opm-parser/pull/751) in other repo.

The only changes are from `->` to `.` and use `state.getEclipseProperties()`.  Also added some `const auto& x` where we previously copied.