### PR TITLE
Using getInputGrid API from Parser

### DIFF
--- a/tests/test_eclmateriallawmanager.cpp
+++ b/tests/test_eclmateriallawmanager.cpp
@@ -247,7 +247,7 @@ inline void testAll()
 
         const auto deck = parser.parseString(fam1DeckString, parseContext);
         const auto eclState = std::make_shared<Opm::EclipseState>(deck, parseContext);
-        const auto eclGrid = eclState->getEclipseGrid();
+        const auto eclGrid = eclState->getInputGrid();
 
         size_t n = eclGrid->getCartesianSize();
         std::vector<int> compressedToCartesianIdx(n);


### PR DESCRIPTION
Using new EclipseState.getInputGrid API in Parser

See OPM/opm-parser#769