### PR TITLE
Fix const method overload.

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -218,7 +218,7 @@ public:
         return materialLawParams_[elemIdx];
     }
 
-    std::shared_ptr<const MaterialLawParams>& materialLawParamsPointer(unsigned elemIdx) const
+    const std::shared_ptr<MaterialLawParams>& materialLawParamsPointer(unsigned elemIdx) const
     {
         assert(0 <= elemIdx && elemIdx < materialLawParams_.size());
         return materialLawParams_[elemIdx];


### PR DESCRIPTION
A `const shared_ptr<Foo>` cannot be converted to a `shared_ptr<const Foo>`.