### PR TITLE
 implement the E100 VAPPARS keyword

### DIFF
--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -1706,7 +1706,7 @@ protected:
                              const Evaluation& b,
                              const Evaluation& c,
                              const Evaluation& d,
-                             Scalar x0 = -1e100, Scalar x1 = 1e100) const
+                             Scalar x0 = -1e30, Scalar x1 = 1e30) const
     {
         int n = Opm::invertCubicPolynomial(sol,
                                            a_(segIdx) - a,

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -356,8 +356,8 @@ public:
         Scalar x1 = xMax();
         int m = numX();
 
-        Scalar y0 = 1e100;
-        Scalar y1 = -1e100;
+        Scalar y0 = 1e30;
+        Scalar y1 = -1e30;
         int n = 0;
         for (int i = 0; i < m; ++ i) {
             y0 = std::min(y0, yMin(i));

--- a/opm/material/eos/PengRobinson.hpp
+++ b/opm/material/eos/PengRobinson.hpp
@@ -317,10 +317,10 @@ protected:
         typedef MathToolbox<Evaluation> Toolbox;
 
         Evaluation minVm(0);
-        Evaluation maxVm(1e100);
+        Evaluation maxVm(1e30);
 
         Evaluation minP(0);
-        Evaluation maxP(1e100);
+        Evaluation maxP(1e30);
 
         // first, we need to find an isotherm where the EOS exhibits
         // a maximum and a minimum

--- a/opm/material/fluidsystems/H2OAirFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirFluidSystem.hpp
@@ -163,7 +163,7 @@ public:
             ? H2O::molarMass()
             : (compIdx == AirIdx)
             ? Air::molarMass()
-            : 1e100;
+            : 1e30;
     }
 
 
@@ -179,7 +179,7 @@ public:
             ? H2O::criticalTemperature()
             : (compIdx == AirIdx)
             ? Air::criticalTemperature()
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -194,7 +194,7 @@ public:
             ? H2O::criticalPressure()
             : (compIdx == AirIdx)
             ? Air::criticalPressure()
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -209,7 +209,7 @@ public:
             ? H2O::acentricFactor()
             : (compIdx == AirIdx)
             ? Air::acentricFactor()
-            : 1e100;
+            : 1e30;
     }
 
     /****************************************
@@ -271,7 +271,7 @@ public:
         else {
             // random value which will hopefully cause things to blow
             // up if it is used in a calculation!
-            p = - 1e100;
+            p = - 1e30;
             Valgrind::SetUndefined(p);
         }
 

--- a/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
@@ -212,7 +212,7 @@ public:
             const LhsEval& p =
                 H2O::liquidIsCompressible()
                 ? FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx))
-                : 1e100;
+                : 1e30;
 
             const LhsEval& rholH2O = H2O::liquidDensity(T, p);
             const LhsEval& clH2O = rholH2O/H2O::molarMass();
@@ -229,7 +229,7 @@ public:
             const LhsEval& p =
                 NAPL::liquidIsCompressible()
                 ? FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx))
-                : 1e100;
+                : 1e30;
             return NAPL::liquidDensity(T, p);
         }
 

--- a/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
@@ -161,7 +161,7 @@ public:
             // the NAPL component decides for the napl comp...
             : (compIdx == NAPLIdx)
             ? NAPL::molarMass()
-            : 1e100;
+            : 1e30;
     }
 
     //! \copydoc BaseFluidSystem::density
@@ -191,7 +191,7 @@ public:
         else if (phaseIdx == naplPhaseIdx) {
             // assume pure NAPL for the NAPL phase
             const auto& T = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
-            return NAPL::liquidDensity(T, LhsEval(1e100));
+            return NAPL::liquidDensity(T, LhsEval(1e30));
         }
 
         assert (phaseIdx == gasPhaseIdx);

--- a/opm/material/fluidsystems/H2ON2FluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2FluidSystem.hpp
@@ -173,7 +173,7 @@ public:
             ? H2O::molarMass()
             : (compIdx == N2Idx)
             ? N2::molarMass()
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -187,7 +187,7 @@ public:
             ? H2O::criticalTemperature()
             : (compIdx == N2Idx)
             ? N2::criticalTemperature()
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -201,7 +201,7 @@ public:
             ? H2O::criticalPressure()
             : (compIdx == N2Idx)
             ? N2::criticalPressure()
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -215,7 +215,7 @@ public:
             ? H2O::acentricFactor()
             : (compIdx == N2Idx)
             ? N2::acentricFactor()
-            : 1e100;
+            : 1e30;
     }
 
     /****************************************

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -161,7 +161,7 @@ public:
             ? H2O::molarMass()
             : (compIdx == N2Idx)
             ? N2::molarMass()
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -176,7 +176,7 @@ public:
             ? H2O::criticalTemperature()
             : (compIdx == N2Idx)
             ? N2::criticalTemperature()
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -191,7 +191,7 @@ public:
             ? H2O::criticalPressure()
             : (compIdx == N2Idx)
             ? N2::criticalPressure()
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -206,7 +206,7 @@ public:
             ? H2O::acentricFactor()
             : (compIdx == N2Idx)
             ? N2::acentricFactor()
-            : 1e100;
+            : 1e30;
     }
 
     /****************************************

--- a/opm/material/fluidsystems/Spe5FluidSystem.hpp
+++ b/opm/material/fluidsystems/Spe5FluidSystem.hpp
@@ -182,7 +182,7 @@ public:
             ? 206.00e-3
             : (compIdx == C20Idx)
             ? 282.00e-3
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -205,7 +205,7 @@ public:
             ? 1270.0*5/9
             : (compIdx == C20Idx)
             ? 1380.0*5/9
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -228,7 +228,7 @@ public:
             ? 200.0 * 6894.7573
             : (compIdx == C20Idx)
             ? 162.0 * 6894.7573
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -251,7 +251,7 @@ public:
             ? 0.245*R*criticalTemperature(C15Idx)/criticalPressure(C15Idx)
             : (compIdx == C20Idx)
             ? 0.235*R*criticalTemperature(C20Idx)/criticalPressure(C20Idx)
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -274,7 +274,7 @@ public:
             ? 0.6500
             : (compIdx == C20Idx)
             ? 0.8500
-            : 1e100;
+            : 1e30;
     }
 
     /*!
@@ -318,8 +318,8 @@ public:
         // mixtures is just a convex combination of the attractive and
         // repulsive parameters of the pure components
 
-        Scalar minA = 1e100, maxA = -1e100;
-        Scalar minB = 1e100, maxB = -1e100;
+        Scalar minA = 1e30, maxA = -1e30;
+        Scalar minB = 1e30, maxB = -1e30;
 
         prParams.updatePure(minT, minP);
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -231,6 +231,17 @@ public:
     { return 0.0; /* this is dead oil! */ }
 
     /*!
+     * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
+     */
+    template <class Evaluation>
+    Evaluation saturatedGasDissolutionFactor(unsigned /*regionIdx*/,
+                                             const Evaluation& /*temperature*/,
+                                             const Evaluation& /*pressure*/,
+                                             const Evaluation& /*oilSaturation*/,
+                                             const Evaluation& /*maxOilSaturation*/) const
+    { return 0.0; /* this is dead oil! */ }
+
+    /*!
      * \brief Returns the saturation pressure of the oil phase [Pa]
      *        depending on its mass fraction of the gas component
      *

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -220,6 +220,17 @@ public:
     { return 0.0; /* this is dead oil! */ }
 
     /*!
+     * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
+     */
+    template <class Evaluation>
+    Evaluation saturatedGasDissolutionFactor(unsigned /*regionIdx*/,
+                                             const Evaluation& /*temperature*/,
+                                             const Evaluation& /*pressure*/,
+                                             const Evaluation& /*oilSaturation*/,
+                                             const Evaluation& /*maxOilSaturation*/) const
+    { return 0.0; /* this is dead oil! */ }
+
+    /*!
      * \brief Returns the saturation pressure of the oil phase [Pa]
      *        depending on its mass fraction of the gas component
      *

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -247,7 +247,18 @@ public:
     { return 0.0; /* this is dry gas! */ }
 
     /*!
-     * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
+     * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the oil phase.
+     */
+    template <class Evaluation>
+    Evaluation saturatedOilVaporizationFactor(unsigned /*regionIdx*/,
+                                              const Evaluation& /*temperature*/,
+                                              const Evaluation& /*pressure*/,
+                                              const Evaluation& /*oilSaturation*/,
+                                              const Evaluation& /*maxOilSaturation*/) const
+    { return 0.0; /* this is dry gas! */ }
+
+    /*!
+     * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the oil phase.
      */
     template <class Evaluation>
     Evaluation saturatedOilVaporizationFactor(unsigned /*regionIdx*/,

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -213,6 +213,17 @@ public:
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilVaporizationFactor(regionIdx, temperature, pressure)); return 0; }
 
     /*!
+     * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of oil saturated gas.
+     */
+    template <class Evaluation = Scalar>
+    Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
+                                              const Evaluation& temperature,
+                                              const Evaluation& pressure,
+                                              const Evaluation& oilSaturation,
+                                              const Evaluation& maxOilSaturation) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilVaporizationFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation)); return 0; }
+
+    /*!
      * \brief Returns the saturation pressure of the gas phase [Pa]
      *        depending on its mass fraction of the oil component
      *

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -211,16 +211,30 @@ public:
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the gas phase.
      *
-     * This method implements temperature dependence and requires the isothermal oil
-     * vaporization factor for oil saturated gas and temperature as inputs. Currently it
-     * is just a dummy method which passes through the isothermal oil vaporization
-     * factor.
+     * This method implements temperature dependence and requires the gas pressure,
+     * temperature and the oil saturation as inputs. Currently it is just a dummy method
+     * which passes through the isothermal oil vaporization factor.
      */
     template <class Evaluation>
     Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
                                               const Evaluation& temperature,
                                               const Evaluation& pressure) const
     { return isothermalPvt_->saturatedOilVaporizationFactor(regionIdx, temperature, pressure); }
+
+    /*!
+     * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the gas phase.
+     *
+     * This method implements temperature dependence and requires the gas pressure,
+     * temperature and the oil saturation as inputs. Currently it is just a dummy method
+     * which passes through the isothermal oil vaporization factor.
+     */
+    template <class Evaluation>
+    Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
+                                              const Evaluation& temperature,
+                                              const Evaluation& pressure,
+                                              const Evaluation& oilSaturation,
+                                              const Evaluation& maxOilSaturation) const
+    { return isothermalPvt_->saturatedOilVaporizationFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation); }
 
     /*!
      * \brief Returns the saturation pressure of the gas phase [Pa]

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -515,7 +515,7 @@ private:
         for (size_t i=0; i <= n; ++ i) {
             Scalar pSat = gasDissolutionFac.xMin() + i*delta;
             Rs = saturatedGasDissolutionFactor(regionIdx,
-                                               /*temperature=*/Scalar(1e100),
+                                               /*temperature=*/Scalar(1e30),
                                                pSat);
 
             std::pair<Scalar, Scalar> val(Rs, pSat);

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -165,6 +165,12 @@ public:
             }
         }
 
+        vapPar2_ = 0.0;
+        if (deck->hasKeyword("VAPPARS")) {
+            const auto& vapParsKeyword = deck->getKeyword("VAPPARS");
+            vapPar2_ = vapParsKeyword.getRecord(0).getItem("OIL_DENSITY_PROPENSITY").template get<double>(0);
+        }
+
         initEnd();
     }
 
@@ -466,6 +472,35 @@ public:
     { return saturatedGasDissolutionFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
+     * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
+     *
+     * This variant of the method prevents all the oil to be vaporized even if the gas
+     * phase is still not saturated. This is physically quite dubious but it corresponds
+     * to how the Eclipse 100 simulator handles this. (cf the VAPPARS keyword.)
+     */
+    template <class Evaluation>
+    Evaluation saturatedGasDissolutionFactor(unsigned regionIdx,
+                                              const Evaluation& /*temperature*/,
+                                              const Evaluation& pressure,
+                                              const Evaluation& oilSaturation,
+                                              const Evaluation& maxOilSaturation) const
+    {
+        typedef typename Opm::MathToolbox<Evaluation> Toolbox;
+        Evaluation tmp =
+            saturatedGasDissolutionFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true);
+
+        // apply the vaporization parameters for the gas phase (cf. the Eclipse VAPPARS
+        // keyword)
+        if (vapPar2_ > 0.0 && maxOilSaturation > 0.01) {
+            static const Scalar sqrtEps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
+            const Evaluation& So = Toolbox::max(oilSaturation, sqrtEps);
+            tmp *= Toolbox::pow(So/maxOilSaturation, vapPar2_);
+        }
+
+        return tmp;
+    }
+
+    /*!
      * \brief Returns the saturation pressure of the oil phase [Pa]
      *        depending on its mass fraction of the gas component
      *
@@ -535,6 +570,8 @@ private:
     std::vector<TabulatedOneDFunction> inverseSaturatedOilBMuTable_;
     std::vector<TabulatedOneDFunction> saturatedGasDissolutionFactorTable_;
     std::vector<Spline> saturationPressureSpline_;
+
+    Scalar vapPar2_;
 };
 
 } // namespace Opm

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -199,6 +199,18 @@ public:
                                              const Evaluation& pressure) const
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasDissolutionFactor(regionIdx, temperature, pressure)); return 0; }
 
+
+    /*!
+     * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of saturated oil.
+     */
+    template <class Evaluation>
+    Evaluation saturatedGasDissolutionFactor(unsigned regionIdx,
+                                             const Evaluation& temperature,
+                                             const Evaluation& pressure,
+                                             const Evaluation& oilSaturation,
+                                             const Evaluation& maxOilSaturation) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasDissolutionFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation)); return 0; }
+
     /*!
      * \brief Returns the saturation pressure [Pa] of oil given the mass fraction of the
      *        gas component in the oil phase.

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -258,6 +258,21 @@ public:
     { return isothermalPvt_->saturatedGasDissolutionFactor(regionIdx, temperature, pressure); }
 
     /*!
+     * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
+     *
+     * This method implements temperature dependence and requires the isothermal gas
+     * dissolution factor for gas saturated oil and temperature as inputs. Currently it
+     * is just a dummy method which passes through the isothermal gas dissolution factor.
+     */
+    template <class Evaluation>
+    Evaluation saturatedGasDissolutionFactor(unsigned regionIdx,
+                                             const Evaluation& temperature,
+                                             const Evaluation& pressure,
+                                             const Evaluation& oilSaturation,
+                                             const Evaluation& maxOilSaturation) const
+    { return isothermalPvt_->saturatedGasDissolutionFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation); }
+
+    /*!
      * \brief Returns the saturation pressure of the oil phase [Pa]
      *
      * This method implements temperature dependence and requires isothermal satuation

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -143,6 +143,8 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         Evaluation pressure = 1e5;
         Evaluation Rs = 0.0;
         Evaluation Rv = 0.0;
+        Evaluation So = 0.5;
+        Evaluation maxSo = 1.0;
         Evaluation tmp;
 
         /////
@@ -178,6 +180,11 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         tmp = oilPvt.saturatedGasDissolutionFactor(/*regionIdx=*/0,
                                                    temperature,
                                                    pressure);
+        tmp = oilPvt.saturatedGasDissolutionFactor(/*regionIdx=*/0,
+                                                   temperature,
+                                                   pressure,
+                                                   So,
+                                                   maxSo);
 
         /////
         // gas PVT API
@@ -202,6 +209,11 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         tmp = gasPvt.saturatedOilVaporizationFactor(/*regionIdx=*/0,
                                                     temperature,
                                                     pressure);
+        tmp = gasPvt.saturatedOilVaporizationFactor(/*regionIdx=*/0,
+                                                    temperature,
+                                                    pressure,
+                                                    So,
+                                                    maxSo);
 
         // prevent GCC from producing a "variable assigned but unused" warning
         tmp = 2.0*tmp;

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -143,10 +143,10 @@ void ensureBlackoilApi()
             dummy = FluidSystem::saturatedInverseFormationVolumeFactor(fluidState, phaseIdx, /*regionIdx=*/0);
             dummy = FluidSystem::viscosity(fluidState, phaseIdx, /*regionIdx=*/0);
             dummy = FluidSystem::saturatedDissolutionFactor(fluidState, phaseIdx, /*regionIdx=*/0);
+            dummy = FluidSystem::saturatedDissolutionFactor(fluidState, phaseIdx, /*regionIdx=*/0, /*maxSo=*/1.0);
             dummy = FluidSystem::saturationPressure(fluidState, phaseIdx, /*regionIdx=*/0);
-            for (unsigned compIdx = 0; compIdx < FluidSystem::numComponents; ++ compIdx) {
+            for (unsigned compIdx = 0; compIdx < FluidSystem::numComponents; ++ compIdx)
                 dummy = FluidSystem::fugacityCoefficient(fluidState, phaseIdx, compIdx,  /*regionIdx=*/0);
-            }
         }
 
         // prevent GCC from producing a "variable assigned but unused" warning


### PR DESCRIPTION
this is yet another crazy Eclipse hack: in the oil-with-dissolved-gas-and-gas-with-vaporized-oil case it prevents the dissolved component to be fully assimilated by solvent phase if the maximum oil phase saturation seen during the simulation stays below a given limit...

