### PR TITLE
update jenkins build scripts

### DIFF
--- a/jenkins/build-pr.sh
+++ b/jenkins/build-pr.sh
@@ -47,9 +47,9 @@ source $WORKSPACE/deps/opm-common/jenkins/compile-opm-module.sh
 
 # Downstream revisions
 declare -a downstreams
-downstreams=(opm-core
+downstreams=(opm-output
+             opm-core
              opm-grid
-             opm-output
              opm-simulators
              opm-upscaling
              ewoms)


### PR DESCRIPTION
update build order, opm-output moved in the dependency tree