### PR TITLE
fix inconsistency in the VAPPARS treatment of wet gas

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -519,7 +519,7 @@ public:
 
         // apply the vaporization parameters for the gas phase (cf. the Eclipse VAPPARS
         // keyword)
-        if (vapPar1_ > 0.0 && maxOilSaturation > 0.01) {
+        if (vapPar1_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
             static const Scalar sqrtEps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
             const Evaluation& So = Toolbox::max(oilSaturation, sqrtEps);
             tmp *= Toolbox::pow(So/maxOilSaturation, vapPar1_);


### PR DESCRIPTION
this is rather minor: in contrast to live oil, the scaling factor for wet gas was not conditional on whether the oil saturation was smaller than the maximum observed one.