### PR TITLE
fix warnings from Evaluation.hpp when using Dune 2.3

### DIFF
--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -32,6 +32,7 @@
  */
 #include "config.h"
 
+#include <opm/material/localad/Evaluation.hpp>
 #include <opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp>
 #include <opm/material/constraintsolvers/ComputeFromReferencePhase.hpp>
 #include <opm/material/constraintsolvers/ImmiscibleFlash.hpp>

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/material/localad/Evaluation.hpp>
 #include <opm/material/constraintsolvers/ComputeFromReferencePhase.hpp>
 #include <opm/material/constraintsolvers/NcpFlash.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>


### PR DESCRIPTION
these warnings were caused by the fmatrix.hh header being included
before Evaluation.hpp. While they were harmeless, they were annoying.

(I did not discover this earlier because I normally use Dune 2.4 which
does not have this particular issue.)