### PR TITLE
Nested AD and opm-material spring cleaning

### DIFF
--- a/opm/material/checkFluidSystem.hpp
+++ b/opm/material/checkFluidSystem.hpp
@@ -297,18 +297,19 @@ void checkFluidSystem()
                   " as the one passed to the checkFluidSystem() function");
 
     // check whether the parameter cache adheres to the API
-    typedef typename FluidSystem::ParameterCache PC;
-    PC paramCache;
+    typedef typename FluidSystem::template ParameterCache<LhsEval> ParameterCache;
+
+    ParameterCache paramCache;
     try { paramCache.updateAll(fs); } catch (...) {};
-    try { paramCache.updateAll(fs, /*except=*/PC::None); } catch (...) {};
-    try { paramCache.updateAll(fs, /*except=*/PC::Temperature | PC::Pressure | PC::Composition); } catch (...) {};
+    try { paramCache.updateAll(fs, /*except=*/ParameterCache::None); } catch (...) {};
+    try { paramCache.updateAll(fs, /*except=*/ParameterCache::Temperature | ParameterCache::Pressure | ParameterCache::Composition); } catch (...) {};
     try { paramCache.updateAllPressures(fs); } catch (...) {};
 
     for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
         fs.restrictToPhase(static_cast<int>(phaseIdx));
         try { paramCache.updatePhase(fs, phaseIdx); } catch (...) {};
-        try { paramCache.updatePhase(fs, phaseIdx, /*except=*/PC::None); } catch (...) {};
-        try { paramCache.updatePhase(fs, phaseIdx, /*except=*/PC::Temperature | PC::Pressure | PC::Composition); } catch (...) {};
+        try { paramCache.updatePhase(fs, phaseIdx, /*except=*/ParameterCache::None); } catch (...) {};
+        try { paramCache.updatePhase(fs, phaseIdx, /*except=*/ParameterCache::Temperature | ParameterCache::Pressure | ParameterCache::Composition); } catch (...) {};
         try { paramCache.updateTemperature(fs, phaseIdx); } catch (...) {};
         try { paramCache.updatePressure(fs, phaseIdx); } catch (...) {};
         try { paramCache.updateComposition(fs, phaseIdx); } catch (...) {};

--- a/opm/material/common/MathToolbox.hpp
+++ b/opm/material/common/MathToolbox.hpp
@@ -121,6 +121,17 @@ public:
     static Scalar passThroughOrCreateConstant(Scalar value)
     { return value; }
 
+    /*!
+     * \brief Returns true if two values are identical up to a specified tolerance
+     */
+    static bool isSame(Scalar a, Scalar b, Scalar tolerance)
+    {
+        Scalar valueDiff = a - b;
+        Scalar denom = std::max<Scalar>(1.0, std::abs(a + b));
+
+        return std::abs(valueDiff) < tolerance || std::abs(valueDiff)/denom < tolerance;
+    }
+
     ////////////
     // arithmetic functions
     ////////////

--- a/opm/material/common/MathToolbox.hpp
+++ b/opm/material/common/MathToolbox.hpp
@@ -109,19 +109,6 @@ public:
     { return eval; }
 
     /*!
-     * \brief Pass a value through if it is an evaluation, or create a constant
-     *        evaluation if it is a scalar.
-     *
-     * In some sense, this method is the opposite of "toLhs()": If the function argument
-     * is a Scalar, an Evaluation which represents a constant value is returned, if the
-     * argument is an Evaluation, it is returned as is. This method makes it possible to
-     * uniformly handle the cases where some condition is either given by a constant
-     * value or as a value which depends on other variables. (E.g. boundary conditions.)
-     */
-    static Scalar passThroughOrCreateConstant(Scalar value)
-    { return value; }
-
-    /*!
      * \brief Returns true if two values are identical up to a specified tolerance
      */
     static bool isSame(Scalar a, Scalar b, Scalar tolerance)

--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -199,9 +199,9 @@ public:
         Evaluation beta = yToJ(y);
 
         unsigned i = std::max(0U, std::min(static_cast<unsigned>(numX()) - 2,
-                                           static_cast<unsigned>(Toolbox::value(alpha))));
+                                           static_cast<unsigned>(Toolbox::scalarValue(alpha))));
         unsigned j = std::max(0U, std::min(static_cast<unsigned>(numY()) - 2,
-                                           static_cast<unsigned>(Toolbox::value(beta))));
+                                           static_cast<unsigned>(Toolbox::scalarValue(beta))));
 
         alpha -= i;
         beta -= j;

--- a/opm/material/components/H2O.hpp
+++ b/opm/material/components/H2O.hpp
@@ -702,7 +702,7 @@ public:
 
             // calculate the partial derivative of the specific volume
             // to the pressure at the vapor pressure.
-            Scalar eps = Toolbox::value(pv)*1e-8;
+            Scalar eps = Toolbox::scalarValue(pv)*1e-8;
             Evaluation v0 = volumeRegion1_(temperature, pv);
             Evaluation v1 = volumeRegion1_(temperature, pv + eps);
             Evaluation dv_dp = (v1 - v0)/eps;
@@ -754,10 +754,10 @@ public:
         // assume the pressure to be 10% higher than the vapor
         // pressure
         Evaluation pressure = 1.1*vaporPressure(temperature);
-        Scalar eps = Toolbox::value(pressure)*1e-7;
+        Scalar eps = Toolbox::scalarValue(pressure)*1e-7;
 
         Evaluation deltaP = pressure*2;
-        for (int i = 0; i < 5 && std::abs(Toolbox::value(pressure)*1e-9) < std::abs(Toolbox::value(deltaP)); ++i) {
+        for (int i = 0; i < 5 && std::abs(Toolbox::scalarValue(pressure)*1e-9) < std::abs(Toolbox::scalarValue(deltaP)); ++i) {
             Evaluation f = liquidDensity(temperature, pressure) - density;
 
             Evaluation df_dp;

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -260,7 +260,7 @@ public:
         typedef MathToolbox<Evaluation> Toolbox;
 
         const Evaluation& result = interpolateT_(vaporPressure_, temperature);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::vaporPressure(temperature);
         return result;
     }
@@ -279,7 +279,7 @@ public:
         const Evaluation& result = interpolateGasTP_(gasEnthalpy_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::gasEnthalpy(temperature, pressure);
         return result;
     }
@@ -298,7 +298,7 @@ public:
         const Evaluation& result = interpolateLiquidTP_(liquidEnthalpy_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::liquidEnthalpy(temperature, pressure);
         return result;
     }
@@ -317,7 +317,7 @@ public:
         const Evaluation& result = interpolateGasTP_(gasHeatCapacity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::gasHeatCapacity(temperature, pressure);
         return result;
     }
@@ -336,7 +336,7 @@ public:
         const Evaluation& result = interpolateLiquidTP_(liquidHeatCapacity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::liquidHeatCapacity(temperature, pressure);
         return result;
     }
@@ -375,7 +375,7 @@ public:
         const Evaluation& result = interpolateGasTRho_(gasPressure_,
                                                        temperature,
                                                        density);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::gasPressure(temperature,
                                              density);
         return result;
@@ -395,7 +395,7 @@ public:
         const Evaluation& result = interpolateLiquidTRho_(liquidPressure_,
                                                           temperature,
                                                           density);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::liquidPressure(temperature,
                                                 density);
         return result;
@@ -435,7 +435,7 @@ public:
         const Evaluation& result = interpolateGasTP_(gasDensity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::gasDensity(temperature, pressure);
         return result;
     }
@@ -455,7 +455,7 @@ public:
         const Evaluation& result = interpolateLiquidTP_(liquidDensity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::liquidDensity(temperature, pressure);
         return result;
     }
@@ -474,7 +474,7 @@ public:
         const Evaluation& result = interpolateGasTP_(gasViscosity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::gasViscosity(temperature, pressure);
         return result;
     }
@@ -493,7 +493,7 @@ public:
         const Evaluation& result = interpolateLiquidTP_(liquidViscosity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::liquidViscosity(temperature, pressure);
         return result;
     }
@@ -512,7 +512,7 @@ public:
         const Evaluation& result = interpolateGasTP_(gasThermalConductivity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::gasThermalConductivity(temperature, pressure);
         return result;
     }
@@ -531,7 +531,7 @@ public:
         const Evaluation& result = interpolateLiquidTP_(liquidThermalConductivity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(Toolbox::value(result)))
+        if (std::isnan(Toolbox::scalarValue(result)))
             return RawComponent::liquidThermalConductivity(temperature, pressure);
         return result;
     }
@@ -547,7 +547,7 @@ private:
         if (alphaT < 0 || alphaT >= nTemp_ - 1)
             return std::numeric_limits<Scalar>::quiet_NaN();
 
-        unsigned iT = (unsigned) Toolbox::value(alphaT);
+        unsigned iT = (unsigned) Toolbox::scalarValue(alphaT);
         alphaT -= iT;
 
         return
@@ -567,23 +567,23 @@ private:
             return Toolbox::createConstant(std::numeric_limits<Scalar>::quiet_NaN());
         }
 
-        size_t iT =
-            std::max<size_t>(0,
-                             std::min<size_t>(nTemp_ - 2,
-                                              static_cast<size_t>(Toolbox::value(alphaT))));
+        int iT =
+            std::max<int>(0,
+                          std::min<int>(nTemp_ - 2,
+                                        static_cast<int>(Toolbox::scalarValue(alphaT))));
         alphaT -= iT;
 
         Evaluation alphaP1 = pressLiquidIdx_(p, iT);
         Evaluation alphaP2 = pressLiquidIdx_(p, iT + 1);
 
-        size_t iP1 =
-            std::max<size_t>(0,
-                             std::min<size_t>(nPress_ - 2,
-                                              static_cast<size_t>(Toolbox::value(alphaP1))));
-        size_t iP2 =
-            std::max<size_t>(0,
-                             std::min<size_t>(nPress_ - 2,
-                                              static_cast<size_t>(Toolbox::value(alphaP2))));
+        int iP1 =
+            std::max<int>(0,
+                          std::min<int>(nPress_ - 2,
+                                        static_cast<int>(Toolbox::scalarValue(alphaP1))));
+        int iP2 =
+            std::max<int>(0,
+                          std::min<int>(nPress_ - 2,
+                                        static_cast<int>(Toolbox::scalarValue(alphaP2))));
         alphaP1 -= iP1;
         alphaP2 -= iP2;
 
@@ -618,21 +618,21 @@ private:
             return Toolbox::createConstant(std::numeric_limits<Scalar>::quiet_NaN());
         }
 
-        size_t iT =
-            std::max<size_t>(0,
-                             std::min<size_t>(nTemp_ - 2,
-                                              static_cast<size_t>(Toolbox::value(alphaT))));
+        int iT =
+            std::max<int>(0,
+                          std::min<int>(nTemp_ - 2,
+                                        static_cast<int>(Toolbox::scalarValue(alphaT))));
         alphaT -= iT;
 
         Evaluation alphaP1 = pressGasIdx_(p, iT);
         Evaluation alphaP2 = pressGasIdx_(p, iT + 1);
-        size_t iP1 =
-            std::max<size_t>(0, std::min<size_t>(nPress_ - 2,
-                                           static_cast<size_t>(Toolbox::value(alphaP1))));
-        size_t iP2 =
-            std::max<size_t>(0,
-                             std::min<size_t>(nPress_ - 2,
-                                              static_cast<size_t>(Toolbox::value(alphaP2))));
+        int iP1 =
+            std::max<int>(0, std::min<int>(nPress_ - 2,
+                                           static_cast<int>(Toolbox::scalarValue(alphaP1))));
+        int iP2 =
+            std::max<int>(0,
+                          std::min<int>(nPress_ - 2,
+                                        static_cast<int>(Toolbox::scalarValue(alphaP2))));
         alphaP1 -= iP1;
         alphaP2 -= iP2;
 
@@ -661,7 +661,7 @@ private:
     static Evaluation interpolateGasTRho_(const Scalar *values, const Evaluation& T, const Evaluation& rho)
     {
         Evaluation alphaT = tempIdx_(T);
-        unsigned iT = std::max<int>(0, std::min<int>(nTemp_ - 2, (int) alphaT));
+        int iT = std::max<int>(0, std::min<int>(nTemp_ - 2, (int) alphaT));
         alphaT -= iT;
 
         Evaluation alphaP1 = densityGasIdx_(rho, iT);
@@ -684,7 +684,7 @@ private:
     static Evaluation interpolateLiquidTRho_(const Scalar *values, const Evaluation& T, const Evaluation& rho)
     {
         Evaluation alphaT = tempIdx_(T);
-        unsigned iT = std::max<int>(0, std::min<int>(nTemp_ - 2, (int) alphaT));
+        int iT = std::max<int>(0, std::min<int>(nTemp_ - 2, (int) alphaT));
         alphaT -= iT;
 
         Evaluation alphaP1 = densityLiquidIdx_(rho, iT);

--- a/opm/material/constraintsolvers/CompositionFromFugacities.hpp
+++ b/opm/material/constraintsolvers/CompositionFromFugacities.hpp
@@ -55,8 +55,6 @@ class CompositionFromFugacities
 {
     enum { numComponents = FluidSystem::numComponents };
 
-    typedef typename FluidSystem::ParameterCache ParameterCache;
-
 public:
     typedef Dune::FieldVector<Evaluation, numComponents> ComponentVector;
 
@@ -65,7 +63,6 @@ public:
      */
     template <class FluidState>
     static void guessInitial(FluidState &fluidState,
-                             ParameterCache &/*paramCache*/,
                              unsigned phaseIdx,
                              const ComponentVector &/*fugVec*/)
     {
@@ -89,7 +86,7 @@ public:
      */
     template <class FluidState>
     static void solve(FluidState &fluidState,
-                      ParameterCache &paramCache,
+                      typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                       unsigned phaseIdx,
                       const ComponentVector &targetFug)
     {
@@ -195,7 +192,7 @@ protected:
     // independent of the phase's composition.
     template <class FluidState>
     static void solveIdealMix_(FluidState &fluidState,
-                               ParameterCache &paramCache,
+                               typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                                unsigned phaseIdx,
                                const ComponentVector &fugacities)
     {
@@ -223,7 +220,7 @@ protected:
     static Scalar linearize_(Dune::FieldMatrix<Evaluation, numComponents, numComponents> &J,
                              Dune::FieldVector<Evaluation, numComponents> &defect,
                              FluidState &fluidState,
-                             ParameterCache &paramCache,
+                             typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                              unsigned phaseIdx,
                              const ComponentVector &targetFug)
     {
@@ -295,7 +292,7 @@ protected:
 
     template <class FluidState>
     static Scalar update_(FluidState &fluidState,
-                          ParameterCache &paramCache,
+                          typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                           Dune::FieldVector<Evaluation, numComponents> &x,
                           Dune::FieldVector<Evaluation, numComponents> &/*b*/,
                           unsigned phaseIdx,

--- a/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
+++ b/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
@@ -105,9 +105,9 @@ public:
      *                    enthalpy/internal energy of each phase
      *                    should also be set.
      */
-    template <class FluidState, class ParameterCache>
+    template <class FluidState>
     static void solve(FluidState &fluidState,
-                      ParameterCache &paramCache,
+                      typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache,
                       unsigned refPhaseIdx,
                       bool setViscosity,
                       bool setEnthalpy)

--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -27,16 +27,19 @@
 #ifndef OPM_NCP_FLASH_HPP
 #define OPM_NCP_FLASH_HPP
 
-#include <dune/common/fvector.hh>
-#include <dune/common/fmatrix.hh>
-
 #include <opm/material/fluidmatrixinteractions/NullMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
+#include <opm/material/fluidstates/CompositionalFluidState.hpp>
+#include <opm/material/localad/Evaluation.hpp>
+#include <opm/material/localad/Math.hpp>
 #include <opm/material/common/MathToolbox.hpp>
+#include <opm/material/common/Valgrind.hpp>
+
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
-#include <opm/material/common/Means.hpp>
-#include <opm/material/common/Valgrind.hpp>
+
+#include <dune/common/fvector.hh>
+#include <dune/common/fmatrix.hh>
 
 #include <limits>
 #include <iostream>
@@ -87,6 +90,12 @@ class NcpFlash
 {
     enum { numPhases = FluidSystem::numPhases };
     enum { numComponents = FluidSystem::numComponents };
+
+    enum {
+        p0PvIdx = 0,
+        S0PvIdx = 1,
+        x00PvIdx = S0PvIdx + numPhases - 1
+    };
 
     static const int numEq = numPhases*(numComponents + 1);
 
@@ -142,15 +151,25 @@ public:
                       const Dune::FieldVector<typename FluidState::Scalar, numComponents>& globalMolarities,
                       Scalar tolerance = -1.0)
     {
-        typedef typename FluidState::Scalar Evaluation;
-        typedef Dune::FieldMatrix<Evaluation, numEq, numEq> Matrix;
-        typedef Dune::FieldVector<Evaluation, numEq> Vector;
+        typedef typename FluidState::Scalar InputEval;
 
-        Dune::FMatrixPrecision<Scalar>::set_singular_limit(1e-35);
+        typedef Dune::FieldMatrix<InputEval, numEq, numEq> Matrix;
+        typedef Dune::FieldVector<InputEval, numEq> Vector;
+
+        typedef Opm::LocalAd::Evaluation</*Scalar=*/InputEval,
+                                         /*numDerivs=*/numEq> FlashEval;
+
+        typedef Dune::FieldVector<FlashEval, numEq> FlashDefectVector;
+        typedef Opm::CompositionalFluidState<FlashEval, FluidSystem, /*energy=*/false> FlashFluidState;
+
+        Dune::FMatrixPrecision<InputEval>::set_singular_limit(1e-35);
 
         if (tolerance <= 0)
-            tolerance = std::min<Scalar>(1e-5,
+            tolerance = std::min<Scalar>(1e-3,
                                          1e8*std::numeric_limits<Scalar>::epsilon());
+
+        typename FluidSystem::template ParameterCache<FlashEval> flashParamCache;
+        flashParamCache.assignPersistentData(paramCache);
 
         /////////////////////////
         // Newton method
@@ -167,88 +186,55 @@ public:
         Valgrind::SetUndefined(deltaX);
         Valgrind::SetUndefined(b);
 
-        // make the fluid state consistent with the fluid system.
-        completeFluidState_<MaterialLaw>(fluidState,
-                                         paramCache,
-                                         matParams);
+        FlashFluidState flashFluidState;
+        assignFlashFluidState_<MaterialLaw>(fluidState, flashFluidState, matParams, flashParamCache);
 
-        /*
-        std::cout << "--------------------\n";
-        std::cout << "globalMolarities: ";
+        // copy the global molarities to a vector of evaluations. Remember that the
+        // global molarities are constants. (but we need to copy them to a vector of
+        // FlashEvals anyway in order to avoid getting into hell's kitchen.)
+        Dune::FieldVector<FlashEval, numComponents> flashGlobalMolarities;
         for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx)
-            std::cout << globalMolarities[compIdx] << " ";
-        std::cout << "\n";
-        */
-        const int nMax = 50; // <- maximum number of newton iterations
-        for (int nIdx = 0; nIdx < nMax; ++nIdx) {
-            // calculate Jacobian matrix and right hand side
-            linearize_<MaterialLaw>(J,
-                                    b,
-                                    fluidState,
-                                    paramCache,
-                                    matParams,
-                                    globalMolarities);
+            flashGlobalMolarities[compIdx] = globalMolarities[compIdx];
+
+        FlashDefectVector defect;
+        const unsigned nMax = 50; // <- maximum number of newton iterations
+        for (unsigned nIdx = 0; nIdx < nMax; ++nIdx) {
+            // calculate the defect of the flash equations and their derivatives
+            evalDefect_(defect, flashFluidState, flashGlobalMolarities);
+            Valgrind::CheckDefined(defect);
+
+            // create field matrices and vectors out of the evaluation vector to solve
+            // the linear system of equations.
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++ eqIdx) {
+                for (unsigned pvIdx = 0; pvIdx < numEq; ++ pvIdx)
+                    J[eqIdx][pvIdx] = defect[eqIdx].derivatives[pvIdx];
+
+                b[eqIdx] = defect[eqIdx].value;
+            }
             Valgrind::CheckDefined(J);
             Valgrind::CheckDefined(b);
 
             // Solve J*x = b
-            deltaX = 0;
-
+            deltaX = 0.0;
             try { J.solve(deltaX, b); }
-            catch (const Dune::FMatrixError& e)
-            {
-                /*
-                printFluidState_(fluidState);
-                std::cout << "error: " << e << "\n";
-                std::cout << "b: " << b << "\n";
-                std::cout << "J: " << J << "\n";
-                */
-
+            catch (const Dune::FMatrixError& e) {
                 throw Opm::NumericalProblem(e.what());
             }
             Valgrind::CheckDefined(deltaX);
 
-            /*
-            printFluidState_(fluidState);
-            std::cout << "J:\n";
-            for (int i = 0; i < numEq; ++i) {
-                for (int j = 0; j < numEq; ++j) {
-                    std::ostringstream os;
-                    os << J[i][j];
-
-                    std::string s(os.str());
-                    do {
-                        s += " ";
-                    } while (s.size() < 20);
-                    std::cout << s;
-                }
-                std::cout << "\n";
-            }
-
-            std::cout << "deltaX: " << deltaX << "\n";
-            std::cout << "---------------\n";
-            */
-
             // update the fluid quantities.
-            //update_<MaterialLaw>(fluidState, paramCache, matParams, deltaX);
-            Scalar relError = update_<MaterialLaw>(fluidState, paramCache, matParams, deltaX);
+            Scalar relError = update_<MaterialLaw>(flashFluidState, matParams, flashParamCache, deltaX);
 
-            if (relError < tolerance)
+            if (relError < tolerance) {
+                assignOutputFluidState_(flashFluidState, fluidState);
                 return;
+            }
         }
 
-        /*
-        printFluidState_(fluidState);
-        std::cout << "globalMolarities: ";
-        for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx)
-            std::cout << globalMolarities[compIdx] << " ";
-        std::cout << "\n";
-        */
-
         OPM_THROW(NumericalProblem,
-                  "Flash calculation failed."
-                  " {c_alpha^kappa} = {" << globalMolarities << "}, T = "
-                  << fluidState.temperature(/*phaseIdx=*/0));
+                  "NcpFlash solver failed: "
+                  "{c_alpha^kappa} = {" << globalMolarities << "}, "
+                  << "T = " << fluidState.temperature(/*phaseIdx=*/0));
     }
 
     /*!
@@ -276,6 +262,8 @@ protected:
     template <class FluidState>
     static void printFluidState_(const FluidState &fluidState)
     {
+        typedef typename FluidState::Scalar FsScalar;
+
         std::cout << "saturations: ";
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             std::cout << fluidState.saturation(phaseIdx) << " ";
@@ -309,7 +297,7 @@ protected:
 
         std::cout << "global component molarities: ";
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-            Scalar sum = 0;
+            FsScalar sum = 0;
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 sum += fluidState.saturation(phaseIdx)*fluidState.molarity(phaseIdx, compIdx);
             }
@@ -318,74 +306,109 @@ protected:
         std::cout << "\n";
     }
 
-    template <class MaterialLaw,
-              class FluidState,
-              class Matrix,
-              class Vector,
-              class ComponentVector>
-    static void linearize_(Matrix &J,
-                           Vector &b,
-                           FluidState &fluidState,
-                           typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
-                           const typename MaterialLaw::Params &matParams,
-                           const ComponentVector &globalMolarities)
+    template <class MaterialLaw, class InputFluidState, class FlashFluidState>
+    static void assignFlashFluidState_(const InputFluidState& inputFluidState,
+                                       FlashFluidState& flashFluidState,
+                                       const typename MaterialLaw::Params& matParams,
+                                       typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar>& flashParamCache)
     {
-        typedef typename FluidState::Scalar Evaluation;
+        typedef typename FlashFluidState::Scalar FlashEval;
+        typedef typename InputFluidState::Scalar Evaluation;
+        typedef MathToolbox<Evaluation> InputToolbox;
 
-        FluidState origFluidState(fluidState);
-        auto origParamCache(paramCache);
+        // copy the temperature: even though the model which uses the flash solver might
+        // be non-isothermal, the flash solver does not consider energy. (it could be
+        // modified to do so relatively easily, but it would come at increased
+        // computational cost and normally temperature instead of "total internal energy
+        // of the fluids" is specified.)
+        flashFluidState.setTemperature(inputFluidState.temperature(/*phaseIdx=*/0));
 
-        Vector tmp;
+        // copy the saturations: the first N-1 phases are primary variables, the last one
+        // is one minus the sum of the former.
+        FlashEval Slast = InputToolbox::createConstant(1.0);
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx) {
+            FlashEval S = inputFluidState.saturation(phaseIdx);
+            S.derivatives[S0PvIdx + phaseIdx] = 1.0;
 
-        // reset jacobian
-        J = 0;
+            Slast -= S;
 
-        Valgrind::SetUndefined(b);
-        calculateDefect_(b, fluidState, fluidState, globalMolarities);
-        Valgrind::CheckDefined(b);
+            flashFluidState.setSaturation(phaseIdx, S);
+        }
+        flashFluidState.setSaturation(numPhases - 1, Slast);
 
-        ///////
-        // assemble jacobian matrix
-        ///////
-        for (unsigned pvIdx = 0; pvIdx < numEq; ++ pvIdx) {
-            ////////
-            // approximately calculate partial derivatives of the
-            // fugacity defect of all components in regard to the mole
-            // fraction of the i-th component. This is done via
-            // forward differences
+        // copy the pressures: the first pressure is the first primary variable, the
+        // remaining ones are given as p_beta = p_alpha + p_calpha,beta
+        FlashEval p0 = inputFluidState.pressure(0);
+        p0.derivatives[p0PvIdx] = 1.0;
 
-            // deviate the mole fraction of the i-th component
-            const Evaluation& x_i = getQuantity_(fluidState, pvIdx);
-            const Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e8/(quantityWeight_(fluidState, pvIdx));
+        std::array<FlashEval, numPhases> pc;
+        MaterialLaw::capillaryPressures(pc, matParams, flashFluidState);
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+            flashFluidState.setPressure(phaseIdx, p0 + (pc[phaseIdx] - pc[0]));
 
-            setQuantity_<MaterialLaw>(fluidState, paramCache, matParams, pvIdx, x_i + eps);
+        // copy the mole fractions: all of them are primary variables
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
+                FlashEval x = inputFluidState.moleFraction(phaseIdx, compIdx);
+                x.derivatives[x00PvIdx + phaseIdx*numComponents + compIdx] = 1.0;
+                flashFluidState.setMoleFraction(phaseIdx, compIdx, x);
+            }
+        }
 
-            // compute derivative of the defect
-            calculateDefect_(tmp, origFluidState, fluidState, globalMolarities);
-            tmp -= b;
-            for (unsigned i = 0; i < numEq; ++ i)
-                tmp[i] /= eps;
+        flashParamCache.updateAll(flashFluidState);
 
-            // store derivative in jacobian matrix
-            for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx)
-                J[eqIdx][pvIdx] = tmp[eqIdx];
+        // compute the density of each phase and the fugacity coefficient of each
+        // component in each phase.
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            const FlashEval& rho = FluidSystem::density(flashFluidState, flashParamCache, phaseIdx);
+            flashFluidState.setDensity(phaseIdx, rho);
 
-            // fluid state and parameter cache to their original values
-            fluidState = origFluidState;
-            paramCache = origParamCache;
-
-            // end forward differences
-            ////////
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
+                const FlashEval& fugCoeff = FluidSystem::fugacityCoefficient(flashFluidState, flashParamCache, phaseIdx, compIdx);
+                flashFluidState.setFugacityCoefficient(phaseIdx, compIdx, fugCoeff);
+            }
         }
     }
 
-    template <class FluidState, class Vector, class ComponentVector>
-    static void calculateDefect_(Vector &b,
-                                 const FluidState &fluidStateEval,
-                                 const FluidState &fluidState,
-                                 const ComponentVector &globalMolarities)
+    template <class FlashFluidState, class OutputFluidState>
+    static void assignOutputFluidState_(const FlashFluidState& flashFluidState,
+                                        OutputFluidState& outputFluidState)
     {
-        typedef typename FluidState::Scalar Evaluation;
+        outputFluidState.setTemperature(flashFluidState.temperature(/*phaseIdx=*/0).value);
+
+        // copy the saturations, pressures and densities
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            const auto& S = flashFluidState.saturation(phaseIdx).value;
+            outputFluidState.setSaturation(phaseIdx, S);
+
+            const auto& p = flashFluidState.pressure(phaseIdx).value;
+            outputFluidState.setPressure(phaseIdx, p);
+
+            const auto& rho = flashFluidState.density(phaseIdx).value;
+            outputFluidState.setDensity(phaseIdx, rho);
+        }
+
+        // copy the mole fractions and fugacity coefficients
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
+                const auto& moleFrac =
+                    flashFluidState.moleFraction(phaseIdx, compIdx).value;
+                outputFluidState.setMoleFraction(phaseIdx, compIdx, moleFrac);
+
+                const auto& fugCoeff =
+                    flashFluidState.fugacityCoefficient(phaseIdx, compIdx).value;
+                outputFluidState.setFugacityCoefficient(phaseIdx, compIdx, fugCoeff);
+            }
+        }
+    }
+
+    template <class FlashFluidState, class FlashDefectVector, class FlashComponentVector>
+    static void evalDefect_(FlashDefectVector &b,
+                            const FlashFluidState &fluidState,
+                            const FlashComponentVector &globalMolarities)
+    {
+        typedef typename FlashFluidState::Scalar FlashEval;
+        typedef Opm::MathToolbox<FlashEval> FlashToolbox;
 
         unsigned eqIdx = 0;
 
@@ -398,7 +421,6 @@ protected:
                 ++eqIdx;
             }
         }
-
         assert(eqIdx == numComponents*(numPhases - 1));
 
         // the fact saturations must sum up to 1 is included implicitly and also,
@@ -419,138 +441,108 @@ protected:
 
         // model assumptions (-> non-linear complementarity functions) must be adhered
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            Evaluation sumMoleFracEval = 0.0;
+            FlashEval oneMinusSumMoleFrac = FlashToolbox::createConstant(1.0);
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
-                sumMoleFracEval += fluidStateEval.moleFraction(phaseIdx, compIdx);
+                oneMinusSumMoleFrac -= fluidState.moleFraction(phaseIdx, compIdx);
 
-            if (1.0 - sumMoleFracEval > fluidStateEval.saturation(phaseIdx)) {
+            if (oneMinusSumMoleFrac > fluidState.saturation(phaseIdx))
                 b[eqIdx] = fluidState.saturation(phaseIdx);
-            }
-            else {
-                Evaluation sumMoleFrac = 0.0;
-                for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
-                    sumMoleFrac += fluidState.moleFraction(phaseIdx, compIdx);
-                b[eqIdx] = 1.0 - sumMoleFrac;
-            }
+            else
+                b[eqIdx] = oneMinusSumMoleFrac;
 
             ++eqIdx;
         }
     }
 
-    template <class MaterialLaw, class FluidState, class Vector>
-    static Scalar update_(FluidState &fluidState,
-                          typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
-                          const typename MaterialLaw::Params &matParams,
-                          const Vector &deltaX)
+    template <class MaterialLaw, class FlashFluidState, class EvalVector>
+    static Scalar update_(FlashFluidState& fluidState,
+                          const typename MaterialLaw::Params& matParams,
+                          typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar>& paramCache,
+                          const EvalVector& deltaX)
     {
-        typedef typename FluidState::Scalar Evaluation;
-        typedef Opm::MathToolbox<Evaluation> Toolbox;
+        // note that it is possible that FlashEval::Scalar is an Evaluation itself
+        typedef typename FlashFluidState::Scalar FlashEval;
+        typedef typename FlashEval::ValueType InnerEval;
+        typedef Opm::MathToolbox<InnerEval> InnerEvalToolbox;
 
-        // make sure we don't swallow non-finite update vectors
 #ifndef NDEBUG
+        // make sure we don't swallow non-finite update vectors
         assert(deltaX.dimension == numEq);
         for (unsigned i = 0; i < numEq; ++i)
-            assert(std::isfinite(Toolbox::value(deltaX[i])));
+            assert(std::isfinite(InnerEvalToolbox::scalarValue(deltaX[i])));
 #endif
 
         Scalar relError = 0;
         for (unsigned pvIdx = 0; pvIdx < numEq; ++ pvIdx) {
-            const Evaluation& tmp = getQuantity_(fluidState, pvIdx);
-            Evaluation delta = deltaX[pvIdx];
+            FlashEval tmp = getQuantity_(fluidState, pvIdx);
+            InnerEval delta = deltaX[pvIdx];
 
-            relError = std::max<Scalar>(relError,
-                                        std::abs(Toolbox::value(delta))
-                                        * quantityWeight_(fluidState, pvIdx));
+            relError = std::max(relError,
+                                std::abs(InnerEvalToolbox::scalarValue(delta))
+                                * quantityWeight_(fluidState, pvIdx));
 
             if (isSaturationIdx_(pvIdx)) {
                 // dampen to at most 25% change in saturation per iteration
-                delta = Toolbox::min(0.25, Toolbox::max(-0.25, delta));
+                delta = InnerEvalToolbox::min(0.25, InnerEvalToolbox::max(-0.25, delta));
             }
             else if (isMoleFracIdx_(pvIdx)) {
                 // dampen to at most 20% change in mole fraction per iteration
-                delta = Toolbox::min(0.20, Toolbox::max(-0.20, delta));
+                delta = InnerEvalToolbox::min(0.20, InnerEvalToolbox::max(-0.20, delta));
             }
             else if (isPressureIdx_(pvIdx)) {
                 // dampen to at most 50% change in pressure per iteration
-                delta = Toolbox::min(0.5*fluidState.pressure(0),
-                                     Toolbox::max(-0.5*fluidState.pressure(0), delta));
+                delta = InnerEvalToolbox::min(0.5*fluidState.pressure(0).value,
+                                              InnerEvalToolbox::max(-0.5*fluidState.pressure(0).value,
+                                                                    delta));
             }
 
-            setQuantityRaw_(fluidState, pvIdx, tmp - delta);
+            tmp -= delta;
+            setQuantity_(fluidState, pvIdx, tmp);
         }
-
-        /*
-        // make sure all saturations, pressures and mole fractions are non-negative
-        Scalar sumSat = 0;
-        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            Scalar value = fluidState.saturation(phaseIdx);
-            if (value < -0.05) {
-                value = -0.05;
-                fluidState.setSaturation(phaseIdx, value);
-            }
-            sumSat += value;
-
-            value = fluidState.pressure(phaseIdx);
-            if (value < 0)
-                fluidState.setPressure(phaseIdx, 0.0);
-
-            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-                value = fluidState.moleFraction(phaseIdx, compIdx);
-                if (value < 0)
-                    fluidState.setMoleFraction(phaseIdx, compIdx, 0.0);
-            }
-        }
-
-        // last saturation
-        if (sumSat > 1.05) {
-            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-                Scalar value = fluidState.saturation(phaseIdx)/(0.95*sumSat);
-                fluidState.setSaturation(phaseIdx, value);
-            }
-        }
-        */
 
         completeFluidState_<MaterialLaw>(fluidState, paramCache, matParams);
 
         return relError;
     }
 
-    template <class MaterialLaw, class FluidState>
-    static void completeFluidState_(FluidState &fluidState,
-                                    typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
+    template <class MaterialLaw, class FlashFluidState>
+    static void completeFluidState_(FlashFluidState &flashFluidState,
+                                    typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar> &paramCache,
                                     const typename MaterialLaw::Params &matParams)
     {
-        typedef typename FluidState::Scalar Evaluation;
-        typedef typename FluidSystem::template ParameterCache<Evaluation> ParameterCache;
+        typedef typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar> ParamCache;
+
+        typedef typename FlashFluidState::Scalar FlashEval;
+        typedef Opm::MathToolbox<FlashEval> FlashToolbox;
 
         // calculate the saturation of the last phase as a function of
         // the other saturations
-        Evaluation sumSat = 0.0;
+        FlashEval sumSat = FlashToolbox::createConstant(0.0);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx)
-            sumSat += fluidState.saturation(phaseIdx);
-        fluidState.setSaturation(/*phaseIdx=*/numPhases - 1, 1.0 - sumSat);
+            sumSat += flashFluidState.saturation(phaseIdx);
+        flashFluidState.setSaturation(/*phaseIdx=*/numPhases - 1, 1.0 - sumSat);
 
         // update the pressures using the material law (saturations
         // and first pressure are already set because it is implicitly
         // solved for.)
-        Dune::FieldVector<Scalar, numPhases> pC;
-        MaterialLaw::capillaryPressures(pC, matParams, fluidState);
+        Dune::FieldVector<FlashEval, numPhases> pC;
+        MaterialLaw::capillaryPressures(pC, matParams, flashFluidState);
         for (unsigned phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
-            fluidState.setPressure(phaseIdx,
-                                   fluidState.pressure(0)
-                                   + (pC[phaseIdx] - pC[0]));
+            flashFluidState.setPressure(phaseIdx,
+                                        flashFluidState.pressure(0)
+                                        + (pC[phaseIdx] - pC[0]));
 
         // update the parameter cache
-        paramCache.updateAll(fluidState, /*except=*/ParameterCache::Temperature);
+        paramCache.updateAll(flashFluidState, /*except=*/ParamCache::Temperature);
 
         // update all densities and fugacity coefficients
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
-            const Evaluation& rho = FluidSystem::density(fluidState, paramCache, phaseIdx);
-            fluidState.setDensity(phaseIdx, rho);
+            const FlashEval& rho = FluidSystem::density(flashFluidState, paramCache, phaseIdx);
+            flashFluidState.setDensity(phaseIdx, rho);
 
             for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
-                const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
-                fluidState.setFugacityCoefficient(phaseIdx, compIdx, phi);
+                const FlashEval& phi = FluidSystem::fugacityCoefficient(flashFluidState, paramCache, phaseIdx, compIdx);
+                flashFluidState.setFugacityCoefficient(phaseIdx, compIdx, phi);
             }
         }
     }
@@ -590,106 +582,10 @@ protected:
     }
 
     // set a quantity in the fluid state
-    template <class MaterialLaw, class FluidState>
+    template <class FluidState>
     static void setQuantity_(FluidState &fluidState,
-                             typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
-                             const typename MaterialLaw::Params &matParams,
                              unsigned pvIdx,
                              const typename FluidState::Scalar& value)
-    {
-        typedef typename FluidState::Scalar Evaluation;
-
-        assert(0 <= pvIdx && pvIdx < numEq);
-
-        if (pvIdx < 1) { // <- first pressure
-            Evaluation delta = value - fluidState.pressure(0);
-
-            // set all pressures. here we assume that the capillary
-            // pressure does not depend on absolute pressure.
-            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
-                fluidState.setPressure(phaseIdx, fluidState.pressure(phaseIdx) + delta);
-            paramCache.updateAllPressures(fluidState);
-
-            // update all densities and fugacity coefficients
-            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-                const Evaluation& rho = FluidSystem::density(fluidState, paramCache, phaseIdx);
-                Valgrind::CheckDefined(rho);
-                fluidState.setDensity(phaseIdx, rho);
-
-                for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-                    const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
-                    Valgrind::CheckDefined(phi);
-                    fluidState.setFugacityCoefficient(phaseIdx, compIdx, phi);
-                }
-            }
-        }
-        else if (pvIdx < numPhases) { // <- first M - 1 saturations
-            const Evaluation& delta = value - fluidState.saturation(/*phaseIdx=*/pvIdx - 1);
-            Valgrind::CheckDefined(delta);
-            fluidState.setSaturation(/*phaseIdx=*/pvIdx - 1, value);
-
-            // set last saturation (-> minus the change of the saturation of the other
-            // phase)
-            fluidState.setSaturation(/*phaseIdx=*/numPhases - 1,
-                                     fluidState.saturation(numPhases - 1) - delta);
-
-            // update all fluid pressures using the capillary pressure law
-            Dune::FieldVector<Evaluation, numPhases> pC;
-            MaterialLaw::capillaryPressures(pC, matParams, fluidState);
-            Valgrind::CheckDefined(pC);
-            for (unsigned phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
-                fluidState.setPressure(phaseIdx,
-                                       fluidState.pressure(0)
-                                       + (pC[phaseIdx] - pC[0]));
-            paramCache.updateAllPressures(fluidState);
-
-            // update all densities and fugacity coefficients
-            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-                const Evaluation& rho = FluidSystem::density(fluidState, paramCache, phaseIdx);
-                Valgrind::CheckDefined(rho);
-                fluidState.setDensity(phaseIdx, rho);
-
-                for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-                    const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
-                    Valgrind::CheckDefined(phi);
-                    fluidState.setFugacityCoefficient(phaseIdx, compIdx, phi);
-                }
-            }
-        }
-        else if (pvIdx < numPhases + numPhases*numComponents) // <- mole fractions
-        {
-            unsigned phaseIdx = (pvIdx - numPhases)/numComponents;
-            unsigned compIdx = (pvIdx - numPhases)%numComponents;
-
-            Valgrind::CheckDefined(value);
-            fluidState.setMoleFraction(phaseIdx, compIdx, value);
-            paramCache.updateSingleMoleFraction(fluidState, phaseIdx, compIdx);
-
-            // update the density of the phase
-            const Evaluation& rho = FluidSystem::density(fluidState, paramCache, phaseIdx);
-            Valgrind::CheckDefined(rho);
-            fluidState.setDensity(phaseIdx, rho);
-
-            // if the phase's fugacity coefficients are composition
-            // dependent, update them as well.
-            if (!FluidSystem::isIdealMixture(phaseIdx)) {
-                for (unsigned fugCompIdx = 0; fugCompIdx < numComponents; ++fugCompIdx) {
-                    const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState, paramCache, phaseIdx, fugCompIdx);
-                    Valgrind::CheckDefined(phi);
-                    fluidState.setFugacityCoefficient(phaseIdx, fugCompIdx, phi);
-                }
-            }
-        }
-        else {
-            assert(false);
-        }
-    }
-
-    // set a quantity in the fluid state
-    template <class FluidState>
-    static void setQuantityRaw_(FluidState &fluidState,
-                                unsigned pvIdx,
-                                const typename FluidState::Scalar& value)
     {
         assert(pvIdx < numEq);
 
@@ -705,8 +601,8 @@ protected:
             fluidState.setSaturation(phaseIdx, value);
         }
         // mole fractions
-        else // if (pvIdx < numPhases + numPhases*numComponents)
-        {
+        else {
+            assert(pvIdx < numPhases + numPhases*numComponents);
             unsigned phaseIdx = (pvIdx - numPhases)/numComponents;
             unsigned compIdx = (pvIdx - numPhases)%numComponents;
             fluidState.setMoleFraction(phaseIdx, compIdx, value);
@@ -718,7 +614,7 @@ protected:
     {
         // first pressure
         if (pvIdx < 1)
-            return 1/1e6;
+            return 1e-6;
         // first M - 1 saturations
         else if (pvIdx < numPhases)
             return 1.0;

--- a/opm/material/eos/PengRobinsonParamsMixture.hpp
+++ b/opm/material/eos/PengRobinsonParamsMixture.hpp
@@ -61,6 +61,8 @@ class PengRobinsonParamsMixture
     // Peng-Robinson parameters for pure substances
     typedef Opm::PengRobinsonParams<Scalar> PureParams;
 
+    typedef MathToolbox<Scalar> Toolbox;
+
     // the ideal gas constant
     static const Scalar R;
 
@@ -107,13 +109,13 @@ public:
 
             Valgrind::CheckDefined(f_omega);
 
-            Scalar tmp = 1 + f_omega*(1 - std::sqrt(Tr));
+            Scalar tmp = 1 + f_omega*(1 - Toolbox::sqrt(Tr));
             tmp = tmp*tmp;
 
             Scalar newA = 0.4572355*RTc*RTc/pc * tmp;
             Scalar newB = 0.0777961 * RTc / pc;
-            assert(std::isfinite(newA));
-            assert(std::isfinite(newB));
+            assert(std::isfinite(Toolbox::scalarValue(newA)));
+            assert(std::isfinite(Toolbox::scalarValue(newB)));
 
             this->pureParams_[i].setA(newA);
             this->pureParams_[i].setB(newB);
@@ -147,23 +149,23 @@ public:
         Scalar newB = 0;
         for (unsigned compIIdx = 0; compIIdx < numComponents; ++compIIdx) {
             const Scalar moleFracI = fs.moleFraction(phaseIdx, compIIdx);
-            Scalar xi = std::max(Scalar(0), std::min(Scalar(1.0), moleFracI));
+            Scalar xi = Toolbox::max(0.0, Toolbox::min(1.0, moleFracI));
             Valgrind::CheckDefined(xi);
 
             for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
                 const Scalar moleFracJ = fs.moleFraction(phaseIdx, compJIdx );
-                Scalar xj = std::max(Scalar(0), std::min(Scalar(1), moleFracJ));
+                Scalar xj = Toolbox::max(0.0, Toolbox::min(1.0, moleFracJ));
                 Valgrind::CheckDefined(xj);
 
                 // mixing rule from Reid, page 82
                 newA +=  xi * xj * aCache_[compIIdx][compJIdx];
 
-                assert(std::isfinite(newA));
+                assert(std::isfinite(Toolbox::scalarValue(newA)));
             }
 
             // mixing rule from Reid, page 82
-            newB += std::max(Scalar(0), xi) * this->pureParams_[compIIdx].b();
-            assert(std::isfinite(newB));
+            newB += Toolbox::max(0.0, xi) * this->pureParams_[compIIdx].b();
+            assert(std::isfinite(Toolbox::scalarValue(newB)));
         }
 
         // assert(newB > 0);
@@ -232,8 +234,8 @@ private:
                 Scalar Psi = FluidSystem::interactionCoefficient(compIIdx, compJIdx);
 
                 aCache_[compIIdx][compJIdx] =
-                    std::sqrt(this->pureParams_[compIIdx].a()
-                              * this->pureParams_[compJIdx].a())
+                    Toolbox::sqrt(this->pureParams_[compIIdx].a()
+                                  * this->pureParams_[compJIdx].a())
                     * (1 - Psi);
             }
         }

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -160,9 +160,6 @@ public:
             break;
         }
 
-        default:
-            OPM_THROW(std::logic_error,
-                      "Cannot calculate capillary pressure: Invalid two-phase system");
         }
     }
 

--- a/opm/material/fluidsystems/BaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/BaseFluidSystem.hpp
@@ -51,12 +51,14 @@ public:
     /*!
      * \brief The type of the fluid system's parameter cache
      *
-     * The parameter cache can be used to avoid re-calculating
-     * expensive parameters for multiple quantities. Be aware that
-     * what the parameter cache actually does is specific for each
-     * fluid system and that it is opaque outside the fluid system.
+     * The parameter cache can be used to avoid re-calculating expensive parameters for
+     * multiple quantities. Be aware that what the parameter cache actually does is
+     * specific for each fluid system and that it is opaque outside the fluid system.
      */
-    typedef NullParameterCache ParameterCache;
+    template <class Evaluation>
+    struct ParameterCache {
+        ParameterCache() = delete; // derived fluid systems must specify this class!
+    };
 
     //! Number of chemical species in the fluid system
     static const int numComponents = -1000;
@@ -167,9 +169,9 @@ public:
      * \copydoc Doxygen::fluidSystemBaseParams
      * \copydoc Doxygen::phaseIdxParam
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval density(const FluidState &/*fluidState*/,
-                           const ParameterCache &/*paramCache*/,
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCache>
+    static LhsEval density(const FluidState& /*fluidState*/,
+                           const ParamCache& /*paramCache*/,
                            unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error,
@@ -190,9 +192,9 @@ public:
      * \copydoc Doxygen::phaseIdxParam
      * \copydoc Doxygen::compIdxParam
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval fugacityCoefficient(const FluidState &/*fluidState*/,
-                                       const ParameterCache &/*paramCache*/,
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCache>
+    static LhsEval fugacityCoefficient(const FluidState& /*fluidState*/,
+                                       ParamCache& /*paramCache*/,
                                        unsigned /*phaseIdx*/,
                                        unsigned /*compIdx*/)
     {
@@ -205,9 +207,9 @@ public:
      * \copydoc Doxygen::fluidSystemBaseParams
      * \copydoc Doxygen::phaseIdxParam
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval viscosity(const FluidState &/*fluidState*/,
-                             const ParameterCache &/*paramCache*/,
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCache>
+    static LhsEval viscosity(const FluidState& /*fluidState*/,
+                             ParamCache& /*paramCache*/,
                              unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Opm::className<Implementation>() << "'  does not provide a viscosity() method!");
@@ -230,9 +232,9 @@ public:
      * \copydoc Doxygen::phaseIdxParam
      * \copydoc Doxygen::compIdxParam
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval diffusionCoefficient(const FluidState &/*fluidState*/,
-                                        const ParameterCache &/*paramCache*/,
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCache>
+    static LhsEval diffusionCoefficient(const FluidState& /*fluidState*/,
+                                        ParamCache& /*paramCache*/,
                                         unsigned /*phaseIdx*/,
                                         unsigned /*compIdx*/)
     {
@@ -246,9 +248,9 @@ public:
      * \copydoc Doxygen::fluidSystemBaseParams
      * \copydoc Doxygen::phaseIdxParam
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval enthalpy(const FluidState &/*fluidState*/,
-                            const ParameterCache &/*paramCache*/,
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCache>
+    static LhsEval enthalpy(const FluidState& /*fluidState*/,
+                            ParamCache& /*paramCache*/,
                             unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Opm::className<Implementation>() << "'  does not provide an enthalpy() method!");
@@ -260,9 +262,9 @@ public:
      * \copydoc Doxygen::fluidSystemBaseParams
      * \copydoc Doxygen::phaseIdxParam
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval thermalConductivity(const FluidState &/*fluidState*/,
-                                       const ParameterCache &/*paramCache*/,
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCache>
+    static LhsEval thermalConductivity(const FluidState& /*fluidState*/,
+                                       ParamCache& /*paramCache*/,
                                        unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Opm::className<Implementation>() << "'  does not provide a thermalConductivity() method!");
@@ -274,9 +276,9 @@ public:
      * \copydoc Doxygen::fluidSystemBaseParams
      * \copydoc Doxygen::phaseIdxParam
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParameterCache = NullParameterCache>
-    static LhsEval heatCapacity(const FluidState &/*fluidState*/,
-                                const ParameterCache &/*paramCache*/,
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCache>
+    static LhsEval heatCapacity(const FluidState& /*fluidState*/,
+                                ParamCache& /*paramCache*/,
                                 unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Opm::className<Implementation>() << "'  does not provide a heatCapacity() method!");

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -121,6 +121,17 @@ public:
         { regionIdx_ = 0; }
 
         /*!
+         * \brief Copy the data which is not dependent on the type of the Scalars from
+         *        another parameter cache.
+         *
+         * For the black-oil parameter cache this means that the region index must be
+         * copied.
+         */
+        template <class OtherCache>
+        void assignPersistentData(const OtherCache& other)
+        { regionIdx_ = other.regionIndex(); }
+
+        /*!
          * \brief Return the index of the region which should be used to determine the
          *        thermodynamic properties
          *

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -113,7 +113,8 @@ public:
     typedef Opm::WaterPvtMultiplexer<Scalar> WaterPvt;
 
     //! \copydoc BaseFluidSystem::ParameterCache
-    class ParameterCache : public Opm::NullParameterCache
+    template <class Evaluation>
+    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
     {
     public:
         ParameterCache(int /*regionIdx*/=0)
@@ -396,24 +397,24 @@ public:
      * thermodynamic quantities (generic version, only isothermal)
      ****************************************/
     //! \copydoc BaseFluidSystem::density
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval density(const FluidState &fluidState,
-                           ParameterCache &paramCache,
+                           const ParameterCache<ParamCacheEval> &paramCache,
                            unsigned phaseIdx)
     { return density<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &paramCache,
+                                       const ParameterCache<ParamCacheEval> &paramCache,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     { return fugacityCoefficient<FluidState, LhsEval>(fluidState, phaseIdx, compIdx, paramCache.regionIndex()); }
 
     //! \copydoc BaseFluidSystem::viscosity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &paramCache,
+                             const ParameterCache<ParamCacheEval> &paramCache,
                              unsigned phaseIdx)
     { return viscosity<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
 

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -69,11 +69,12 @@ class BrineCO2
     typedef H2O_Tabulated H2O;
 
 public:
+    template <class Evaluation>
+    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    {};
+
     //! The binary coefficients for brine and CO2 used by this fluid system
     typedef Opm::BinaryCoeff::Brine_CO2<Scalar, CO2Tables> BinaryCoeffBrineCO2;
-
-    //! \copydoc BaseFluidSystem::ParameterCache
-    typedef Opm::NullParameterCache ParameterCache;
 
     /****************************************
      * Fluid phase related static parameters
@@ -228,9 +229,9 @@ public:
     /*!
      * \copydoc BaseFluidSystem::density
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &/*paramCache*/,
+                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -282,9 +283,9 @@ public:
     /*!
      * \copydoc BaseFluidSystem::viscosity
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &/*paramCache*/,
+                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -311,9 +312,9 @@ public:
     /*!
      * \copydoc BaseFluidSystem::fugacityCoefficient
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
@@ -368,9 +369,9 @@ public:
     /*!
      * \copydoc BaseFluidSystem::diffusionCoefficient
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache &/*paramCache*/,
+                                        const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                         unsigned phaseIdx,
                                         unsigned /*compIdx*/)
     {
@@ -388,9 +389,9 @@ public:
     /*!
      * \copydoc BaseFluidSystem::enthalpy
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &/*paramCache*/,
+                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -425,9 +426,9 @@ public:
     /*!
      * \copydoc BaseFluidSystem::thermalConductivity
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval thermalConductivity(const FluidState &/*fluidState*/,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx)
     {
         typedef MathToolbox<LhsEval> LhsToolbox;
@@ -452,9 +453,9 @@ public:
      * \param phaseIdx The index of the fluid phase to consider
      * \tparam FluidState the fluid state class
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &/*paramCache*/,
+                                const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                 unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -193,8 +193,8 @@ public:
      */
     static void init()
     {
-        init(/*startTemp=*/273.15, /*endTemp=*/623.15, /*tempSteps=*/100,
-             /*startPressure=*/1e4, /*endPressure=*/40e6, /*pressureSteps=*/200);
+        init(/*startTemp=*/273.15, /*endTemp=*/623.15, /*tempSteps=*/50,
+             /*startPressure=*/1e4, /*endPressure=*/40e6, /*pressureSteps=*/50);
     }
 
     /*!

--- a/opm/material/fluidsystems/H2OAirFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirFluidSystem.hpp
@@ -226,10 +226,10 @@ public:
         if (H2O::isTabulated)
             init(/*tempMin=*/273.15,
                  /*tempMax=*/623.15,
-                 /*numTemp=*/100,
+                 /*numTemp=*/50,
                  /*pMin=*/-10,
                  /*pMax=*/20e6,
-                 /*numP=*/200);
+                 /*numP=*/50);
     }
 
     /*!

--- a/opm/material/fluidsystems/H2OAirFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirFluidSystem.hpp
@@ -67,8 +67,9 @@ class H2OAir
     typedef Opm::IdealGas<Scalar> IdealGas;
 
 public:
-    //! \copydoc BaseFluidSystem::ParameterCache
-    typedef NullParameterCache ParameterCache;
+    template <class Evaluation>
+    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    {};
 
     //! The type of the water component used for this fluid system
     typedef H2Otype H2O;
@@ -253,9 +254,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::density
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &/*paramCache*/,
+                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -319,9 +320,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::viscosity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &/*paramCache*/,
+                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<LhsEval> LhsToolbox;
@@ -388,9 +389,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
@@ -414,9 +415,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval binaryDiffusionCoefficient(const FluidState &fluidState,
-                                              const ParameterCache &/*paramCache*/,
+                                              const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                               unsigned phaseIdx,
                                               unsigned /*compIdx*/)
     {
@@ -433,9 +434,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::enthalpy
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &/*paramCache*/,
+                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -467,9 +468,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::thermalConductivity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
@@ -101,10 +101,10 @@ public:
     {
         init(/*tempMin=*/273.15,
              /*tempMax=*/623.15,
-             /*numTemp=*/100,
+             /*numTemp=*/50,
              /*pMin=*/0.0,
              /*pMax=*/20e6,
-             /*numP=*/200);
+             /*numP=*/50);
     }
 
     /*!

--- a/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
@@ -63,8 +63,9 @@ class H2OAirMesitylene
     typedef Opm::TabulatedComponent<Scalar, IapwsH2O, /*alongVaporPressure=*/false> TabulatedH2O;
 
 public:
-    //! \copydoc BaseFluidSystem::ParameterCache
-    typedef NullParameterCache ParameterCache;
+    template <class Evaluation>
+    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    {};
 
     //! The type of the mesithylene/napl component
     typedef Opm::Mesitylene<Scalar> NAPL;
@@ -197,9 +198,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::density
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &/*paramCache*/,
+                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -244,9 +245,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::viscosity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &/*paramCache*/,
+                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -308,9 +309,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval diffusionCoefficient(const FluidState &/*fluidState*/,
-                                        const ParameterCache &/*paramCache*/,
+                                        const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                         unsigned /*phaseIdx*/,
                                         unsigned /*compIdx*/)
     {
@@ -369,9 +370,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
@@ -418,9 +419,9 @@ public:
 
 
     //! \copydoc BaseFluidSystem::enthalpy
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &/*paramCache*/,
+                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -447,9 +448,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::thermalConductivity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
@@ -56,8 +56,9 @@ class H2OAirXylene
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
 public:
-    //! \copydoc BaseFluidSystem::ParameterCache
-    typedef NullParameterCache ParameterCache;
+    template <class Evaluation>
+    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    {};
 
     //! The type of the water component
     typedef Opm::H2O<Scalar> H2O;
@@ -164,9 +165,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::density
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &/*paramCache*/,
+                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -207,9 +208,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::viscosity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &/*paramCache*/,
+                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -271,9 +272,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache &/*paramCache*/,
+                                        const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                         unsigned phaseIdx,
                                         unsigned compIdx)
     {
@@ -325,9 +326,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
@@ -370,9 +371,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::enthalpy
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &/*paramCache*/,
+                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/H2ON2FluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2FluidSystem.hpp
@@ -67,7 +67,8 @@ class H2ON2
 
 public:
     //! \copydoc BaseFluidSystem::ParameterCache
-    typedef NullParameterCache ParameterCache;
+    template <class Evaluation>
+    using ParameterCache = NullParameterCache<Evaluation>;
 
     /****************************************
      * Fluid phase related static parameters
@@ -264,9 +265,9 @@ public:
      * of a multiphase multicomponent model for PEMFC - Technical report: IRTG-NUPUS",
      * University of Stuttgart, 2008
      */
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &/*paramCache*/,
+                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
                            unsigned phaseIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx < numPhases);
@@ -321,9 +322,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::viscosity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &/*paramCache*/,
+                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
                              unsigned phaseIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx < numPhases);
@@ -382,9 +383,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
@@ -411,9 +412,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache &/*paramCache*/,
+                                        const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                         unsigned phaseIdx,
                                         unsigned /*compIdx*/)
 
@@ -433,9 +434,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::enthalpy
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &/*paramCache*/,
+                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -467,9 +468,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::thermalConductivity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx)
     {
         assert(0 <= phaseIdx  && phaseIdx < numPhases);
@@ -502,9 +503,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::heatCapacity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &/*paramCache*/,
+                                const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                 unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/H2ON2FluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2FluidSystem.hpp
@@ -231,10 +231,10 @@ public:
     {
         init(/*tempMin=*/273.15,
              /*tempMax=*/623.15,
-             /*numTemp=*/100,
+             /*numTemp=*/50,
              /*pMin=*/0.0,
              /*pMax=*/20e6,
-             /*numP=*/200);
+             /*numP=*/50);
     }
 
     /*!

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -67,7 +67,9 @@ class H2ON2LiquidPhase
 
 public:
     //! \copydoc BaseFluidSystem::ParameterCache
-    typedef NullParameterCache ParameterCache;
+    template <class Evaluation>
+    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    {};
 
     /****************************************
      * Fluid phase related static parameters
@@ -248,9 +250,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::density
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &/*paramCache*/,
+                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -285,9 +287,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::viscosity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &/*paramCache*/,
+                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -302,9 +304,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
@@ -322,9 +324,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache &/*paramCache*/,
+                                        const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                         unsigned phaseIdx,
                                         unsigned /*compIdx*/)
 
@@ -340,9 +342,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::enthalpy
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &/*paramCache*/,
+                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -359,9 +361,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::thermalConductivity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        const unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -378,9 +380,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::heatCapacity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &/*paramCache*/,
+                                const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                 unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -221,10 +221,10 @@ public:
     {
         init(/*tempMin=*/273.15,
              /*tempMax=*/623.15,
-             /*numTemp=*/100,
+             /*numTemp=*/50,
              /*pMin=*/0.0,
              /*pMax=*/20e6,
-             /*numP=*/200);
+             /*numP=*/50);
     }
 
     /*!

--- a/opm/material/fluidsystems/NullParameterCache.hpp
+++ b/opm/material/fluidsystems/NullParameterCache.hpp
@@ -35,7 +35,8 @@ namespace Opm {
  * \ingroup Fluidsystems
  * \brief A parameter cache which does nothing
  */
-class NullParameterCache : public ParameterCacheBase<NullParameterCache>
+template <class Evaluation>
+class NullParameterCache : public ParameterCacheBase<NullParameterCache<Evaluation> >
 {
 public:
     NullParameterCache()

--- a/opm/material/fluidsystems/ParameterCacheBase.hpp
+++ b/opm/material/fluidsystems/ParameterCacheBase.hpp
@@ -58,6 +58,14 @@ public:
     {}
 
     /*!
+     * \brief Copy the data which is not dependent on the type of the Scalars from
+     *        another parameter cache.
+     */
+    template <class OtherCache>
+    void assignPersistentData(const OtherCache& other)
+    {}
+
+    /*!
      * \brief Update the quantities of the parameter cache for all phases
      *
      * \param fluidState The representation of the thermodynamic system of interest.

--- a/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
@@ -63,7 +63,9 @@ class SinglePhase
 
 public:
     //! \copydoc BaseFluidSystem::ParameterCache
-    typedef NullParameterCache ParameterCache;
+    template <class Evaluation>
+    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    {};
 
     /****************************************
      * Fluid phase related static parameters
@@ -183,9 +185,9 @@ public:
     { }
 
     //! \copydoc BaseFluidSystem::density
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &/*paramCache*/,
+                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -198,9 +200,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::viscosity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &/*paramCache*/,
+                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -213,9 +215,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval fugacityCoefficient(const FluidState &/*fluidState*/,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
@@ -232,9 +234,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::enthalpy
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &/*paramCache*/,
+                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -247,9 +249,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::thermalConductivity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -262,9 +264,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::heatCapacity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &/*paramCache*/,
+                                const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                 unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
+++ b/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
@@ -63,9 +63,11 @@ class TwoPhaseImmiscible
 
     typedef TwoPhaseImmiscible<Scalar, WettingPhase, NonwettingPhase> ThisType;
     typedef BaseFluidSystem<Scalar, ThisType> Base;
+
 public:
-    //! \copydoc BaseFluidSystem::ParameterCache
-    typedef NullParameterCache ParameterCache;
+    template <class Evaluation>
+    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    {};
 
     /****************************************
      * Fluid phase related static parameters
@@ -219,9 +221,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::density
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache &/*paramCache*/,
+                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -236,9 +238,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::viscosity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache &/*paramCache*/,
+                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -253,9 +255,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval fugacityCoefficient(const FluidState &/*fluidState*/,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
@@ -274,9 +276,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::enthalpy
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache &/*paramCache*/,
+                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -291,9 +293,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::thermalConductivity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache &/*paramCache*/,
+                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                        unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -308,9 +310,9 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::heatCapacity
-    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache &/*paramCache*/,
+                                const ParameterCache<ParamCacheEval> &/*paramCache*/,
                                 unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -157,7 +157,7 @@ public:
      * \brief Return the number of PVT regions which are considered by this PVT-object.
      */
     unsigned numRegions() const
-    { return waterReferenceDensity_.size(); };
+    { return waterReferenceDensity_.size(); }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -189,7 +189,7 @@ public:
      * \brief Return the number of PVT regions which are considered by this PVT-object.
      */
     unsigned numRegions() const
-    { return gasReferenceDensity_.size(); };
+    { return gasReferenceDensity_.size(); }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -57,7 +57,6 @@ namespace Opm {
         break;                                                          \
     }                                                                   \
     case NoGasPvt:                                                      \
-    default:                                                            \
         OPM_THROW(std::logic_error, "Not implemented: Gas PVT of this deck!"); \
     }
 
@@ -164,7 +163,7 @@ public:
      * \brief Return the number of PVT regions which are considered by this PVT-object.
      */
     unsigned numRegions() const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); };
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); return 1; }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -56,7 +56,6 @@ namespace Opm {
         break;                                                          \
     }                                                                   \
     case NoOilPvt:                                                      \
-    default:                                                            \
         OPM_THROW(std::logic_error, "Not implemented: Oil PVT of this deck!"); \
     }
 
@@ -151,7 +150,7 @@ public:
      * \brief Return the number of PVT regions which are considered by this PVT-object.
      */
     unsigned numRegions() const
-    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); };
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); return 1; }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -43,7 +43,6 @@
         break;                                                          \
     }                                                                   \
     case NoWaterPvt:                                                    \
-    default:                                                            \
         OPM_THROW(std::logic_error, "Not implemented: Water PVT of this deck!"); \
     }
 
@@ -115,7 +114,7 @@ public:
      * \brief Return the number of PVT regions which are considered by this PVT-object.
      */
     unsigned numRegions() const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); };
+    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); return 1; }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -432,7 +432,7 @@ public:
      * \brief Return the number of PVT regions which are considered by this PVT-object.
      */
     unsigned numRegions() const
-    { return gasReferenceDensity_.size(); };
+    { return gasReferenceDensity_.size(); }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.

--- a/opm/material/heatconduction/FluidConduction.hpp
+++ b/opm/material/heatconduction/FluidConduction.hpp
@@ -57,7 +57,7 @@ public:
     static Evaluation heatConductivity(const Params &params,
                                        const FluidState &fluidState)
     {
-        typename FluidSystem::ParameterCache paramCache;
+        typename FluidSystem::template ParameterCache<Evaluation> paramCache;
         paramCache.updatePhase(fluidState, phaseIdx);
         return FluidSystem::template thermalConductivity<FluidState, Evaluation>(fluidState,
                                                                                  paramCache,

--- a/opm/material/localad/Evaluation.hpp
+++ b/opm/material/localad/Evaluation.hpp
@@ -29,12 +29,15 @@
 #ifndef OPM_LOCAL_AD_EVALUATION_HPP
 #define OPM_LOCAL_AD_EVALUATION_HPP
 
-#include <iostream>
-#include <array>
-#include <cassert>
 #include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
+
+#include <array>
+#include <cmath>
+#include <cassert>
+#include <iostream>
+#include <algorithm>
 
 namespace Opm {
 namespace LocalAd {

--- a/opm/material/localad/Evaluation.hpp
+++ b/opm/material/localad/Evaluation.hpp
@@ -45,7 +45,7 @@ namespace LocalAd {
  * \brief Represents a function evaluation and its derivatives w.r.t. a fixed set of
  *        variables.
  */
-template <class ScalarT, class VarSetTag, int numVars>
+template <class ScalarT, int numVars>
 class Evaluation
 {
 public:
@@ -347,40 +347,40 @@ public:
     std::array<Scalar, size> derivatives;
 };
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-bool operator<(const ScalarA& a, const Evaluation<Scalar, VarSetTag, numVars> &b)
+template <class ScalarA, class Scalar, int numVars>
+bool operator<(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
 { return b > a; }
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-bool operator>(const ScalarA& a, const Evaluation<Scalar, VarSetTag, numVars> &b)
+template <class ScalarA, class Scalar, int numVars>
+bool operator>(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
 { return b < a; }
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-bool operator<=(const ScalarA& a, const Evaluation<Scalar, VarSetTag, numVars> &b)
+template <class ScalarA, class Scalar, int numVars>
+bool operator<=(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
 { return b >= a; }
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-bool operator>=(const ScalarA& a, const Evaluation<Scalar, VarSetTag, numVars> &b)
+template <class ScalarA, class Scalar, int numVars>
+bool operator>=(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
 { return b <= a; }
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-bool operator!=(const ScalarA& a, const Evaluation<Scalar, VarSetTag, numVars> &b)
+template <class ScalarA, class Scalar, int numVars>
+bool operator!=(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
 { return a != b.value; }
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> operator+(const ScalarA& a, const Evaluation<Scalar, VarSetTag, numVars> &b)
+template <class ScalarA, class Scalar, int numVars>
+Evaluation<Scalar, numVars> operator+(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result(b);
+    Evaluation<Scalar, numVars> result(b);
 
     result += a;
 
     return result;
 }
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> operator-(const ScalarA& a, const Evaluation<Scalar, VarSetTag, numVars> &b)
+template <class ScalarA, class Scalar, int numVars>
+Evaluation<Scalar, numVars> operator-(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = a - b.value;
     for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
@@ -389,25 +389,25 @@ Evaluation<Scalar, VarSetTag, numVars> operator-(const ScalarA& a, const Evaluat
     return result;
 }
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> operator/(const ScalarA& a, const Evaluation<Scalar, VarSetTag, numVars> &b)
+template <class ScalarA, class Scalar, int numVars>
+Evaluation<Scalar, numVars> operator/(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = a/b.value;
 
     // outer derivative
-    Scalar df_dg = - a/(b.value*b.value);
+    const Scalar& df_dg = - a/(b.value*b.value);
     for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
         result.derivatives[varIdx] = df_dg*b.derivatives[varIdx];
 
     return result;
 }
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> operator*(const ScalarA& a, const Evaluation<Scalar, VarSetTag, numVars> &b)
+template <class ScalarA, class Scalar, int numVars>
+Evaluation<Scalar, numVars> operator*(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = a*b.value;
     for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
@@ -416,8 +416,8 @@ Evaluation<Scalar, VarSetTag, numVars> operator*(const ScalarA& a, const Evaluat
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-std::ostream& operator<<(std::ostream& os, const Evaluation<Scalar, VarSetTag, numVars>& eval)
+template <class Scalar, int numVars>
+std::ostream& operator<<(std::ostream& os, const Evaluation<Scalar, numVars>& eval)
 {
     os << eval.value;
     return os;
@@ -452,13 +452,13 @@ std::ostream& operator<<(std::ostream& os, const Evaluation<Scalar, VarSetTag, n
 
 namespace Opm {
 namespace LocalAd {
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> abs(const Evaluation<Scalar, VarSetTag, numVars>&);
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> abs(const Evaluation<Scalar, numVars>&);
 }}
 
 namespace std {
-template <class Scalar, class VarSetTag, int numVars>
-const Opm::LocalAd::Evaluation<Scalar, VarSetTag, numVars> abs(const Opm::LocalAd::Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+const Opm::LocalAd::Evaluation<Scalar, numVars> abs(const Opm::LocalAd::Evaluation<Scalar, numVars>& x)
 { return Opm::LocalAd::abs(x); }
 
 } // namespace std
@@ -476,11 +476,11 @@ const Opm::LocalAd::Evaluation<Scalar, VarSetTag, numVars> abs(const Opm::LocalA
 #include <dune/common/ftraits.hh>
 
 namespace Dune {
-template <class Scalar, class VarSetTag, int numVars>
-struct FieldTraits<Opm::LocalAd::Evaluation<Scalar, VarSetTag, numVars> >
+template <class Scalar, int numVars>
+struct FieldTraits<Opm::LocalAd::Evaluation<Scalar, numVars> >
 {
 public:
-    typedef Opm::LocalAd::Evaluation<Scalar, VarSetTag, numVars> field_type;
+    typedef Opm::LocalAd::Evaluation<Scalar, numVars> field_type;
     // setting real_type to field_type here potentially leads to slightly worse
     // performance, but at least it makes things compile.
     typedef field_type real_type;

--- a/opm/material/localad/Evaluation.hpp
+++ b/opm/material/localad/Evaluation.hpp
@@ -45,11 +45,11 @@ namespace LocalAd {
  * \brief Represents a function evaluation and its derivatives w.r.t. a fixed set of
  *        variables.
  */
-template <class ScalarT, int numVars>
+template <class ValueT, int numVars>
 class Evaluation
 {
 public:
-    typedef ScalarT Scalar;
+    typedef ValueT ValueType;
 
     enum { size = numVars };
 
@@ -68,14 +68,16 @@ public:
     //
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
-    Evaluation(Scalar c)
+    template <class RhsValueType>
+    Evaluation(const RhsValueType& c)
     {
         value = c;
         std::fill(derivatives.begin(), derivatives.end(), 0.0);
     }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
-    static Evaluation createVariable(Scalar value, unsigned varPos)
+    template <class RhsValueType>
+    static Evaluation createVariable(const RhsValueType& value, unsigned varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size);
@@ -93,7 +95,8 @@ public:
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
-    static Evaluation createConstant(Scalar value)
+    template <class RhsValueType>
+    static Evaluation createConstant(const RhsValueType& value)
     {
         Evaluation result;
         result.value = value;
@@ -122,7 +125,8 @@ public:
         return *this;
     }
 
-    Evaluation& operator+=(Scalar other)
+    template <class RhsValueType>
+    Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         this->value += other;
@@ -140,7 +144,8 @@ public:
         return *this;
     }
 
-    Evaluation& operator-=(Scalar other)
+    template <class RhsValueType>
+    Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         this->value -= other;
@@ -152,20 +157,21 @@ public:
     {
         // while the values are multiplied, the derivatives follow the product rule,
         // i.e., (u*v)' = (v'u + u'v).
-        Scalar u = this->value;
-        Scalar v = other.value;
-        this->value *= v;
+        const ValueType& u = this->value;
+        const ValueType& v = other.value;
         for (unsigned varIdx = 0; varIdx < size; ++varIdx) {
-            Scalar uPrime = this->derivatives[varIdx];
-            Scalar vPrime = other.derivatives[varIdx];
+            const ValueType& uPrime = this->derivatives[varIdx];
+            const ValueType& vPrime = other.derivatives[varIdx];
 
             this->derivatives[varIdx] = (v*uPrime + u*vPrime);
         }
+        this->value *= v;
 
         return *this;
     }
 
-    Evaluation& operator*=(Scalar other)
+    template <class RhsValueType>
+    Evaluation& operator*=(const RhsValueType& other)
     {
         // values and derivatives are multiplied
         this->value *= other;
@@ -179,26 +185,26 @@ public:
     {
         // values are divided, derivatives follow the rule for division, i.e., (u/v)' = (v'u -
         // u'v)/v^2.
-        Scalar u = this->value;
-        Scalar v = other.value;
-        this->value /= v;
+        const ValueType& u = this->value;
+        const ValueType& v = other.value;
         for (unsigned varIdx = 0; varIdx < size; ++varIdx) {
-            Scalar uPrime = this->derivatives[varIdx];
-            Scalar vPrime = other.derivatives[varIdx];
+            const ValueType& uPrime = this->derivatives[varIdx];
+            const ValueType& vPrime = other.derivatives[varIdx];
 
             this->derivatives[varIdx] = (v*uPrime - u*vPrime)/(v*v);
         }
+        this->value /= v;
 
         return *this;
     }
 
-    Evaluation& operator/=(Scalar other)
+    template <class RhsValueType>
+    Evaluation& operator/=(const RhsValueType& other)
     {
         // values and derivatives are divided
-        other = 1.0/other;
-        this->value *= other;
+        this->value /= other;
         for (unsigned varIdx = 0; varIdx < size; ++varIdx)
-            this->derivatives[varIdx] *= other;
+            this->derivatives[varIdx] /= other;
 
         return *this;
     }
@@ -210,7 +216,8 @@ public:
         return result;
     }
 
-    Evaluation operator+(Scalar other) const
+    template <class RhsValueType>
+    Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
         result += other;
@@ -224,7 +231,8 @@ public:
         return result;
     }
 
-    Evaluation operator-(Scalar other) const
+    template <class RhsValueType>
+    Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
         result -= other;
@@ -249,7 +257,8 @@ public:
         return result;
     }
 
-    Evaluation operator*(Scalar other) const
+    template <class RhsValueType>
+    Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
         result *= other;
@@ -263,14 +272,16 @@ public:
         return result;
     }
 
-    Evaluation operator/(Scalar other) const
+    template <class RhsValueType>
+    Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
         result /= other;
         return result;
     }
 
-    Evaluation& operator=(Scalar other)
+    template <class RhsValueType>
+    Evaluation& operator=(const RhsValueType& other)
     {
         this->value = other;
         std::fill(this->derivatives.begin(), this->derivatives.end(), 0.0);
@@ -285,7 +296,8 @@ public:
         return *this;
     }
 
-    bool operator==(Scalar other) const
+    template <class RhsValueType>
+    bool operator==(const RhsValueType& other) const
     { return this->value == other; }
 
     bool operator==(const Evaluation& other) const
@@ -300,87 +312,76 @@ public:
         return true;
     }
 
-    bool isSame(const Evaluation& other, Scalar tolerance) const
-    {
-        Scalar value_diff = other.value - other.value;
-        if (std::abs(value_diff) > tolerance && std::abs(value_diff)/tolerance > 1.0)
-            return false;
-
-        for (unsigned varIdx = 0; varIdx < size; ++varIdx) {
-            Scalar deriv_diff = other.derivatives[varIdx] - this->derivatives[varIdx];
-            if (std::abs(deriv_diff) > tolerance && std::abs(deriv_diff)/tolerance > 1.0)
-                return false;
-        }
-
-        return true;
-    }
-
     bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
-    bool operator>(Scalar other) const
+    template <class RhsValueType>
+    bool operator>(RhsValueType other) const
     { return this->value > other; }
 
     bool operator>(const Evaluation& other) const
     { return this->value > other.value; }
 
-    bool operator<(Scalar other) const
+    template <class RhsValueType>
+    bool operator<(RhsValueType other) const
     { return this->value < other; }
 
     bool operator<(const Evaluation& other) const
     { return this->value < other.value; }
 
-    bool operator>=(Scalar other) const
+    template <class RhsValueType>
+    bool operator>=(RhsValueType other) const
     { return this->value >= other; }
 
     bool operator>=(const Evaluation& other) const
     { return this->value >= other.value; }
 
-    bool operator<=(Scalar other) const
+    template <class RhsValueType>
+    bool operator<=(RhsValueType other) const
     { return this->value <= other; }
 
     bool operator<=(const Evaluation& other) const
     { return this->value <= other.value; }
 
     // maybe this should be made 'private'...
-    Scalar value;
-    std::array<Scalar, size> derivatives;
+    ValueType value;
+    std::array<ValueType, size> derivatives;
 };
 
-template <class ScalarA, class Scalar, int numVars>
-bool operator<(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
+template <class RhsValueType, class ValueType, int numVars>
+bool operator<(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 { return b > a; }
 
-template <class ScalarA, class Scalar, int numVars>
-bool operator>(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
+template <class RhsValueType, class ValueType, int numVars>
+bool operator>(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 { return b < a; }
 
-template <class ScalarA, class Scalar, int numVars>
-bool operator<=(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
+template <class RhsValueType, class ValueType, int numVars>
+bool operator<=(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 { return b >= a; }
 
-template <class ScalarA, class Scalar, int numVars>
-bool operator>=(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
+template <class RhsValueType, class ValueType, int numVars>
+bool operator>=(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 { return b <= a; }
 
-template <class ScalarA, class Scalar, int numVars>
-bool operator!=(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
+template <class RhsValueType, class ValueType, int numVars>
+bool operator!=(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 { return a != b.value; }
 
-template <class ScalarA, class Scalar, int numVars>
-Evaluation<Scalar, numVars> operator+(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
+template <class RhsValueType, class ValueType, int numVars>
+Evaluation<ValueType, numVars> operator+(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 {
-    Evaluation<Scalar, numVars> result(b);
+    Evaluation<ValueType, numVars> result(b);
 
     result += a;
 
     return result;
 }
 
-template <class ScalarA, class Scalar, int numVars>
-Evaluation<Scalar, numVars> operator-(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
+template <class RhsValueType, class ValueType, int numVars>
+Evaluation<ValueType, numVars> operator-(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 {
-    Evaluation<Scalar, numVars> result;
+    Evaluation<ValueType, numVars> result;
 
     result.value = a - b.value;
     for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
@@ -389,25 +390,25 @@ Evaluation<Scalar, numVars> operator-(const ScalarA& a, const Evaluation<Scalar,
     return result;
 }
 
-template <class ScalarA, class Scalar, int numVars>
-Evaluation<Scalar, numVars> operator/(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
+template <class RhsValueType, class ValueType, int numVars>
+Evaluation<ValueType, numVars> operator/(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 {
-    Evaluation<Scalar, numVars> result;
+    Evaluation<ValueType, numVars> result;
 
     result.value = a/b.value;
 
     // outer derivative
-    const Scalar& df_dg = - a/(b.value*b.value);
+    const ValueType& df_dg = - a/(b.value*b.value);
     for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
         result.derivatives[varIdx] = df_dg*b.derivatives[varIdx];
 
     return result;
 }
 
-template <class ScalarA, class Scalar, int numVars>
-Evaluation<Scalar, numVars> operator*(const ScalarA& a, const Evaluation<Scalar, numVars> &b)
+template <class RhsValueType, class ValueType, int numVars>
+Evaluation<ValueType, numVars> operator*(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 {
-    Evaluation<Scalar, numVars> result;
+    Evaluation<ValueType, numVars> result;
 
     result.value = a*b.value;
     for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
@@ -416,8 +417,8 @@ Evaluation<Scalar, numVars> operator*(const ScalarA& a, const Evaluation<Scalar,
     return result;
 }
 
-template <class Scalar, int numVars>
-std::ostream& operator<<(std::ostream& os, const Evaluation<Scalar, numVars>& eval)
+template <class ValueType, int numVars>
+std::ostream& operator<<(std::ostream& os, const Evaluation<ValueType, numVars>& eval)
 {
     os << eval.value;
     return os;
@@ -452,13 +453,13 @@ std::ostream& operator<<(std::ostream& os, const Evaluation<Scalar, numVars>& ev
 
 namespace Opm {
 namespace LocalAd {
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> abs(const Evaluation<Scalar, numVars>&);
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> abs(const Evaluation<ValueType, numVars>&);
 }}
 
 namespace std {
-template <class Scalar, int numVars>
-const Opm::LocalAd::Evaluation<Scalar, numVars> abs(const Opm::LocalAd::Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+const Opm::LocalAd::Evaluation<ValueType, numVars> abs(const Opm::LocalAd::Evaluation<ValueType, numVars>& x)
 { return Opm::LocalAd::abs(x); }
 
 } // namespace std
@@ -476,11 +477,11 @@ const Opm::LocalAd::Evaluation<Scalar, numVars> abs(const Opm::LocalAd::Evaluati
 #include <dune/common/ftraits.hh>
 
 namespace Dune {
-template <class Scalar, int numVars>
-struct FieldTraits<Opm::LocalAd::Evaluation<Scalar, numVars> >
+template <class ValueType, int numVars>
+struct FieldTraits<Opm::LocalAd::Evaluation<ValueType, numVars> >
 {
 public:
-    typedef Opm::LocalAd::Evaluation<Scalar, numVars> field_type;
+    typedef Opm::LocalAd::Evaluation<ValueType, numVars> field_type;
     // setting real_type to field_type here potentially leads to slightly worse
     // performance, but at least it makes things compile.
     typedef field_type real_type;

--- a/opm/material/localad/Math.hpp
+++ b/opm/material/localad/Math.hpp
@@ -39,19 +39,18 @@
 namespace Opm {
 namespace LocalAd {
 // provide some algebraic functions
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> abs(const Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> abs(const Evaluation<ValueType, numVars>& x)
 {
-    Evaluation<Scalar, numVars> result;
+    Evaluation<ValueType, numVars> result;
 
-    result.value = std::abs(x.value);
-
-    // derivatives use the chain rule
     if (x.value < 0.0) {
+        result.value = -x.value;
         for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
             result.derivatives[curVarIdx] = -x.derivatives[curVarIdx];
     }
     else {
+        result.value = x.value;
         for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
             result.derivatives[curVarIdx] = x.derivatives[curVarIdx];
     }
@@ -59,11 +58,11 @@ Evaluation<Scalar, numVars> abs(const Evaluation<Scalar, numVars>& x)
     return result;
 }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> min(const Evaluation<Scalar, numVars>& x1,
-                                const Evaluation<Scalar, numVars>& x2)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> min(const Evaluation<ValueType, numVars>& x1,
+                                   const Evaluation<ValueType, numVars>& x2)
 {
-    Evaluation<Scalar, numVars> result;
+    Evaluation<ValueType, numVars> result;
 
     if (x1.value < x2.value) {
         result.value = x1.value;
@@ -83,11 +82,11 @@ Evaluation<Scalar, numVars> min(const Evaluation<Scalar, numVars>& x1,
     return result;
 }
 
-template <class ScalarA, class Scalar, int numVars>
-Evaluation<Scalar, numVars> min(ScalarA x1,
-                                const Evaluation<Scalar, numVars>& x2)
+template <class Arg1ValueType, class ValueType, int numVars>
+Evaluation<ValueType, numVars> min(const Arg1ValueType& x1,
+                                   const Evaluation<ValueType, numVars>& x2)
 {
-    Evaluation<Scalar, numVars> result;
+    Evaluation<ValueType, numVars> result;
 
     if (x1 < x2.value) {
         result.value = x1;
@@ -107,16 +106,16 @@ Evaluation<Scalar, numVars> min(ScalarA x1,
     return result;
 }
 
-template <class Arg2Scalar, class Scalar, int numVars>
-Evaluation<Scalar, numVars> min(const Evaluation<Scalar, numVars>& x1,
-                                const Arg2Scalar& x2)
+template <class Arg2ValueType, class ValueType, int numVars>
+Evaluation<ValueType, numVars> min(const Evaluation<ValueType, numVars>& x1,
+                                   const Arg2ValueType& x2)
 { return min(x2, x1); }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> max(const Evaluation<Scalar, numVars>& x1,
-                                const Evaluation<Scalar, numVars>& x2)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> max(const Evaluation<ValueType, numVars>& x1,
+                                   const Evaluation<ValueType, numVars>& x2)
 {
-    Evaluation<Scalar, numVars> result;
+    Evaluation<ValueType, numVars> result;
 
     if (x1.value > x2.value) {
         result.value = x1.value;
@@ -136,11 +135,11 @@ Evaluation<Scalar, numVars> max(const Evaluation<Scalar, numVars>& x1,
     return result;
 }
 
-template <class Arg1Scalar, class Scalar, int numVars>
-Evaluation<Scalar, numVars> max(const Arg1Scalar& x1,
-                                const Evaluation<Scalar, numVars>& x2)
+template <class Arg1ValueType, class ValueType, int numVars>
+Evaluation<ValueType, numVars> max(const Arg1ValueType& x1,
+                                   const Evaluation<ValueType, numVars>& x2)
 {
-    Evaluation<Scalar, numVars> result;
+    Evaluation<ValueType, numVars> result;
 
     if (x1 > x2.value) {
         result.value = x1;
@@ -160,52 +159,58 @@ Evaluation<Scalar, numVars> max(const Arg1Scalar& x1,
     return result;
 }
 
-template <class Arg2Scalar, class Scalar, int numVars>
-Evaluation<Scalar, numVars> max(const Evaluation<Scalar, numVars>& x1,
-                                const Arg2Scalar& x2)
+template <class Arg2ValueType, class ValueType, int numVars>
+Evaluation<ValueType, numVars> max(const Evaluation<ValueType, numVars>& x1,
+                                   const Arg2ValueType& x2)
 { return max(x2, x1); }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> tan(const Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> tan(const Evaluation<ValueType, numVars>& x)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    const Scalar& tmp = std::tan(x.value);
+    Evaluation<ValueType, numVars> result;
+
+    const ValueType& tmp = ValueTypeToolbox::tan(x.value);
     result.value = tmp;
 
     // derivatives use the chain rule
-    Scalar df_dx = 1 + tmp*tmp;
+    const ValueType& df_dx = 1 + tmp*tmp;
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
         result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
 
     return result;
 }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> atan(const Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> atan(const Evaluation<ValueType, numVars>& x)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    result.value = std::atan(x.value);
+    Evaluation<ValueType, numVars> result;
+
+    result.value = ValueTypeToolbox::atan(x.value);
 
     // derivatives use the chain rule
-    Scalar df_dx = 1/(1 + x.value*x.value);
+    const ValueType& df_dx = 1/(1 + x.value*x.value);
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
         result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
 
     return result;
 }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> atan2(const Evaluation<Scalar, numVars>& x,
-                                  const Evaluation<Scalar, numVars>& y)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> atan2(const Evaluation<ValueType, numVars>& x,
+                                     const Evaluation<ValueType, numVars>& y)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    result.value = std::atan2(x.value, y.value);
+    Evaluation<ValueType, numVars> result;
+
+    result.value = ValueTypeToolbox::atan2(x.value, y.value);
 
     // derivatives use the chain rule
-    Scalar alpha = 1/(1 + (x.value*x.value)/(y.value*y.value));
+    const ValueType& alpha = 1/(1 + (x.value*x.value)/(y.value*y.value));
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx) {
         result.derivatives[curVarIdx] =
             alpha
@@ -216,76 +221,86 @@ Evaluation<Scalar, numVars> atan2(const Evaluation<Scalar, numVars>& x,
     return result;
 }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> sin(const Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> sin(const Evaluation<ValueType, numVars>& x)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    result.value = std::sin(x.value);
+    Evaluation<ValueType, numVars> result;
+
+    result.value = ValueTypeToolbox::sin(x.value);
 
     // derivatives use the chain rule
-    Scalar df_dx = std::cos(x.value);
+    const ValueType& df_dx = ValueTypeToolbox::cos(x.value);
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
         result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
 
     return result;
 }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> asin(const Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> asin(const Evaluation<ValueType, numVars>& x)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    result.value = std::asin(x.value);
+    Evaluation<ValueType, numVars> result;
+
+    result.value = ValueTypeToolbox::asin(x.value);
 
     // derivatives use the chain rule
-    Scalar df_dx = 1.0/std::sqrt(1 - x.value*x.value);
+    const ValueType& df_dx = 1.0/ValueTypeToolbox::sqrt(1 - x.value*x.value);
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
         result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
 
     return result;
 }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> cos(const Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> cos(const Evaluation<ValueType, numVars>& x)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    result.value = std::cos(x.value);
+    Evaluation<ValueType, numVars> result;
+
+    result.value = ValueTypeToolbox::cos(x.value);
 
     // derivatives use the chain rule
-    Scalar df_dx = -std::sin(x.value);
+    const ValueType& df_dx = -ValueTypeToolbox::sin(x.value);
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
         result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
 
     return result;
 }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> acos(const Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> acos(const Evaluation<ValueType, numVars>& x)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    result.value = std::acos(x.value);
+    Evaluation<ValueType, numVars> result;
+
+    result.value = ValueTypeToolbox::acos(x.value);
 
     // derivatives use the chain rule
-    Scalar df_dx = - 1.0/std::sqrt(1 - x.value*x.value);
+    const ValueType& df_dx = - 1.0/ValueTypeToolbox::sqrt(1 - x.value*x.value);
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
         result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
 
     return result;
 }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> sqrt(const Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> sqrt(const Evaluation<ValueType, numVars>& x)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    Scalar sqrt_x = std::sqrt(x.value);
+    Evaluation<ValueType, numVars> result;
+
+    const ValueType& sqrt_x = ValueTypeToolbox::sqrt(x.value);
     result.value = sqrt_x;
 
     // derivatives use the chain rule
-    Scalar df_dx = 0.5/sqrt_x;
+    ValueType df_dx = 0.5/sqrt_x;
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx) {
         result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
     }
@@ -293,16 +308,17 @@ Evaluation<Scalar, numVars> sqrt(const Evaluation<Scalar, numVars>& x)
     return result;
 }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> exp(const Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> exp(const Evaluation<ValueType, numVars>& x)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
+    Evaluation<ValueType, numVars> result;
 
-    Scalar exp_x = std::exp(x.value);
+    const ValueType& exp_x = ValueTypeToolbox::exp(x.value);
     result.value = exp_x;
 
     // derivatives use the chain rule
-    Scalar df_dx = exp_x;
+    const ValueType& df_dx = exp_x;
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
         result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
 
@@ -310,17 +326,18 @@ Evaluation<Scalar, numVars> exp(const Evaluation<Scalar, numVars>& x)
 }
 
 // exponentiation of arbitrary base with a fixed constant
-template <class Scalar, int numVars, class ExpType>
-Evaluation<Scalar, numVars> pow(const Evaluation<Scalar, numVars>& base,
-                                const ExpType& exp)
+template <class ValueType, int numVars, class ExpType>
+Evaluation<ValueType, numVars> pow(const Evaluation<ValueType, numVars>& base,
+                                   const ExpType& exp)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
+    Evaluation<ValueType, numVars> result;
 
-    Scalar pow_x = std::pow(base.value, exp);
+    const ValueType& pow_x = ValueTypeToolbox::pow(base.value, exp);
     result.value = pow_x;
 
     // derivatives use the chain rule
-    Scalar df_dx = pow_x/base.value*exp;
+    const ValueType& df_dx = pow_x/base.value*exp;
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
         result.derivatives[curVarIdx] = df_dx*base.derivatives[curVarIdx];
 
@@ -328,17 +345,19 @@ Evaluation<Scalar, numVars> pow(const Evaluation<Scalar, numVars>& base,
 }
 
 // exponentiation of constant base with an arbitrary exponent
-template <class BaseType, class Scalar, int numVars>
-Evaluation<Scalar, numVars> pow(const BaseType& base,
-                                const Evaluation<Scalar, numVars>& exp)
+template <class BaseType, class ValueType, int numVars>
+Evaluation<ValueType, numVars> pow(const BaseType& base,
+                                   const Evaluation<ValueType, numVars>& exp)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    Scalar lnBase = std::log(base);
-    result.value = std::exp(lnBase*exp.value);
+    Evaluation<ValueType, numVars> result;
+
+    const ValueType& lnBase = ValueTypeToolbox::log(base);
+    result.value = ValueTypeToolbox::exp(lnBase*exp.value);
 
     // derivatives use the chain rule
-    Scalar df_dx = lnBase*result.value;
+    const ValueType& df_dx = lnBase*result.value;
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
         result.derivatives[curVarIdx] = df_dx*exp.derivatives[curVarIdx];
 
@@ -347,38 +366,42 @@ Evaluation<Scalar, numVars> pow(const BaseType& base,
 
 // this is the most expensive power function. Computationally it is pretty expensive, so
 // one of the above two variants above should be preferred if possible.
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> pow(const Evaluation<Scalar, numVars>& base,
-                                const Evaluation<Scalar, numVars>& exp)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> pow(const Evaluation<ValueType, numVars>& base,
+                                   const Evaluation<ValueType, numVars>& exp)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    Scalar valuePow = std::pow(base.value, exp.value);
+    Evaluation<ValueType, numVars> result;
+
+    ValueType valuePow = ValueTypeToolbox::pow(base.value, exp.value);
     result.value = valuePow;
 
     // use the chain rule for the derivatives. since both, the base and the exponent can
     // potentially depend on the variable set, calculating these is quite elaborate...
-    Scalar f = base.value;
-    Scalar g = exp.value;
-    Scalar logF = std::log(f);
+    const ValueType& f = base.value;
+    const ValueType& g = exp.value;
+    const ValueType& logF = ValueTypeToolbox::log(f);
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx) {
-        Scalar fPrime = base.derivatives[curVarIdx];
-        Scalar gPrime = exp.derivatives[curVarIdx];
+        const ValueType& fPrime = base.derivatives[curVarIdx];
+        const ValueType& gPrime = exp.derivatives[curVarIdx];
         result.derivatives[curVarIdx] = (g*fPrime/f + logF*gPrime) * valuePow;
     }
 
     return result;
 }
 
-template <class Scalar, int numVars>
-Evaluation<Scalar, numVars> log(const Evaluation<Scalar, numVars>& x)
+template <class ValueType, int numVars>
+Evaluation<ValueType, numVars> log(const Evaluation<ValueType, numVars>& x)
 {
-    Evaluation<Scalar, numVars> result;
+    typedef MathToolbox<ValueType> ValueTypeToolbox;
 
-    result.value = std::log(x.value);
+    Evaluation<ValueType, numVars> result;
+
+    result.value = ValueTypeToolbox::log(x.value);
 
     // derivatives use the chain rule
-    Scalar df_dx = 1/x.value;
+    const ValueType& df_dx = 1/x.value;
     for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
         result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
 
@@ -389,21 +412,26 @@ Evaluation<Scalar, numVars> log(const Evaluation<Scalar, numVars>& x)
 
 // a kind of traits class for the automatic differentiation case. (The toolbox for the
 // scalar case is provided by the MathToolbox.hpp header file.)
-template <class ScalarT, int numVars>
-struct MathToolbox<Opm::LocalAd::Evaluation<ScalarT, numVars> >
+template <class ValueT, int numVars>
+struct MathToolbox<Opm::LocalAd::Evaluation<ValueT, numVars> >
 {
 private:
 public:
-    typedef ScalarT Scalar;
-    typedef Opm::LocalAd::Evaluation<ScalarT, numVars> Evaluation;
+    typedef ValueT ValueType;
+    typedef Opm::MathToolbox<ValueType> InnerToolbox;
+    typedef typename InnerToolbox::Scalar Scalar;
+    typedef Opm::LocalAd::Evaluation<ValueType, numVars> Evaluation;
 
-    static Scalar value(const Evaluation& eval)
+    static ValueType value(const Evaluation& eval)
     { return eval.value; }
 
-    static Evaluation createConstant(Scalar value)
+    static decltype(InnerToolbox::scalarValue(0.0)) scalarValue(const Evaluation& eval)
+    { return InnerToolbox::scalarValue(eval.value); }
+
+    static Evaluation createConstant(ValueType value)
     { return Evaluation::createConstant(value); }
 
-    static Evaluation createVariable(Scalar value, int varIdx)
+    static Evaluation createVariable(ValueType value, int varIdx)
     { return Evaluation::createVariable(value, varIdx); }
 
     template <class LhsEval>
@@ -427,15 +455,15 @@ public:
     // comparison
     static bool isSame(const Evaluation& a, const Evaluation& b, Scalar tolerance)
     {
-        typedef MathToolbox<Scalar> ScalarToolbox;
+        typedef MathToolbox<ValueType> ValueTypeToolbox;
 
         // make sure that the value of the evaluation is identical
-        if (!ScalarToolbox::isSame(a.value, b.value, tolerance))
+        if (!ValueTypeToolbox::isSame(a.value, b.value, tolerance))
             return false;
 
         // make sure that the derivatives are identical
         for (unsigned curVarIdx = 0; curVarIdx < numVars; ++curVarIdx)
-            if (!ScalarToolbox::isSame(a.derivatives[curVarIdx], b.derivatives[curVarIdx], tolerance))
+            if (!ValueTypeToolbox::isSame(a.derivatives[curVarIdx], b.derivatives[curVarIdx], tolerance))
                 return false;
 
         return true;
@@ -483,10 +511,12 @@ public:
     static Evaluation log(const Evaluation& arg)
     { return Opm::LocalAd::log(arg); }
 
-    static Evaluation pow(const Evaluation& arg1, typename Evaluation::Scalar arg2)
+    template <class RhsValueType>
+    static Evaluation pow(const Evaluation& arg1, const RhsValueType& arg2)
     { return Opm::LocalAd::pow(arg1, arg2); }
 
-    static Evaluation pow(typename Evaluation::Scalar arg1, const Evaluation& arg2)
+    template <class RhsValueType>
+    static Evaluation pow(const RhsValueType& arg1, const Evaluation& arg2)
     { return Opm::LocalAd::pow(arg1, arg2); }
 
     static Evaluation pow(const Evaluation& arg1, const Evaluation& arg2)

--- a/opm/material/localad/Math.hpp
+++ b/opm/material/localad/Math.hpp
@@ -39,10 +39,10 @@
 namespace Opm {
 namespace LocalAd {
 // provide some algebraic functions
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> abs(const Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> abs(const Evaluation<Scalar, numVars>& x)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = std::abs(x.value);
 
@@ -59,11 +59,11 @@ Evaluation<Scalar, VarSetTag, numVars> abs(const Evaluation<Scalar, VarSetTag, n
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> min(const Evaluation<Scalar, VarSetTag, numVars>& x1,
-                                           const Evaluation<Scalar, VarSetTag, numVars>& x2)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> min(const Evaluation<Scalar, numVars>& x1,
+                                const Evaluation<Scalar, numVars>& x2)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     if (x1.value < x2.value) {
         result.value = x1.value;
@@ -83,11 +83,11 @@ Evaluation<Scalar, VarSetTag, numVars> min(const Evaluation<Scalar, VarSetTag, n
     return result;
 }
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> min(ScalarA x1,
-                                           const Evaluation<Scalar, VarSetTag, numVars>& x2)
+template <class ScalarA, class Scalar, int numVars>
+Evaluation<Scalar, numVars> min(ScalarA x1,
+                                const Evaluation<Scalar, numVars>& x2)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     if (x1 < x2.value) {
         result.value = x1;
@@ -107,16 +107,16 @@ Evaluation<Scalar, VarSetTag, numVars> min(ScalarA x1,
     return result;
 }
 
-template <class ScalarB, class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> min(const Evaluation<Scalar, VarSetTag, numVars>& x2,
-                                           ScalarB x1)
-{ return min(x1, x2); }
+template <class Arg2Scalar, class Scalar, int numVars>
+Evaluation<Scalar, numVars> min(const Evaluation<Scalar, numVars>& x1,
+                                const Arg2Scalar& x2)
+{ return min(x2, x1); }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> max(const Evaluation<Scalar, VarSetTag, numVars>& x1,
-                                           const Evaluation<Scalar, VarSetTag, numVars>& x2)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> max(const Evaluation<Scalar, numVars>& x1,
+                                const Evaluation<Scalar, numVars>& x2)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     if (x1.value > x2.value) {
         result.value = x1.value;
@@ -136,11 +136,11 @@ Evaluation<Scalar, VarSetTag, numVars> max(const Evaluation<Scalar, VarSetTag, n
     return result;
 }
 
-template <class ScalarA, class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> max(ScalarA x1,
-                                           const Evaluation<Scalar, VarSetTag, numVars>& x2)
+template <class Arg1Scalar, class Scalar, int numVars>
+Evaluation<Scalar, numVars> max(const Arg1Scalar& x1,
+                                const Evaluation<Scalar, numVars>& x2)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     if (x1 > x2.value) {
         result.value = x1;
@@ -160,17 +160,17 @@ Evaluation<Scalar, VarSetTag, numVars> max(ScalarA x1,
     return result;
 }
 
-template <class ScalarB, class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> max(const Evaluation<Scalar, VarSetTag, numVars>& x2,
-                                           ScalarB x1)
-{ return max(x1, x2); }
+template <class Arg2Scalar, class Scalar, int numVars>
+Evaluation<Scalar, numVars> max(const Evaluation<Scalar, numVars>& x1,
+                                const Arg2Scalar& x2)
+{ return max(x2, x1); }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> tan(const Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> tan(const Evaluation<Scalar, numVars>& x)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
-    Scalar tmp = std::tan(x.value);
+    const Scalar& tmp = std::tan(x.value);
     result.value = tmp;
 
     // derivatives use the chain rule
@@ -181,10 +181,10 @@ Evaluation<Scalar, VarSetTag, numVars> tan(const Evaluation<Scalar, VarSetTag, n
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> atan(const Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> atan(const Evaluation<Scalar, numVars>& x)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = std::atan(x.value);
 
@@ -196,11 +196,11 @@ Evaluation<Scalar, VarSetTag, numVars> atan(const Evaluation<Scalar, VarSetTag, 
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> atan2(const Evaluation<Scalar, VarSetTag, numVars>& x,
-                                             const Evaluation<Scalar, VarSetTag, numVars>& y)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> atan2(const Evaluation<Scalar, numVars>& x,
+                                  const Evaluation<Scalar, numVars>& y)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = std::atan2(x.value, y.value);
 
@@ -216,10 +216,10 @@ Evaluation<Scalar, VarSetTag, numVars> atan2(const Evaluation<Scalar, VarSetTag,
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> sin(const Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> sin(const Evaluation<Scalar, numVars>& x)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = std::sin(x.value);
 
@@ -231,10 +231,10 @@ Evaluation<Scalar, VarSetTag, numVars> sin(const Evaluation<Scalar, VarSetTag, n
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> asin(const Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> asin(const Evaluation<Scalar, numVars>& x)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = std::asin(x.value);
 
@@ -246,10 +246,10 @@ Evaluation<Scalar, VarSetTag, numVars> asin(const Evaluation<Scalar, VarSetTag, 
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> cos(const Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> cos(const Evaluation<Scalar, numVars>& x)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = std::cos(x.value);
 
@@ -261,10 +261,10 @@ Evaluation<Scalar, VarSetTag, numVars> cos(const Evaluation<Scalar, VarSetTag, n
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> acos(const Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> acos(const Evaluation<Scalar, numVars>& x)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = std::acos(x.value);
 
@@ -276,10 +276,10 @@ Evaluation<Scalar, VarSetTag, numVars> acos(const Evaluation<Scalar, VarSetTag, 
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> sqrt(const Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> sqrt(const Evaluation<Scalar, numVars>& x)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     Scalar sqrt_x = std::sqrt(x.value);
     result.value = sqrt_x;
@@ -293,10 +293,10 @@ Evaluation<Scalar, VarSetTag, numVars> sqrt(const Evaluation<Scalar, VarSetTag, 
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> exp(const Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> exp(const Evaluation<Scalar, numVars>& x)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     Scalar exp_x = std::exp(x.value);
     result.value = exp_x;
@@ -310,10 +310,11 @@ Evaluation<Scalar, VarSetTag, numVars> exp(const Evaluation<Scalar, VarSetTag, n
 }
 
 // exponentiation of arbitrary base with a fixed constant
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> pow(const Evaluation<Scalar, VarSetTag, numVars>& base, Scalar exp)
+template <class Scalar, int numVars, class ExpType>
+Evaluation<Scalar, numVars> pow(const Evaluation<Scalar, numVars>& base,
+                                const ExpType& exp)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     Scalar pow_x = std::pow(base.value, exp);
     result.value = pow_x;
@@ -327,10 +328,11 @@ Evaluation<Scalar, VarSetTag, numVars> pow(const Evaluation<Scalar, VarSetTag, n
 }
 
 // exponentiation of constant base with an arbitrary exponent
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> pow(Scalar base, const Evaluation<Scalar, VarSetTag, numVars>& exp)
+template <class BaseType, class Scalar, int numVars>
+Evaluation<Scalar, numVars> pow(const BaseType& base,
+                                const Evaluation<Scalar, numVars>& exp)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     Scalar lnBase = std::log(base);
     result.value = std::exp(lnBase*exp.value);
@@ -345,10 +347,11 @@ Evaluation<Scalar, VarSetTag, numVars> pow(Scalar base, const Evaluation<Scalar,
 
 // this is the most expensive power function. Computationally it is pretty expensive, so
 // one of the above two variants above should be preferred if possible.
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> pow(const Evaluation<Scalar, VarSetTag, numVars>& base, const Evaluation<Scalar, VarSetTag, numVars>& exp)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> pow(const Evaluation<Scalar, numVars>& base,
+                                const Evaluation<Scalar, numVars>& exp)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     Scalar valuePow = std::pow(base.value, exp.value);
     result.value = valuePow;
@@ -367,10 +370,10 @@ Evaluation<Scalar, VarSetTag, numVars> pow(const Evaluation<Scalar, VarSetTag, n
     return result;
 }
 
-template <class Scalar, class VarSetTag, int numVars>
-Evaluation<Scalar, VarSetTag, numVars> log(const Evaluation<Scalar, VarSetTag, numVars>& x)
+template <class Scalar, int numVars>
+Evaluation<Scalar, numVars> log(const Evaluation<Scalar, numVars>& x)
 {
-    Evaluation<Scalar, VarSetTag, numVars> result;
+    Evaluation<Scalar, numVars> result;
 
     result.value = std::log(x.value);
 
@@ -386,13 +389,13 @@ Evaluation<Scalar, VarSetTag, numVars> log(const Evaluation<Scalar, VarSetTag, n
 
 // a kind of traits class for the automatic differentiation case. (The toolbox for the
 // scalar case is provided by the MathToolbox.hpp header file.)
-template <class ScalarT, class VariableSetTag, int numVars>
-struct MathToolbox<Opm::LocalAd::Evaluation<ScalarT, VariableSetTag, numVars>>
+template <class ScalarT, int numVars>
+struct MathToolbox<Opm::LocalAd::Evaluation<ScalarT, numVars> >
 {
 private:
 public:
     typedef ScalarT Scalar;
-    typedef Opm::LocalAd::Evaluation<ScalarT, VariableSetTag, numVars> Evaluation;
+    typedef Opm::LocalAd::Evaluation<ScalarT, numVars> Evaluation;
 
     static Scalar value(const Evaluation& eval)
     { return eval.value; }

--- a/opm/material/localad/Math.hpp
+++ b/opm/material/localad/Math.hpp
@@ -424,13 +424,6 @@ public:
     toLhs(const Evaluation& eval)
     { return eval.value; }
 
-    static const Evaluation passThroughOrCreateConstant(Scalar value)
-    { return createConstant(value); }
-
-    static const Evaluation& passThroughOrCreateConstant(const Evaluation& eval)
-    { return eval; }
-
-
     // comparison
     static bool isSame(const Evaluation& a, const Evaluation& b, Scalar tolerance)
     {

--- a/opm/material/localad/Math.hpp
+++ b/opm/material/localad/Math.hpp
@@ -431,6 +431,23 @@ public:
     { return eval; }
 
 
+    // comparison
+    static bool isSame(const Evaluation& a, const Evaluation& b, Scalar tolerance)
+    {
+        typedef MathToolbox<Scalar> ScalarToolbox;
+
+        // make sure that the value of the evaluation is identical
+        if (!ScalarToolbox::isSame(a.value, b.value, tolerance))
+            return false;
+
+        // make sure that the derivatives are identical
+        for (unsigned curVarIdx = 0; curVarIdx < numVars; ++curVarIdx)
+            if (!ScalarToolbox::isSame(a.derivatives[curVarIdx], b.derivatives[curVarIdx], tolerance))
+                return false;
+
+        return true;
+    }
+
     // arithmetic functions
     template <class Arg1Eval, class Arg2Eval>
     static Evaluation max(const Arg1Eval& arg1, const Arg2Eval& arg2)

--- a/tests/test_2dtables.cpp
+++ b/tests/test_2dtables.cpp
@@ -32,6 +32,10 @@
 #include <opm/material/common/UniformXTabulated2DFunction.hpp>
 #include <opm/material/common/UniformTabulated2DFunction.hpp>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 #include <memory>
 #include <cmath>
 #include <iostream>
@@ -382,11 +386,14 @@ inline int testAll( const typename TestType::Scalar tolerance = 1e-6 )
 }
 
 
-int main()
+int main(int argc, char **argv)
 {
-    if( testAll< Test<double> >( 1e-12 ) )
+    Dune::MPIHelper::instance(argc, argv);
+
+    if (testAll<Test<double> >(1e-12))
         return 1;
-    if( testAll< Test<float> >( 1e-6 ) )
+    if (testAll<Test<float> >(1e-6))
         return 1;
+
     return 0;
 }

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -85,12 +85,10 @@ void testAllComponents()
     checkComponent<Opm::Xylene<Scalar>, Evaluation>();
 }
 
-class TestAdTag;
-
 template <class Scalar>
 inline void testAll()
 {
-    typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
+    typedef Opm::LocalAd::Evaluation<Scalar, 3> Evaluation;
 
     // ensure that all components are API-compliant
     testAllComponents<Scalar, Scalar>();

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -60,19 +60,9 @@ namespace ComponentsTest {
 #include <opm/material/components/co2tables.inc>
 }}
 
-
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
-
-// include dune's MPI helper header
-#include <dune/common/version.hh>
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,3)
 #include <dune/common/parallel/mpihelper.hh>
-#else
-#include <dune/common/mpihelper.hh>
-#endif
-
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
-
 
 template <class Scalar, class Evaluation>
 void testAllComponents()
@@ -112,7 +102,8 @@ int main(int argc, char **argv)
 {
     Dune::MPIHelper::instance(argc, argv);
 
-    testAll< double >();
-    testAll< float  >();
+    testAll<double>();
+    testAll<float>();
+
     return 0;
 }

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -54,6 +54,10 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 // values of strings based on the first SPE1 test case of opm-data.  note that in the
 // real world it does not make much sense to specify a fluid phase using more than a
 // single keyword, but for a unit test, this saves a lot of boiler-plate code.
@@ -275,9 +279,12 @@ inline void testAll()
 }
 
 
-int main()
+int main(int argc, char **argv)
 {
-    testAll< double >();
-    testAll< float  >();
+    Dune::MPIHelper::instance(argc, argv);
+
+    testAll<double>();
+    testAll<float>();
+
     return 0;
 }

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -268,8 +268,7 @@ inline void testAll()
     oilPvt.initFromDeck(deck, eclState);
     waterPvt.initFromDeck(deck, eclState);
 
-    struct Foo;
-    typedef Opm::LocalAd::Evaluation<Scalar, Foo, 1> FooEval;
+    typedef Opm::LocalAd::Evaluation<Scalar, 1> FooEval;
     ensurePvtApi<Scalar>(oilPvt, gasPvt, waterPvt);
     ensurePvtApi<FooEval>(oilPvt, gasPvt, waterPvt);
 

--- a/tests/test_eclmateriallawmanager.cpp
+++ b/tests/test_eclmateriallawmanager.cpp
@@ -43,6 +43,10 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 // values of strings taken from the SPE1 test case1 of opm-data
 static const char* fam1DeckString =
     "RUNSPEC\n"
@@ -322,10 +326,12 @@ inline void testAll()
     }
 }
 
-
-int main()
+int main(int argc, char **argv)
 {
-    testAll< double >();
-    testAll< float  >();
+    Dune::MPIHelper::instance(argc, argv);
+
+    testAll<double>();
+    testAll<float>();
+
     return 0;
 }

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -69,19 +69,9 @@
 
 #include <opm/material/common/Unused.hpp>
 
-
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
-
-// include dune's MPI helper header
-#include <dune/common/version.hh>
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,3)
 #include <dune/common/parallel/mpihelper.hh>
-#else
-#include <dune/common/mpihelper.hh>
-#endif
-
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
-
 
 // this function makes sure that a capillary pressure law adheres to
 // the generic programming interface for such laws. This API _must_ be
@@ -443,7 +433,9 @@ inline void testAll()
 int main(int argc, char **argv)
 {
     Dune::MPIHelper::instance(argc, argv);
-    testAll< double >();
-    testAll< float  >();
+
+    testAll<double>();
+    testAll<float>();
+
     return 0;
 }

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -259,8 +259,6 @@ void testThreePhaseSatApi()
 {
 }
 
-class TestAdTag;
-
 template <class Scalar>
 inline void testAll()
 {
@@ -282,7 +280,7 @@ inline void testAll()
                                           ThreePFluidSystem::oilPhaseIdx,
                                           ThreePFluidSystem::gasPhaseIdx> ThreePhaseTraits;
 
-    typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
+    typedef Opm::LocalAd::Evaluation<Scalar, 3> Evaluation;
     typedef Opm::ImmiscibleFluidState<Evaluation, TwoPFluidSystem> TwoPhaseFluidState;
     typedef Opm::ImmiscibleFluidState<Evaluation, ThreePFluidSystem> ThreePhaseFluidState;
 

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -236,8 +236,7 @@ void testAllFluidSystems()
         typedef Opm::FluidSystems::BlackOil<Scalar> FluidSystem;
         if (false) checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>();
 
-        struct BlackoilDummyEvalTag;
-        typedef Opm::LocalAd::Evaluation<Scalar, BlackoilDummyEvalTag, 1> BlackoilDummyEval;
+        typedef Opm::LocalAd::Evaluation<Scalar, 1> BlackoilDummyEval;
         ensureBlackoilApi<Scalar, FluidSystem>();
         ensureBlackoilApi<BlackoilDummyEval, FluidSystem>();
     }
@@ -307,12 +306,10 @@ void testAllFluidSystems()
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 }
 
-class TestAdTag;
-
 template <class Scalar>
 inline void testAll()
 {
-    typedef Opm::LocalAd::Evaluation<Scalar, TestAdTag, 3> Evaluation;
+    typedef Opm::LocalAd::Evaluation<Scalar, 3> Evaluation;
 
     // ensure that all fluid states are API-compliant
     testAllFluidStates<Scalar>();

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -60,17 +60,8 @@ namespace FluidSystemsTest {
 #include <opm/material/components/co2tables.inc>
 } }
 
-
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
-
-// include dune's MPI helper header
-#include <dune/common/version.hh>
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,3)
 #include <dune/common/parallel/mpihelper.hh>
-#else
-#include <dune/common/mpihelper.hh>
-#endif
-
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 // check that the blackoil fluid system implements all non-standard functions
@@ -338,7 +329,9 @@ inline void testAll()
 int main(int argc, char **argv)
 {
     Dune::MPIHelper::instance(argc, argv);
-    testAll< double > ();
-    testAll< float >  ();
+
+    testAll<double>();
+    testAll<float>();
+
     return 0;
 }

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -108,9 +108,9 @@ void checkImmiscibleFlash(const FluidState &fsRef,
     fsFlash.setTemperature(fsRef.temperature(/*phaseIdx=*/0));
 
     // run the flash calculation
-    typename FluidSystem::ParameterCache paramCache;
-    ImmiscibleFlash::guessInitial(fsFlash, paramCache, globalMolarities);
-    ImmiscibleFlash::template solve<MaterialLaw>(fsFlash, paramCache, matParams, globalMolarities);
+    ImmiscibleFlash::guessInitial(fsFlash, globalMolarities);
+    typename FluidSystem::template ParameterCache<typename FluidState::Scalar> paramCache;
+    ImmiscibleFlash::template solve<MaterialLaw>(fsFlash, matParams, paramCache, globalMolarities);
 
     // compare the "flashed" fluid state with the reference one
     checkSame<Scalar>(fsRef, fsFlash);
@@ -138,7 +138,7 @@ void completeReferenceFluidState(FluidState &fs,
                    + (pC[otherPhaseIdx] - pC[refPhaseIdx]));
 
     // set all phase densities
-    typename FluidSystem::ParameterCache paramCache;
+    typename FluidSystem::template ParameterCache<typename FluidState::Scalar> paramCache;
     paramCache.updateAll(fs);
     for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
         Scalar rho = FluidSystem::density(fs, paramCache, phaseIdx);

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -55,34 +55,40 @@ void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
     enum { numPhases = FluidState::numPhases };
     enum { numComponents = FluidState::numComponents };
 
+    Scalar tol = std::max(std::numeric_limits<Scalar>::epsilon()*1e4, 1e-6);
+
     for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
         Scalar error;
 
         // check the pressures
         error = 1 - fsRef.pressure(phaseIdx)/fsFlash.pressure(phaseIdx);
-        if (std::abs(error) > 1e-6) {
-            std::cout << "pressure error phase " << phaseIdx << ": "
+        if (std::abs(error) > tol) {
+            OPM_THROW(std::runtime_error,
+                      "pressure error phase " << phaseIdx << " is incorrect: "
                       << fsFlash.pressure(phaseIdx)  << " flash vs "
                       << fsRef.pressure(phaseIdx) << " reference"
-                      << " error=" << error << "\n";
+                      << " error=" << error);
         }
 
         // check the saturations
         error = fsRef.saturation(phaseIdx) - fsFlash.saturation(phaseIdx);
-        if (std::abs(error) > 1e-6)
-            std::cout << "saturation error phase " << phaseIdx << ": "
+        if (std::abs(error) > tol)
+            OPM_THROW(std::runtime_error,
+                      "saturation error phase " << phaseIdx << " is incorrect: "
                       << fsFlash.saturation(phaseIdx) << " flash vs "
                       << fsRef.saturation(phaseIdx) << " reference"
-                      << " error=" << error << "\n";
+                      << " error=" << error);
 
         // check the compositions
         for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
             error = fsRef.moleFraction(phaseIdx, compIdx) - fsFlash.moleFraction(phaseIdx, compIdx);
-            if (std::abs(error) > 1e-6)
-                std::cout << "composition error phase " << phaseIdx << ", component " << compIdx << ": "
+            if (std::abs(error) > tol)
+                OPM_THROW(std::runtime_error,
+                          "composition error phase " << phaseIdx << ", component " << compIdx
+                          << " is incorrect: "
                           << fsFlash.moleFraction(phaseIdx, compIdx) << " flash vs "
                           << fsRef.moleFraction(phaseIdx, compIdx) << " reference"
-                          << " error=" << error << "\n";
+                          << " error=" << error);
         }
     }
 }
@@ -169,6 +175,7 @@ inline void testAll()
     typedef Opm::EffToAbsLaw<EffMaterialLaw> MaterialLaw;
     typedef typename MaterialLaw::Params MaterialLawParams;
 
+    std::cout << "---- using " << Dune::className<Scalar>() << " as scalar ----\n";
     Scalar T = 273.15 + 25;
 
     // initialize the tables of the fluid system

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -45,6 +45,10 @@
 #include <opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 template <class Scalar, class FluidState>
 void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
 {
@@ -263,9 +267,12 @@ inline void testAll()
     checkImmiscibleFlash<Scalar, FluidSystem, MaterialLaw>(fsRef, matParams2);
 }
 
-int main()
+int main(int argc, char **argv)
 {
-    testAll< double >();
-    testAll< float  >();
+    Dune::MPIHelper::instance(argc, argv);
+
+    testAll<double>();
+    testAll<float>();
+
     return 0;
 }

--- a/tests/test_localad.cpp
+++ b/tests/test_localad.cpp
@@ -50,19 +50,12 @@
 #include <cassert>
 #include <stdexcept>
 
-struct TestVariables
-{
-    static const int size = 3;
+static const int numVars = 3;
 
-    static const int temperatureIdx = 0;
-    static const int pressureIdx = 1;
-    static const int saturationIdx = 2;
-};
-
-template <class Scalar, class VariablesDescriptor>
-void testOperators(const Scalar tolerance )
+template <class Scalar>
+void testOperators(const Scalar tolerance)
 {
-    typedef Opm::LocalAd::Evaluation<Scalar, VariablesDescriptor, VariablesDescriptor::size> Eval;
+    typedef Opm::LocalAd::Evaluation<Scalar, numVars> Eval;
 
     // test the constructors of the Opm::LocalAd::Evaluation class
     const Scalar c = 1.234;
@@ -235,10 +228,10 @@ void testOperators(const Scalar tolerance )
     }
 }
 
-template <class Scalar, class VariablesDescriptor, class AdFn, class ClassicFn>
+template <class Scalar, class AdFn, class ClassicFn>
 void test1DFunction(AdFn* adFn, ClassicFn* classicFn, Scalar xMin = 1e-6, Scalar xMax = 1000)
 {
-    typedef Opm::LocalAd::Evaluation<Scalar, VariablesDescriptor, VariablesDescriptor::size> Eval;
+    typedef Opm::LocalAd::Evaluation<Scalar, numVars> Eval;
 
     int n = 100*1000;
     for (int i = 0; i < n; ++ i) {
@@ -269,12 +262,11 @@ void test1DFunction(AdFn* adFn, ClassicFn* classicFn, Scalar xMin = 1e-6, Scalar
 }
 
 template <class Scalar,
-          class VariablesDescriptor,
           class AdFn,
           class ClassicFn>
 void test2DFunction1(AdFn* adFn, ClassicFn* classicFn, Scalar xMin, Scalar xMax, Scalar y)
 {
-    typedef Opm::LocalAd::Evaluation<Scalar, VariablesDescriptor, VariablesDescriptor::size> Eval;
+    typedef Opm::LocalAd::Evaluation<Scalar, numVars> Eval;
 
     int n = 100*1000;
     for (int i = 0; i < n; ++ i) {
@@ -307,12 +299,11 @@ void test2DFunction1(AdFn* adFn, ClassicFn* classicFn, Scalar xMin, Scalar xMax,
 }
 
 template <class Scalar,
-          class VariablesDescriptor,
           class AdFn,
           class ClassicFn>
 void test2DFunction2(AdFn* adFn, ClassicFn* classicFn, Scalar x, Scalar yMin, Scalar yMax)
 {
-    typedef Opm::LocalAd::Evaluation<Scalar, VariablesDescriptor, VariablesDescriptor::size> Eval;
+    typedef Opm::LocalAd::Evaluation<Scalar, numVars> Eval;
 
     int n = 100*1000;
     for (int i = 0; i < n; ++ i) {
@@ -344,10 +335,10 @@ void test2DFunction2(AdFn* adFn, ClassicFn* classicFn, Scalar x, Scalar yMin, Sc
     }
 }
 
-template <class Scalar, class VariablesDescriptor>
+template <class Scalar>
 void testPowBase(Scalar baseMin = 1e-2, Scalar baseMax = 100)
 {
-    typedef Opm::LocalAd::Evaluation<Scalar, VariablesDescriptor, VariablesDescriptor::size> Eval;
+    typedef Opm::LocalAd::Evaluation<Scalar, numVars> Eval;
 
     Scalar exp = 1.234;
     const auto& expEval = Eval::createConstant(exp);
@@ -385,10 +376,10 @@ void testPowBase(Scalar baseMin = 1e-2, Scalar baseMax = 100)
     }
 }
 
-template <class Scalar, class VariablesDescriptor>
+template <class Scalar>
 void testPowExp(Scalar expMin = -100, Scalar expMax = 100)
 {
-    typedef Opm::LocalAd::Evaluation<Scalar, VariablesDescriptor, VariablesDescriptor::size> Eval;
+    typedef Opm::LocalAd::Evaluation<Scalar, numVars> Eval;
 
     Scalar base = 1.234;
     const auto& baseEval = Eval::createConstant(base);
@@ -426,10 +417,10 @@ void testPowExp(Scalar expMin = -100, Scalar expMax = 100)
     }
 }
 
-template <class Scalar, class VariablesDescriptor>
+template <class Scalar>
 void testAtan2()
 {
-    typedef Opm::LocalAd::Evaluation<Scalar, VariablesDescriptor, VariablesDescriptor::size> Eval;
+    typedef Opm::LocalAd::Evaluation<Scalar, numVars> Eval;
 
     int n = 1000;
     Scalar maxVal = 10.0;
@@ -488,8 +479,6 @@ double myScalarMax(double a, double b)
 template <class Scalar>
 inline void testAll()
 {
-    typedef TestVariables VarsDescriptor;
-
     // the following is commented out because it is supposed to produce a compiler
     // error. This is the case since the function does not calculate the derivatives
     // w.r.t. Pressure but they have been requested...
@@ -497,84 +486,84 @@ inline void testAll()
 
     std::cout << "testing operators and constructors\n";
     const Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e3;
-    testOperators<Scalar, VarsDescriptor>(eps);
+    testOperators<Scalar>(eps);
 
     std::cout << "testing min()\n";
-    test2DFunction1<Scalar, VarsDescriptor>(Opm::LocalAd::min<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                            myScalarMin,
-                                            -1000, 1000,
-                                            /*p=*/1.234);
+    test2DFunction1<Scalar>(Opm::LocalAd::min<Scalar, numVars>,
+                            myScalarMin,
+                            -1000, 1000,
+                            /*p=*/1.234);
 
-    test2DFunction2<Scalar, VarsDescriptor>(Opm::LocalAd::min<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                            myScalarMin,
-                                            /*T=*/1.234,
-                                            -1000, 1000);
+    test2DFunction2<Scalar>(Opm::LocalAd::min<Scalar, numVars>,
+                            myScalarMin,
+                            /*T=*/1.234,
+                            -1000, 1000);
 
     std::cout << "testing max()\n";
-    test2DFunction1<Scalar, VarsDescriptor>(Opm::LocalAd::max<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                            myScalarMax,
-                                            -1000, 1000,
-                                            /*p=*/1.234);
+    test2DFunction1<Scalar>(Opm::LocalAd::max<Scalar, numVars>,
+                            myScalarMax,
+                            -1000, 1000,
+                            /*p=*/1.234);
 
-    test2DFunction2<Scalar, VarsDescriptor>(Opm::LocalAd::max<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                            myScalarMax,
-                                            /*T=*/1.234,
-                                            -1000, 1000);
+    test2DFunction2<Scalar>(Opm::LocalAd::max<Scalar, numVars>,
+                            myScalarMax,
+                            /*T=*/1.234,
+                            -1000, 1000);
 
     std::cout << "testing pow()\n";
-    testPowBase<Scalar, VarsDescriptor>();
-    testPowExp<Scalar, VarsDescriptor>();
+    testPowBase<Scalar>();
+    testPowExp<Scalar>();
 
     std::cout << "testing abs()\n";
-    test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::abs<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                           static_cast<Scalar (*)(Scalar)>(std::abs));
+    test1DFunction<Scalar>(Opm::LocalAd::abs<Scalar, numVars>,
+                           static_cast<Scalar (*)(Scalar)>(std::abs));
 
     std::cout << "testing sqrt()\n";
-    test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::sqrt<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                           static_cast<Scalar (*)(Scalar)>(std::sqrt));
+    test1DFunction<Scalar>(Opm::LocalAd::sqrt<Scalar, numVars>,
+                           static_cast<Scalar (*)(Scalar)>(std::sqrt));
 
     std::cout << "testing sin()\n";
-    test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::sin<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                           static_cast<Scalar (*)(Scalar)>(std::sin),
-                                           0, 2*M_PI);
+    test1DFunction<Scalar>(Opm::LocalAd::sin<Scalar, numVars>,
+                           static_cast<Scalar (*)(Scalar)>(std::sin),
+                           0, 2*M_PI);
 
     std::cout << "testing asin()\n";
-    test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::asin<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                           static_cast<Scalar (*)(Scalar)>(std::asin),
-                                           -1.0, 1.0);
+    test1DFunction<Scalar>(Opm::LocalAd::asin<Scalar, numVars>,
+                           static_cast<Scalar (*)(Scalar)>(std::asin),
+                           -1.0, 1.0);
 
     std::cout << "testing cos()\n";
-    test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::cos<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                           static_cast<Scalar (*)(Scalar)>(std::cos),
-                                           0, 2*M_PI);
+    test1DFunction<Scalar>(Opm::LocalAd::cos<Scalar, numVars>,
+                           static_cast<Scalar (*)(Scalar)>(std::cos),
+                           0, 2*M_PI);
 
     std::cout << "testing acos()\n";
-    test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::acos<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                           static_cast<Scalar (*)(Scalar)>(std::acos),
-                                           -1.0, 1.0);
+    test1DFunction<Scalar>(Opm::LocalAd::acos<Scalar, numVars>,
+                           static_cast<Scalar (*)(Scalar)>(std::acos),
+                           -1.0, 1.0);
 
     std::cout << "testing tan()\n";
-    test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::tan<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                           static_cast<Scalar (*)(Scalar)>(std::tan),
-                                           -M_PI / 2 * 0.95, M_PI / 2 * 0.95);
+    test1DFunction<Scalar>(Opm::LocalAd::tan<Scalar, numVars>,
+                           static_cast<Scalar (*)(Scalar)>(std::tan),
+                           -M_PI / 2 * 0.95, M_PI / 2 * 0.95);
 
     std::cout << "testing atan()\n";
-    test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::atan<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                           static_cast<Scalar (*)(Scalar)>(std::atan),
-                                           -10*1000.0, 10*1000.0);
+    test1DFunction<Scalar>(Opm::LocalAd::atan<Scalar, numVars>,
+                           static_cast<Scalar (*)(Scalar)>(std::atan),
+                           -10*1000.0, 10*1000.0);
 
     std::cout << "testing atan2()\n";
-    testAtan2<Scalar, VarsDescriptor>();
+    testAtan2<Scalar>();
 
     std::cout << "testing exp()\n";
-    test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::exp<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                           static_cast<Scalar (*)(Scalar)>(std::exp),
-                                           -100, 100);
+    test1DFunction<Scalar>(Opm::LocalAd::exp<Scalar, numVars>,
+                           static_cast<Scalar (*)(Scalar)>(std::exp),
+                           -100, 100);
 
     std::cout << "testing log()\n";
-    test1DFunction<Scalar, VarsDescriptor>(Opm::LocalAd::log<Scalar, VarsDescriptor, VarsDescriptor::size>,
-                                           static_cast<Scalar (*)(Scalar)>(std::log),
-                                           1e-6, 1e9);
+    test1DFunction<Scalar>(Opm::LocalAd::log<Scalar, numVars>,
+                           static_cast<Scalar (*)(Scalar)>(std::log),
+                           1e-6, 1e9);
 }
 
 int main(int argc, char **argv)

--- a/tests/test_localad.cpp
+++ b/tests/test_localad.cpp
@@ -339,6 +339,7 @@ template <class Scalar>
 void testPowBase(Scalar baseMin = 1e-2, Scalar baseMax = 100)
 {
     typedef Opm::LocalAd::Evaluation<Scalar, numVars> Eval;
+    typedef Opm::MathToolbox<Eval> EvalToolbox;
 
     Scalar exp = 1.234;
     const auto& expEval = Eval::createConstant(exp);
@@ -371,7 +372,7 @@ void testPowBase(Scalar baseMin = 1e-2, Scalar baseMax = 100)
                                    + std::to_string((long double) zEval1.derivatives[0])
                                    + " delta: " + std::to_string((long double) std::abs(zPrime - zEval1.derivatives[0])));
 
-        if (!zEval1.isSame(zEval2, /*tolerance=*/std::numeric_limits<Scalar>::epsilon()*1e3*zEval1.value))
+        if (!EvalToolbox::isSame(zEval1, zEval2, /*tolerance=*/std::numeric_limits<Scalar>::epsilon()*1e3*zEval1.value))
             throw std::logic_error("oops: pow(Eval, Scalar) != pow(Eval, Eval)");
     }
 }
@@ -380,6 +381,7 @@ template <class Scalar>
 void testPowExp(Scalar expMin = -100, Scalar expMax = 100)
 {
     typedef Opm::LocalAd::Evaluation<Scalar, numVars> Eval;
+    typedef Opm::MathToolbox<Eval> EvalToolbox;
 
     Scalar base = 1.234;
     const auto& baseEval = Eval::createConstant(base);
@@ -412,7 +414,7 @@ void testPowExp(Scalar expMin = -100, Scalar expMax = 100)
                                    + std::to_string((long double) zEval1.derivatives[1])
                                    + " delta: " + std::to_string((long double) std::abs(zPrime - zEval1.derivatives[1])));
 
-        if (!zEval1.isSame(zEval2, /*tolerance=*/std::numeric_limits<Scalar>::epsilon()*1e3*zEval1.value))
+        if (!EvalToolbox::isSame(zEval1, zEval2, /*tolerance=*/std::numeric_limits<Scalar>::epsilon()*1e3*zEval1.value))
             throw std::logic_error("oops: pow(Eval, Scalar) != pow(Eval, Eval)");
     }
 }

--- a/tests/test_localad.cpp
+++ b/tests/test_localad.cpp
@@ -34,17 +34,21 @@
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
 
+#include <opm/material/localad/Evaluation.hpp>
+#include <opm/material/localad/Math.hpp>
+
+#include <opm/material/common/Unused.hpp>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 #include <iostream>
 #include <array>
 #include <cmath>
 #include <algorithm>
 #include <cassert>
 #include <stdexcept>
-
-#include <opm/material/common/Unused.hpp>
-
-#include <opm/material/localad/Evaluation.hpp>
-#include <opm/material/localad/Math.hpp>
 
 struct TestVariables
 {
@@ -573,9 +577,12 @@ inline void testAll()
                                            1e-6, 1e9);
 }
 
-int main()
+int main(int argc, char **argv)
 {
-    testAll< double >();
-    testAll< float  >();
+    Dune::MPIHelper::instance(argc, argv);
+
+    testAll<double>();
+    testAll<float>();
+
     return 0;
 }

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -55,34 +55,39 @@ void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
     enum { numPhases = FluidState::numPhases };
     enum { numComponents = FluidState::numComponents };
 
+    Scalar tol = std::max(std::numeric_limits<Scalar>::epsilon()*1e4, 1e-6);
+
     for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
         Scalar error;
 
         // check the pressures
         error = 1 - fsRef.pressure(phaseIdx)/fsFlash.pressure(phaseIdx);
-        if (std::abs(error) > 1e-6) {
-            std::cout << "pressure error phase " << phaseIdx << ": "
-                      << fsFlash.pressure(phaseIdx)  << " flash vs "
-                      << fsRef.pressure(phaseIdx) << " reference"
-                      << " error=" << error << "\n";
+        if (std::abs(error) > tol) {
+            OPM_THROW(std::runtime_error,
+                      "pressure error for phase " << phaseIdx << " exceeds tolerance"
+                      << " (" << fsFlash.pressure(phaseIdx)  << " flash vs "
+                      << fsRef.pressure(phaseIdx) << " reference,"
+                      << " error=" << error << ")");
         }
 
         // check the saturations
         error = fsRef.saturation(phaseIdx) - fsFlash.saturation(phaseIdx);
-        if (std::abs(error) > 1e-6)
-            std::cout << "saturation error phase " << phaseIdx << ": "
-                      << fsFlash.saturation(phaseIdx) << " flash vs "
-                      << fsRef.saturation(phaseIdx) << " reference"
-                      << " error=" << error << "\n";
+        if (std::abs(error) > tol)
+            OPM_THROW(std::runtime_error,
+                      "saturation error for phase " << phaseIdx << " exceeds tolerance"
+                      << " (" << fsFlash.saturation(phaseIdx) << " flash vs "
+                      << fsRef.saturation(phaseIdx) << " reference,"
+                      << " error=" << error << ")");
 
         // check the compositions
         for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
             error = fsRef.moleFraction(phaseIdx, compIdx) - fsFlash.moleFraction(phaseIdx, compIdx);
-            if (std::abs(error) > 1e-6)
-                std::cout << "composition error phase " << phaseIdx << ", component " << compIdx << ": "
-                          << fsFlash.moleFraction(phaseIdx, compIdx) << " flash vs "
-                          << fsRef.moleFraction(phaseIdx, compIdx) << " reference"
-                          << " error=" << error << "\n";
+            if (std::abs(error) > tol)
+                OPM_THROW(std::runtime_error,
+                          "composition error phase " << phaseIdx << ", component " << compIdx << " exceeds tolerance"
+                          << " (" << fsFlash.moleFraction(phaseIdx, compIdx) << " flash vs "
+                          << fsRef.moleFraction(phaseIdx, compIdx) << " reference,"
+                          << " error=" << error << ")");
         }
     }
 }
@@ -175,6 +180,7 @@ inline void testAll()
     typedef Opm::EffToAbsLaw<EffMaterialLaw> MaterialLaw;
     typedef typename MaterialLaw::Params MaterialLawParams;
 
+    std::cout << "---- using " << Dune::className<Scalar>() << " as scalar ----\n";
     Scalar T = 273.15 + 25;
 
     // initialize the tables of the fluid system

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -32,9 +32,9 @@
  */
 #include "config.h"
 
+#include <opm/material/constraintsolvers/NcpFlash.hpp>
 #include <opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp>
 #include <opm/material/constraintsolvers/ComputeFromReferencePhase.hpp>
-#include <opm/material/constraintsolvers/NcpFlash.hpp>
 
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
 
@@ -44,6 +44,10 @@
 #include <opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp>
 #include <opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 template <class Scalar, class FluidState>
 void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
@@ -297,9 +301,12 @@ inline void testAll()
     checkNcpFlash<Scalar, FluidSystem, MaterialLaw>(fsRef, matParams2);
 }
 
-int main()
+int main(int argc, char **argv)
 {
-    testAll< double >();
-    while (false) testAll< float  >();
+    Dune::MPIHelper::instance(argc, argv);
+
+    testAll<double>();
+    testAll<float>();
+
     return 0;
 }

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -35,6 +35,10 @@
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 template <class FluidSystem, class FluidState>
 void createSurfaceGasFluidSystem(FluidState &gasFluidState)
 {
@@ -475,9 +479,16 @@ inline void testAll()
                 /*hiresThreshold=*/hiresThresholdPressure);
 }
 
-int main(int /*argc*/, char** /*argv*/)
+int main(int argc, char **argv)
 {
-    testAll< double >();
-    while (0) testAll< float  >();
+    Dune::MPIHelper::instance(argc, argv);
+
+    testAll<double>();
+
+    // the Peng-Robinson test currently does not work with single-precision floating
+    // point scalars because of precision issues. (these are caused by the fact that the
+    // test uses finite differences to calculate derivatives.)
+    while (0) testAll<float>();
+
     return 0;
 }

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -414,7 +414,7 @@ inline void testAll()
     Scalar maxAlpha = surfaceAlpha;
 
     std::cout << "alpha[-] p[Pa] S_g[-] rho_o[kg/m^3] rho_g[kg/m^3] <M_o>[kg/mol] <M_g>[kg/mol] R_s[m^3/m^3] B_g[-] B_o[-]\n";
-    int n = 3000;
+    int n = 300;
     for (int i = 0; i < n; ++i) {
         // ratio between the original and the current volume
         Scalar alpha = minAlpha + (maxAlpha - minAlpha)*i/(n - 1);

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -488,7 +488,10 @@ int main(int argc, char **argv)
     // the Peng-Robinson test currently does not work with single-precision floating
     // point scalars because of precision issues. (these are caused by the fact that the
     // test uses finite differences to calculate derivatives.)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunreachable-code"
     while (0) testAll<float>();
+#pragma GCC diagnostic pop
 
     return 0;
 }

--- a/tests/test_tabulation.cpp
+++ b/tests/test_tabulation.cpp
@@ -59,7 +59,7 @@ inline void testAll()
 
     Scalar pMin = 10.00;
     Scalar pMax = IapwsH2O::vaporPressure(tempMax*1.1);
-    unsigned nPress = 200;
+    unsigned nPress = 50;
 
     std::cout << "Creating tabulation with " << nTemp*nPress << " entries per quantity\n";
     TabulatedH2O::init(tempMin, tempMax, nTemp,

--- a/tests/test_tabulation.cpp
+++ b/tests/test_tabulation.cpp
@@ -34,6 +34,10 @@
 #include <opm/material/components/H2O.hpp>
 #include <opm/material/components/TabulatedComponent.hpp>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 extern bool success;
 bool success;
 
@@ -117,10 +121,12 @@ inline void testAll()
         std::cout << "\nsuccess\n";
 }
 
-
-int main()
+int main(int argc, char **argv)
 {
-    testAll< double >();
-    testAll< float  >();
+    Dune::MPIHelper::instance(argc, argv);
+
+    testAll<double>();
+    testAll<float>();
+
     return 0;
 }


### PR DESCRIPTION
this is the stuff which I would like to be included in the next release. it started out with me wanting to convert the flash solvers to use local automatic differentiation but this turned out to be quite a can of worms:

- using local-AD for the flash solvers required the ability to use `Evaluation<>` in all fluid systems
- using `Evaluation<>` with the spe-5 fluid system required parameter-caches to be local-AD aware
 - this needs an interface change. Fortunately the only affected downstream module is eWoms
 - also, the code for the Peng-Robinson EOS had to be made AD-aware

since nested AD allows some pretty cool stuff like implementing a higher order methods instead of the Newton method -- because higher-order and mixed derivatives of a function can be calculated in a fully transparent manner -- I think it is worth the effort.

while at this I figured that the concept of passing "tags" to the `Evaluation` template is nice in theory, it only leads to much less unreadable compiler messages because they can become quite long. Thus, I removed them and this caused some API change which also affected opm-core and opm-simulators (albeit the fix was easy).

finally this PR fixes some new warnings which were produced by clang-3.9's `-Weverything` and GCC-6 `-Wextra` flags.