### PR TITLE
added: downstream build support in the jenkins trigger

### DIFF
--- a/jenkins/build-opm-material.sh
+++ b/jenkins/build-opm-material.sh
@@ -37,14 +37,13 @@ function build_opm_material {
   build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" 0 $WORKSPACE/deps/opm-common
   popd
 
-  # Build opm-parser
-  clone_and_build_module opm-parser "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_PARSER_REVISION $WORKSPACE/serial
+  build_upstreams
 
   # Build opm-material
   pushd .
   mkdir serial/build-opm-material
   cd serial/build-opm-material
-  build_module "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
+  build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install -DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
   test $? -eq 0 || exit 1
   popd
 }

--- a/jenkins/build-pr.sh
+++ b/jenkins/build-pr.sh
@@ -2,10 +2,15 @@
 
 source `dirname $0`/build-opm-material.sh
 
+# Upstream revisions
+declare -a upstreams
+upstreams=(opm-parser)
+
+declare -A upstreamRev
+upstreamRev[opm-parser]=master
+
 ERT_REVISION=master
 OPM_COMMON_REVISION=master
-OPM_PARSER_REVISION=master
-OPM_MATERIAL_REVISION=$sha1
 
 if grep -q "ert=" <<< $ghprbCommentBody
 then
@@ -17,14 +22,45 @@ then
   OPM_COMMON_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-common=([0-9]+).*/\1/g'`/merge
 fi
 
-if grep -q "opm-parser=" <<< $ghprbCommentBody
-then
-  OPM_PARSER_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-parser=([0-9]+).*/\1/g'`/merge
-fi
+for upstream in $upstreams
+do
+  if grep -q "$upstream=" <<< $ghprbCommentBody
+  then
+    upstreamRev[$upstream]=pull/`echo $ghprbCommentBody | sed -r "s/.*$upstream=([0-9]+).*/\1/g"`/merge
+  fi
+done
 
-echo "Building with ert=$ERT_REVISION opm-common=$OPM_COMMON_REVISION opm-parser=$OPM_PARSER_REVISION opm-material=$OPM_MATERIAL_REVISION"
+echo "Building with ert=$ERT_REVISION opm-common=$OPM_COMMON_REVISION opm-parser=${upstreamRev[opm-parser]} opm-material=$sha1"
 
 build_opm_material
 test $? -eq 0 || exit 1
 
-cp serial/build-opm-material/testoutput.xml .
+# If no downstream builds we are done
+if ! grep -q "with downstreams" <<< $ghprbCommentBody
+then
+  cp serial/build-opm-material/testoutput.xml .
+  exit 0
+fi
+
+source $WORKSPACE/deps/opm-common/jenkins/setup-opm-data.sh
+source $WORKSPACE/deps/opm-common/jenkins/compile-opm-module.sh
+
+# Downstream revisions
+declare -a downstreams
+downstreams=(opm-core
+             opm-grid
+             opm-output
+             opm-simulators
+             opm-upscaling
+             ewoms)
+declare -A downstreamRev
+downstreamRev[opm-core]=master
+downstreamRev[opm-grid]=master
+downstreamRev[opm-output]=master
+downstreamRev[opm-simulators]=master
+downstreamRev[opm-upscaling]=master
+downstreamRev[ewoms]=master
+
+build_downstreams opm-material
+
+test $? -eq 0 || exit 1

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -2,9 +2,14 @@
 
 source `dirname $0`/build-opm-material.sh
 
+declare -a upstreams
+upstreams=(opm-parser)
+
+declare -A upstreamRev
+upstreamRev[opm-parser]=master
+
 ERT_REVISION=master
 OPM_COMMON_REVISION=master
-OPM_PARSER_REVISION=master
 
 build_opm_material
 test $? -eq 0 || exit 1


### PR DESCRIPTION
use 'jenkins build this with downstreams please'.

this will build all downstreams against the PR, and
execute their tests. PR's for upstream and downstream modules
can be specified.

the aggregated test results are attached to the job result on jenkins.

depends on https://github.com/OPM/opm-common/pull/111