### PR TITLE
Updated opm-material to use new travis scheme (from common)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,11 @@ addons:
       - liblapack-dev
       - libgmp3-dev
 
-install:
+before_script:
     - export CXX="g++-4.8" CC="gcc-4.8" FC="gfortran-4.8"
     - cd ..
-
     - git clone https://github.com/OPM/opm-common.git
-    - git clone https://github.com/OPM/opm-parser.git
-    - git clone https://github.com/OPM/opm-data.git
+    - opm-common/travis/clone-opm.sh opm-material
+    - opm-common/travis/build-prereqs.sh
 
-    - opm-parser/travis/clone-and-build-ert.sh
-    - opm-material/travis/clone-and-build-dune-common.sh
-    - opm-common/travis/build-opm-common.sh
-    - opm-parser/travis/build-opm-parser.sh
-
-script: opm-material/travis/build-and-test-opm-material.sh
+script: opm-common/travis/build-and-test.sh opm-material


### PR DESCRIPTION
It seems OPM-material wasn't updated to use opm-common's new build scripts.

Updated opm-material's `.travis.yml` to use 

* `opm-common/travis/clone-opm.sh opm-material`
* `opm-common/travis/build-prereqs.sh`
* `opm-common/travis/build-and-test.sh opm-material`
