### PR TITLE
blackoil PVT: treat the maximum oil saturation for VAPPARS a constant

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -119,7 +119,7 @@ public:
         typedef EvaluationT Evaluation;
 
     public:
-        ParameterCache(const Evaluation& maxOilSat = 1.0, int regionIdx=0)
+        ParameterCache(Scalar maxOilSat = 1.0, int regionIdx=0)
         {
             maxOilSat_ = maxOilSat;
             regionIdx_ = regionIdx;
@@ -160,14 +160,14 @@ public:
         void setRegionIndex(unsigned val)
         { regionIdx_ = val; }
 
-        const Evaluation& maxOilSat() const
+        const Scalar maxOilSat() const
         { return maxOilSat_; }
 
-        void setMaxOilSat(const Evaluation& val)
+        void setMaxOilSat(Scalar val)
         { maxOilSat_ = val; }
 
     private:
-        Evaluation maxOilSat_;
+        Scalar maxOilSat_;
         unsigned regionIdx_;
     };
 
@@ -892,7 +892,7 @@ public:
     static LhsEval saturatedDissolutionFactor(const FluidState& fluidState,
                                               unsigned phaseIdx,
                                               unsigned regionIdx,
-                                              const LhsEval& maxOilSaturation)
+                                              Scalar maxOilSaturation)
     {
         assert(0 <= phaseIdx && phaseIdx <= numPhases);
         assert(0 <= regionIdx && regionIdx <= numRegions());

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -238,7 +238,7 @@ public:
                                              const Evaluation& /*temperature*/,
                                              const Evaluation& /*pressure*/,
                                              const Evaluation& /*oilSaturation*/,
-                                             const Evaluation& /*maxOilSaturation*/) const
+                                             Scalar /*maxOilSaturation*/) const
     { return 0.0; /* this is dead oil! */ }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -227,7 +227,7 @@ public:
                                              const Evaluation& /*temperature*/,
                                              const Evaluation& /*pressure*/,
                                              const Evaluation& /*oilSaturation*/,
-                                             const Evaluation& /*maxOilSaturation*/) const
+                                             Scalar /*maxOilSaturation*/) const
     { return 0.0; /* this is dead oil! */ }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -254,7 +254,7 @@ public:
                                               const Evaluation& /*temperature*/,
                                               const Evaluation& /*pressure*/,
                                               const Evaluation& /*oilSaturation*/,
-                                              const Evaluation& /*maxOilSaturation*/) const
+                                              Scalar /*maxOilSaturation*/) const
     { return 0.0; /* this is dry gas! */ }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -220,7 +220,7 @@ public:
                                               const Evaluation& temperature,
                                               const Evaluation& pressure,
                                               const Evaluation& oilSaturation,
-                                              const Evaluation& maxOilSaturation) const
+                                              Scalar maxOilSaturation) const
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilVaporizationFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation)); return 0; }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -233,7 +233,7 @@ public:
                                               const Evaluation& temperature,
                                               const Evaluation& pressure,
                                               const Evaluation& oilSaturation,
-                                              const Evaluation& maxOilSaturation) const
+                                              Scalar maxOilSaturation) const
     { return isothermalPvt_->saturatedOilVaporizationFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation); }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -483,7 +483,7 @@ public:
                                               const Evaluation& /*temperature*/,
                                               const Evaluation& pressure,
                                               const Evaluation& oilSaturation,
-                                              const Evaluation& maxOilSaturation) const
+                                              Scalar maxOilSaturation) const
     {
         typedef typename Opm::MathToolbox<Evaluation> Toolbox;
         Evaluation tmp =
@@ -491,7 +491,7 @@ public:
 
         // apply the vaporization parameters for the gas phase (cf. the Eclipse VAPPARS
         // keyword)
-        if (vapPar2_ > 0.0 && maxOilSaturation > 0.01) {
+        if (vapPar2_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
             static const Scalar sqrtEps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
             const Evaluation& So = Toolbox::max(oilSaturation, sqrtEps);
             tmp *= Toolbox::pow(So/maxOilSaturation, vapPar2_);

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -199,7 +199,6 @@ public:
                                              const Evaluation& pressure) const
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasDissolutionFactor(regionIdx, temperature, pressure)); return 0; }
 
-
     /*!
      * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of saturated oil.
      */
@@ -208,7 +207,7 @@ public:
                                              const Evaluation& temperature,
                                              const Evaluation& pressure,
                                              const Evaluation& oilSaturation,
-                                             const Evaluation& maxOilSaturation) const
+                                             Scalar maxOilSaturation) const
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasDissolutionFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation)); return 0; }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -269,7 +269,7 @@ public:
                                              const Evaluation& temperature,
                                              const Evaluation& pressure,
                                              const Evaluation& oilSaturation,
-                                             const Evaluation& maxOilSaturation) const
+                                             Scalar maxOilSaturation) const
     { return isothermalPvt_->saturatedGasDissolutionFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation); }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -511,7 +511,7 @@ public:
                                               const Evaluation& /*temperature*/,
                                               const Evaluation& pressure,
                                               const Evaluation& oilSaturation,
-                                              const Evaluation& maxOilSaturation) const
+                                              Scalar maxOilSaturation) const
     {
         typedef typename Opm::MathToolbox<Evaluation> Toolbox;
         Evaluation tmp =

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -137,6 +137,8 @@ static const char* deckString1 =
 template <class Evaluation, class OilPvt, class GasPvt, class WaterPvt>
 void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& waterPvt)
 {
+    typedef typename Opm::MathToolbox<Evaluation> Toolbox;
+
     // we don't want to run this, we just want to make sure that it compiles
     while (0) {
         Evaluation temperature = 273.15 + 20.0;
@@ -144,7 +146,7 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         Evaluation Rs = 0.0;
         Evaluation Rv = 0.0;
         Evaluation So = 0.5;
-        Evaluation maxSo = 1.0;
+        typename Toolbox::Scalar maxSo = 1.0;
         Evaluation tmp;
 
         /////


### PR DESCRIPTION
also, only calculate a factor if the currently observed oil saturation
is smaller than the maximum oil saturation. The new code is not
completely equivalent to the old one because derivatives are not
considered if the oil saturation increases, but the differences should
be small and they should be closer to how the current master version
of opm-simulators handles VAPPARS.