### PR TITLE
Tabulation classes: some micro-optimizations w.r.t. Evaluations

### DIFF
--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -268,7 +268,7 @@ public:
         Scalar y0 = yValues_[segIdx];
         Scalar y1 = yValues_[segIdx + 1];
 
-        return y0 + (y1 - y0)*(x - x0)/(x1 - x0);
+        return y0 + (y1 - y0)/(x1 - x0)*(x - x0);
     }
 
     /*!

--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -147,7 +147,7 @@ public:
       */
     template <class Evaluation>
     Evaluation xToI(const Evaluation& x) const
-    { return (x - xMin())/(xMax() - xMin())*(numX() - 1); }
+    { return (x - xMin())*((numX() - 1)/(xMax() - xMin())); }
 
     /*!
      * \brief Return the interval index of a given position on the y-axis.
@@ -159,7 +159,7 @@ public:
      */
     template <class Evaluation>
     Evaluation yToJ(const Evaluation& y) const
-    { return (y - yMin())/(yMax() - yMin())*(numY() - 1); }
+    { return (y - yMin())*((numY() - 1)/(yMax() - yMin())); }
 
     /*!
      * \brief Returns true iff a coordinate lies in the tabulated range

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -281,9 +281,8 @@ public:
         beta2 -= j2;
 
         // evaluate the two function values for the same y value ...
-        Evaluation s1, s2;
-        s1 = valueAt(i, j1)*(1.0 - beta1) + valueAt(i, j1 + 1)*beta1;
-        s2 = valueAt(i + 1, j2)*(1.0 - beta2) + valueAt(i + 1, j2 + 1)*beta2;
+        const Evaluation& s1 = valueAt(i, j1)*(1.0 - beta1) + valueAt(i, j1 + 1)*beta1;
+        const Evaluation& s2 = valueAt(i + 1, j2)*(1.0 - beta2) + valueAt(i + 1, j2 + 1)*beta2;
 
         Valgrind::CheckDefined(s1);
         Valgrind::CheckDefined(s2);


### PR DESCRIPTION
with this, some relatively expensive "Evaluation times Scalar" multiplications are replaced by relatively cheap "Scalar times Scalar" ones.

although this changes convergence behavior of flow for norne slightly, I could not find any effect on the results and performance was also negatively affected:

before:

```
Total time taken (seconds):  1301.86
Solver time (seconds):       1298.17
Overall Newton Iterations:   1625
Overall Linear Iterations:   25233
```

after:

```
Total time taken (seconds):  1254.06
Solver time (seconds):       1250.26
Overall Newton Iterations:   1626
Overall Linear Iterations:   24950
```

also note that -- since the corresponding release branch has already been created for opm-material -- this patch is not going to be part of the impeding OPM-2016.04 release unless explicitly requested otherwise.
