### PR TITLE
MaterialLawManager: don't use the materialLawParamsPointer() method in materialLawParams()

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -214,15 +214,9 @@ public:
         return *materialLawParams_[elemIdx];
     }
 
-    std::shared_ptr<MaterialLawParams> materialLawParamsPointer(unsigned elemIdx)
+    std::shared_ptr<MaterialLawParams>& materialLawParamsPointerReferenceHack(unsigned elemIdx)
     {
         assert(0 <= elemIdx && elemIdx <  materialLawParams_.size());
-        return materialLawParams_[elemIdx];
-    }
-
-    std::shared_ptr<const MaterialLawParams> materialLawParamsPointer(unsigned elemIdx) const
-    {
-        assert(0 <= elemIdx && elemIdx < materialLawParams_.size());
         return materialLawParams_[elemIdx];
     }
 
@@ -269,12 +263,7 @@ public:
         return *oilWaterScaledEpsInfoDrainage_[elemIdx];
     }
 
-    const std::shared_ptr<EclEpsScalingPointsInfo<Scalar> >& oilWaterScaledEpsInfoDrainagePointer(unsigned elemIdx) const
-    {
-        return oilWaterScaledEpsInfoDrainage_[elemIdx];
-    }
-
-    std::shared_ptr<EclEpsScalingPointsInfo<Scalar> >& oilWaterScaledEpsInfoDrainagePointer(unsigned elemIdx)
+    std::shared_ptr<EclEpsScalingPointsInfo<Scalar> >& oilWaterScaledEpsInfoDrainagePointerReferenceHack(unsigned elemIdx)
     {
         return oilWaterScaledEpsInfoDrainage_[elemIdx];
     }

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -204,21 +204,23 @@ public:
 
     MaterialLawParams& materialLawParams(unsigned elemIdx)
     {
-        return *materialLawParamsPointer(elemIdx);
+        assert(0 <= elemIdx && elemIdx <  materialLawParams_.size());
+        return *materialLawParams_[elemIdx];
     }
 
     const MaterialLawParams& materialLawParams(unsigned elemIdx) const
     {
-        return *materialLawParamsPointer(elemIdx);
+        assert(0 <= elemIdx && elemIdx <  materialLawParams_.size());
+        return *materialLawParams_[elemIdx];
     }
 
-    std::shared_ptr<MaterialLawParams>& materialLawParamsPointer(unsigned elemIdx)
+    std::shared_ptr<MaterialLawParams> materialLawParamsPointer(unsigned elemIdx)
     {
         assert(0 <= elemIdx && elemIdx <  materialLawParams_.size());
         return materialLawParams_[elemIdx];
     }
 
-    std::shared_ptr<const MaterialLawParams>& materialLawParamsPointer(unsigned elemIdx) const
+    std::shared_ptr<const MaterialLawParams> materialLawParamsPointer(unsigned elemIdx) const
     {
         assert(0 <= elemIdx && elemIdx < materialLawParams_.size());
         return materialLawParams_[elemIdx];


### PR DESCRIPTION
this fixes the issue of https://github.com/OPM/opm-material/pull/155
in a better manner. (I hope.)