### PR TITLE
FluidStates: introduce phaseIsPresence(phaseIdx)

### DIFF
--- a/opm/material/checkFluidSystem.hpp
+++ b/opm/material/checkFluidSystem.hpp
@@ -179,6 +179,13 @@ public:
         return  this->base().saturation(phaseIdx);
     }
 
+    auto phaseIsPresent(unsigned phaseIdx) const
+        -> decltype(this->base().phaseIsPresent(phaseIdx))
+    {
+        assert(false);
+        return  this->base().phaseIsPresent(phaseIdx);
+    }
+
     auto fugacity(unsigned phaseIdx, unsigned compIdx) const
         -> decltype(this->base().fugacity(phaseIdx, compIdx))
     {
@@ -254,6 +261,7 @@ void checkFluidState(const BaseFluidState &fs)
         val = fs.molarVolume(/*phaseIdx=*/0);
         val = fs.density(/*phaseIdx=*/0);
         val = fs.saturation(/*phaseIdx=*/0);
+        OPM_UNUSED bool b = fs.phaseIsPresent(/*phaseIdx=*/0);
         val = fs.fugacity(/*phaseIdx=*/0, /*compIdx=*/0);
         val = fs.fugacityCoefficient(/*phaseIdx=*/0, /*compIdx=*/0);
         val = fs.enthalpy(/*phaseIdx=*/0);

--- a/opm/material/fluidstates/FluidStateSaturationModules.hpp
+++ b/opm/material/fluidstates/FluidStateSaturationModules.hpp
@@ -58,6 +58,12 @@ public:
     { return saturation_[phaseIdx]; }
 
     /*!
+     * \brief Returns true iff a fluid phase shall be assumed to be present.
+     */
+    bool phaseIsPresent(int phaseIdx) const
+    { return saturation_[phaseIdx] > 0.0; }
+
+    /*!
      * \brief Set the saturation of a phase [-]
      */
     void setSaturation(unsigned phaseIdx, const Scalar& value)
@@ -110,6 +116,12 @@ public:
      */
     const Scalar& saturation(int /* phaseIdx */) const
     { OPM_THROW(std::runtime_error, "Saturation is not provided by this fluid state"); }
+
+    /*!
+     * \brief Returns true iff a fluid phase shall be assumed to be present.
+     */
+    bool phaseIsPresent(int phaseIdx) const
+    { OPM_THROW(std::runtime_error, "phaseIsPresent() is not provided by this fluid state"); }
 
     /*!
      * \brief Retrieve all parameters from an arbitrary fluid

--- a/opm/material/fluidstates/PressureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/PressureOverlayFluidState.hpp
@@ -89,6 +89,12 @@ public:
     { return fs_->saturation(phaseIdx); }
 
     /*!
+     * \brief Returns true iff a fluid phase shall be assumed to be present.
+     */
+    bool phaseIsPresent(unsigned phaseIdx) const
+    { return fs_->phaseIsPresent(phaseIdx); }
+
+    /*!
      * \brief The mole fraction of a component in a phase []
      */
     auto moleFraction(unsigned phaseIdx, unsigned compIdx) const

--- a/opm/material/fluidstates/SaturationOverlayFluidState.hpp
+++ b/opm/material/fluidstates/SaturationOverlayFluidState.hpp
@@ -88,6 +88,12 @@ public:
     { return saturation_[phaseIdx]; }
 
     /*!
+     * \brief Returns true iff a fluid phase shall be assumed to be present.
+     */
+    bool phaseIsPresent(unsigned phaseIdx) const
+    { return saturation_[phaseIdx] > 0.0; }
+
+    /*!
      * \brief The mole fraction of a component in a phase []
      */
     auto moleFraction(unsigned phaseIdx, unsigned compIdx) const

--- a/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
@@ -91,6 +91,12 @@ public:
     { return fs_->saturation(phaseIdx); }
 
     /*!
+     * \brief Returns true iff a fluid phase shall be assumed to be present.
+     */
+    bool phaseIsPresent(unsigned phaseIdx) const
+    { return fs_->phaseIsPresent(phaseIdx); }
+
+    /*!
      * \brief The mole fraction of a component in a phase []
      */
     auto moleFraction(unsigned phaseIdx, unsigned compIdx) const

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -579,7 +579,7 @@ public:
         switch (phaseIdx) {
         case oilPhaseIdx: {
             if (enableDissolvedGas()) {
-                if (fluidState.saturation(gasPhaseIdx) > 0.0) {
+                if (fluidState.phaseIsPresent(gasPhaseIdx)) {
                     if (fluidState.saturation(gasPhaseIdx) < 1e-4) {
                         // here comes the relatively expensive case: first calculate and then
                         // interpolate between the saturated and undersaturated quantities to
@@ -603,7 +603,7 @@ public:
         }
         case gasPhaseIdx: {
             if (enableVaporizedOil()) {
-                if (fluidState.saturation(oilPhaseIdx) > 0.0) {
+                if (fluidState.phaseIsPresent(oilPhaseIdx)) {
                     if (fluidState.saturation(oilPhaseIdx) < 1e-4) {
                         // here comes the relatively expensive case: first calculate and then
                         // interpolate between the saturated and undersaturated quantities to
@@ -804,7 +804,7 @@ public:
         switch (phaseIdx) {
         case oilPhaseIdx: {
             if (enableDissolvedGas()) {
-                if (fluidState.saturation(gasPhaseIdx) > 0.0) {
+                if (fluidState.phaseIsPresent(gasPhaseIdx)) {
                     if (fluidState.saturation(gasPhaseIdx) < 1e-4) {
                         // here comes the relatively expensive case: first calculate and then
                         // interpolate between the saturated and undersaturated quantities to
@@ -829,7 +829,7 @@ public:
 
         case gasPhaseIdx: {
             if (enableVaporizedOil()) {
-                if (fluidState.saturation(oilPhaseIdx) > 0.0) {
+                if (fluidState.phaseIsPresent(oilPhaseIdx)) {
                     if (fluidState.saturation(oilPhaseIdx) < 1e-4) {
                         // here comes the relatively expensive case: first calculate and then
                         // interpolate between the saturated and undersaturated quantities to


### PR DESCRIPTION
by default, this just checks if the saturation of the incriminating
phase is larger than 0, but in some cases (i.e., black-oil) the
calling code might have a different opinion: E.g., the black-oil model
looks at the primary variables to determine the phase presence.