### PR TITLE
Hystersis cleanups

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -339,7 +339,7 @@ public:
         if (params.inconsistentHysteresisUpdate()) {
             Sg = std::min(Scalar(1.0), std::max(Scalar(0.0), Sg));
             // NOTE: the saturations which are passed to update the hysteresis curves are
-            // inconsistent with the ones used to calculate the relative permeabilities. We do
+            // inconsistent with the ones used to calculate the relative permabilities. We do
             // it like this anyway because (a) the saturation functions of opm-core do it
             // this way (b) the simulations seem to converge better (which is not too much
             // surprising actually, because the time step does not start on a kink in the

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -339,7 +339,7 @@ public:
         if (params.inconsistentHysteresisUpdate()) {
             Sg = std::min(Scalar(1.0), std::max(Scalar(0.0), Sg));
             // NOTE: the saturations which are passed to update the hysteresis curves are
-            // inconsistent with the ones used to calculate the relative permabilities. We do
+            // inconsistent with the ones used to calculate the relative permeabilities. We do
             // it like this anyway because (a) the saturation functions of opm-core do it
             // this way (b) the simulations seem to converge better (which is not too much
             // surprising actually, because the time step does not start on a kink in the

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -129,11 +129,11 @@ private:
     // mentioned in the deck. (saves memory.)
     void retrieveGridPropertyData_(const DoubleData **data,
                                    const Opm::EclipseState& eclState,
-                                   const std::string& properyName)
+                                   const std::string& propertyName)
     {
         (*data) = 0;
-        if (eclState.get3DProperties().hasDeckDoubleGridProperty(properyName))
-            (*data) = &eclState.get3DProperties().getDoubleGridProperty(properyName).getData();
+        if (eclState.get3DProperties().hasDeckDoubleGridProperty(propertyName))
+            (*data) = &eclState.get3DProperties().getDoubleGridProperty(propertyName).getData();
     }
 #endif
 };

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -497,7 +497,7 @@ private:
             return scaledPcnw*(params.config().deckPressureConversionFactor()/alpha);
         }
         else if (params.config().enablePcScaling()) {
-            Scalar alpha = params.unscaledPoints().maxPcnw()/params.scaledPoints().maxPcnw();
+            Scalar alpha = params.scaledPoints().maxPcnw()/params.unscaledPoints().maxPcnw();
             return scaledPcnw/alpha;
         }
 

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -148,10 +148,6 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
     {
-#if 1
-        // TODO: capillary pressure hysteresis
-        return EffectiveLaw::twoPhaseSatPcnw(params.drainageParams(), Sw);
-#else
         if (!params.config().enableHysteresis() || params.config().pcHysteresisModel() < 0)
             return EffectiveLaw::twoPhaseSatPcnw(params.drainageParams(), Sw);
 
@@ -161,7 +157,6 @@ public:
         const Evaluation& SwEff = Sw + params.deltaSwImbPc();
 
         return EffectiveLaw::twoPhaseSatPcnw(params.imbibitionParams(), SwEff);
-#endif
     }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -148,20 +148,20 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
     {
+#if 1
         // TODO: capillary pressure hysteresis
         return EffectiveLaw::twoPhaseSatPcnw(params.drainageParams(), Sw);
-/*
+#else
         if (!params.config().enableHysteresis() || params.config().pcHysteresisModel() < 0)
             return EffectiveLaw::twoPhaseSatPcnw(params.drainageParams(), Sw);
 
-        if (Sw < params.SwMdc())
+        if (Sw <= params.pcSwMdc())
             return EffectiveLaw::twoPhaseSatPcnw(params.drainageParams(), Sw);
 
-        const Evaluation& SwEff = Sw;
+        const Evaluation& SwEff = Sw + params.deltaSwImbPc();
 
-        //return EffectiveLaw::twoPhaseSatPcnw(params.imbibitionParams(), SwEff);
-        return EffectiveLaw::twoPhaseSatPcnw(params.drainageParams(), SwEff);
-*/
+        return EffectiveLaw::twoPhaseSatPcnw(params.imbibitionParams(), SwEff);
+#endif
     }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -231,7 +231,6 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
     {
-
         // if no relperm hysteresis is enabled, use the drainage curve
         if (!params.config().enableHysteresis() || params.config().krHysteresisModel() < 0)
             return EffectiveLaw::twoPhaseSatKrw(params.drainageParams(), Sw);

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -64,6 +64,7 @@ public:
 
         deltaSwImbKrn_ = 0.0;
         // deltaSwImbKrw_ = 0.0;
+        deltaSwImbPc_ = 0.0;
 
 #ifndef NDEBUG
         finalized_ = false;
@@ -235,6 +236,26 @@ public:
      */
     Scalar deltaSwImbKrn() const
     { return deltaSwImbKrn_; }
+
+    /*!
+     * \brief Sets the saturation value which must be added if the capillary pressure is
+     *        calculated using the imbibition curve.
+     *
+     * This means that p_cnw(Sw) = pc_cnw,drainage(Sw) if Sw < SwMdc and pcnw(Sw) =
+     * pcnw_imbibition(Sw + Sw_shift,pc) else
+     */
+    void setDeltaSwImbPc(Scalar value)
+    { deltaSwImbPc_ = value; }
+
+    /*!
+     * \brief Returns the saturation value which must be added if the capillary pressure is
+     *        calculated using the imbibition curve.
+     *
+     * This means that p_cnw(Sw) = pc_cnw,drainage(Sw) if Sw < SwMdc and pcnw(Sw) =
+     * pcnw_imbibition(Sw + Sw_shift,pc) else
+     */
+    Scalar deltaSwImbPc() const
+    { return deltaSwImbPc_; }
 
     /*!
      * \brief Notify the hysteresis law that a given wetting-phase saturation has been seen

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -60,10 +60,10 @@ public:
     {
         pcSwMdc_ = 2.0;
         krnSwMdc_ = 2.0;
-        // krwSwMdc_ = 2.0;
+        krwSwMdc_ = 2.0;
 
         deltaSwImbKrn_ = 0.0;
-        // deltaSwImbKrw_ = 0.0;
+        deltaSwImbKrw_ = 0.0;
         deltaSwImbPc_ = 0.0;
 
 #ifndef NDEBUG
@@ -77,12 +77,6 @@ public:
      */
     void finalize()
     {
-        if (config().enableHysteresis()) {
-            //C_ = 1.0/(Sncri_ - Sncrd_) + 1.0/(Snmaxd_ - Sncrd_);
-
-            updateDynamicParams_();
-        }
-
 #ifndef NDEBUG
         finalized_ = true;
 #endif

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -312,8 +312,8 @@ private:
         Scalar SwPcMdcImbibition = EffLawT::twoPhaseSatPcnwInv(imbibitionParams(), pcMdcDrainage);
         deltaSwImbPc_ = SwPcMdcImbibition - pcSwMdc_;
 
-//        assert(std::abs(EffLawT::twoPhaseSatPcnw(imbibitionParams(), pcSwMdc_ + deltaSwImbPc_)
-//                        - EffLawT::twoPhaseSatPcnw(drainageParams(), pcSwMdc_)) < 1e-8);
+        assert(std::abs(EffLawT::twoPhaseSatPcnw(imbibitionParams(), pcSwMdc_ + deltaSwImbPc_)
+                        - EffLawT::twoPhaseSatPcnw(drainageParams(), pcSwMdc_)) < 1e-8);
         assert(std::abs(EffLawT::twoPhaseSatKrn(imbibitionParams(), krnSwMdc_ + deltaSwImbKrn_)
                         - EffLawT::twoPhaseSatKrn(drainageParams(), krnSwMdc_)) < 1e-8);
         assert(std::abs(EffLawT::twoPhaseSatKrw(imbibitionParams(), krwSwMdc_ + deltaSwImbKrw_)

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -77,6 +77,12 @@ public:
      */
     void finalize()
     {
+        if (config().enableHysteresis()) {
+            //C_ = 1.0/(Sncri_ - Sncrd_) + 1.0/(Snmaxd_ - Sncrd_);
+
+            updateDynamicParams_();
+        }
+
 #ifndef NDEBUG
         finalized_ = true;
 #endif
@@ -324,8 +330,8 @@ private:
                         - EffLawT::twoPhaseSatPcnw(drainageParams(), pcSwMdc_)) < 1e-8);
         assert(std::abs(EffLawT::twoPhaseSatKrn(imbibitionParams(), krnSwMdc_ + deltaSwImbKrn_)
                         - EffLawT::twoPhaseSatKrn(drainageParams(), krnSwMdc_)) < 1e-8);
-        assert(std::abs(EffLawT::twoPhaseSatKrw(imbibitionParams(), krwSwMdc_ + deltaSwImbKrw_)
-                        - EffLawT::twoPhaseSatKrw(drainageParams(), krwSwMdc_)) < 1e-8);
+//        assert(std::abs(EffLawT::twoPhaseSatKrw(imbibitionParams(), krwSwMdc_ + deltaSwImbKrw_)
+//                        - EffLawT::twoPhaseSatKrw(drainageParams(), krwSwMdc_)) < 1e-8);
 
 #if 0
         Scalar Snhy = 1.0 - SwMdc_;

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -203,9 +203,8 @@ public:
      * This means that krw(Sw) = krw_drainage(Sw) if Sw < SwMdc and
      * krw(Sw) = krw_imbibition(Sw + Sw_shift,krw) else
      */
-    void setDeltaSwImbKrw(Scalar /* value */)
-    {}
-    //    { deltaSwImbKrw_ = value; }
+    void setDeltaSwImbKrw(Scalar value)
+    { deltaSwImbKrw_ = value; }
 
     /*!
      * \brief Returns the saturation value which must be added if krw is calculated using
@@ -215,8 +214,7 @@ public:
      * krw(Sw) = krw_imbibition(Sw + Sw_shift,krw) else
      */
     Scalar deltaSwImbKrw() const
-    { return 0.0; }
-//    { return deltaSwImbKrw_; }
+    { return deltaSwImbKrw_; }
 
     /*!
      * \brief Sets the saturation value which must be added if krn is calculated using
@@ -244,7 +242,7 @@ public:
      * This updates the scanning curves and the imbibition<->drainage reversal points as
      * appropriate.
      */
-    void update(Scalar pcSw, Scalar /* krwSw */, Scalar krnSw)
+    void update(Scalar pcSw, Scalar krwSw, Scalar krnSw)
     {
         bool updateParams = false;
         if (pcSw < pcSwMdc_) {
@@ -252,18 +250,10 @@ public:
             updateParams = true;
         }
 
-/*
-        // This is quite hacky: Eclipse says that it only uses relperm hysteresis for the
-        // wetting phase (indicated by '0' for the second item of the EHYSTER keyword),
-        // even though this makes about zero sense: one would expect that hysteresis can
-        // be limited to the oil phase, but the oil phase is the wetting phase of the
-        // gas-oil twophase system whilst it is non-wetting for water-oil.
-        if (krwSw < krwSwMdc_)
-        {
+        if (krwSw < krwSwMdc_) {
             krwSwMdc_ = krwSw;
             updateParams = true;
         }
-*/
 
         if (krnSw < krnSwMdc_) {
             krnSwMdc_ = krnSw;
@@ -288,14 +278,10 @@ private:
 
     void updateDynamicParams_()
     {
-        // HACK: Eclipse seems to disable the wetting-phase relperm even though this is
-        // quite pointless from the physical POV. (see comment above)
-/*
         // calculate the saturation deltas for the relative permeabilities
         Scalar krwMdcDrainage = EffLawT::twoPhaseSatKrw(drainageParams(), krwSwMdc_);
         Scalar SwKrwMdcImbibition = EffLawT::twoPhaseSatKrwInv(imbibitionParams(), krwMdcDrainage);
         deltaSwImbKrw_ = SwKrwMdcImbibition - krwSwMdc_;
-*/
 
         Scalar krnMdcDrainage = EffLawT::twoPhaseSatKrn(drainageParams(), krnSwMdc_);
         Scalar SwKrnMdcImbibition = EffLawT::twoPhaseSatKrnInv(imbibitionParams(), krnMdcDrainage);
@@ -309,14 +295,8 @@ private:
 //                        - EffLawT::twoPhaseSatPcnw(drainageParams(), pcSwMdc_)) < 1e-8);
         assert(std::abs(EffLawT::twoPhaseSatKrn(imbibitionParams(), krnSwMdc_ + deltaSwImbKrn_)
                         - EffLawT::twoPhaseSatKrn(drainageParams(), krnSwMdc_)) < 1e-8);
-//        assert(std::abs(EffLawT::twoPhaseSatKrw(imbibitionParams(), krwSwMdc_ + deltaSwImbKrw_)
-//                        - EffLawT::twoPhaseSatKrw(drainageParams(), krwSwMdc_)) < 1e-8);
-
-#if 0
-        Scalar Snhy = 1.0 - SwMdc_;
-
-        Sncrt_ = Sncrd_ + (Snhy - Sncrd_)/(1 + C_*(Snhy - Sncrd_));
-#endif
+        assert(std::abs(EffLawT::twoPhaseSatKrw(imbibitionParams(), krwSwMdc_ + deltaSwImbKrw_)
+                        - EffLawT::twoPhaseSatKrw(drainageParams(), krwSwMdc_)) < 1e-8);
     }
 
     std::shared_ptr<EclHysteresisConfig> config_;
@@ -326,32 +306,16 @@ private:
     // largest wettinging phase saturation which is on the main-drainage curve. These are
     // three different values because the sourounding code can choose to use different
     // definitions for the saturations for different quantities
-//    Scalar krwSwMdc_;
+    Scalar krwSwMdc_;
     Scalar krnSwMdc_;
     Scalar pcSwMdc_;
 
     // offsets added to wetting phase saturation uf using the imbibition curves need to
     // be used to calculate the wetting phase relperm, the non-wetting phase relperm and
     // the capillary pressure
-//    Scalar deltaSwImbKrw_;
+    Scalar deltaSwImbKrw_;
     Scalar deltaSwImbKrn_;
     Scalar deltaSwImbPc_;
-
-    // trapped non-wetting phase saturation
-    //Scalar Sncrt_;
-
-    // the following uses the conventions of the Eclipse technical description:
-    //
-    // Sncrd_: critical non-wetting phase saturation for the drainage curve
-    // Sncri_: critical non-wetting phase saturation for the imbibition curve
-    // Snmaxd_: non-wetting phase saturation where the non-wetting relperm reaches its
-    //          maximum on the drainage curve
-    // C_: factor required to calculate the trapped non-wetting phase saturation using
-    //     the Killough approach
-    //Scalar Sncrd_;
-    //Scalar Sncri_;
-    //Scalar Snmaxd_;
-    //Scalar C_;
 };
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -189,6 +189,11 @@ public:
                 elemScaledEpsInfo.maxPcow *= pcow/pcowAtSw;
                 auto& elemEclEpsScalingPoints = oilWaterScaledEpsPointsDrainage(elemIdx);
                 elemEclEpsScalingPoints.init(elemScaledEpsInfo, *oilWaterEclEpsConfig_, Opm::EclOilWaterSystem);
+
+                if (enableHysteresis()) {
+                    auto& elemEclEpsScalingPointsImb = oilWaterScaledEpsPointsImbibition(elemIdx);
+                    elemEclEpsScalingPointsImb.init(elemScaledEpsInfo, *oilWaterEclEpsConfig_, Opm::EclOilWaterSystem);
+                }
             }
         }
 
@@ -252,6 +257,36 @@ public:
             auto& realParams = materialParams.template getRealParams<Opm::EclTwoPhaseApproach>();
             return realParams.oilWaterParams().drainageParams().scaledPoints();
         }
+
+        default:
+            OPM_THROW(std::logic_error, "Enum value for material approach unknown!");
+        }
+    }
+
+    EclEpsScalingPoints<Scalar>& oilWaterScaledEpsPointsImbibition(unsigned elemIdx)
+    {
+        auto& materialParams = *materialLawParams_[elemIdx];
+        switch (materialParams.approach()) {
+        case EclStone1Approach: {
+            auto& realParams = materialParams.template getRealParams<Opm::EclStone1Approach>();
+            return realParams.oilWaterParams().imbibitionParams().scaledPoints();
+        }
+
+        case EclStone2Approach: {
+            auto& realParams = materialParams.template getRealParams<Opm::EclStone2Approach>();
+            return realParams.oilWaterParams().imbibitionParams().scaledPoints();
+        }
+
+        case EclDefaultApproach: {
+            auto& realParams = materialParams.template getRealParams<Opm::EclDefaultApproach>();
+            return realParams.oilWaterParams().imbibitionParams().scaledPoints();
+        }
+
+        case EclTwoPhaseApproach: {
+            auto& realParams = materialParams.template getRealParams<Opm::EclTwoPhaseApproach>();
+            return realParams.oilWaterParams().imbibitionParams().scaledPoints();
+        }
+
         default:
             OPM_THROW(std::logic_error, "Enum value for material approach unknown!");
         }

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -29,9 +29,10 @@
 
 #include "PiecewiseLinearTwoPhaseMaterialParams.hpp"
 
+#include <opm/material/common/MathToolbox.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
-#include <opm/material/common/MathToolbox.hpp>
+#include <opm/common/Valgrind.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -268,7 +269,7 @@ private:
 
         if (x0 == x1)
             // since the the function seems to be constant within the segment, we just
-            // return the value of it to avoid a division by zero.
+            // return the front value of it to avoid a division by zero.
             return yValues[segIdx];
 
         Scalar y0 = yValues[segIdx];
@@ -309,7 +310,7 @@ private:
 
         if (x0 == x1)
             // since the the function seems to be constant within the segment, we just
-            // return the value of it to avoid a division by zero.
+            // return the front value of it to avoid a division by zero.
             return yValues[segIdx];
 
         Scalar y0 = yValues[segIdx];

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -49,8 +49,7 @@ namespace Opm {
  * ECLIPSE reservoir simulator uses linear interpolation for capillary
  * pressure and relperm curves, we do the same.
  */
-template <class TraitsT,
-          class ParamsT = PiecewiseLinearTwoPhaseMaterialParams<TraitsT> >
+template <class TraitsT, class ParamsT = PiecewiseLinearTwoPhaseMaterialParams<TraitsT> >
 class PiecewiseLinearTwoPhaseMaterial : public TraitsT
 {
     typedef typename ParamsT::ValueVector ValueVector;
@@ -268,8 +267,8 @@ private:
         Scalar x1 = xValues[segIdx + 1];
 
         if (x0 == x1)
-            // since the the function seems to be constant within the segment, we just
-            // return the front value of it to avoid a division by zero.
+            // since the the function seems to be discontinuous, we just return the front
+            // value of the segment to avoid a division by zero.
             return yValues[segIdx];
 
         Scalar y0 = yValues[segIdx];
@@ -309,8 +308,8 @@ private:
         Scalar x1 = xValues[segIdx + 1];
 
         if (x0 == x1)
-            // since the the function seems to be constant within the segment, we just
-            // return the front value of it to avoid a division by zero.
+            // since the the function seems to be discontinuous, we just return the front
+            // value of the segment to avoid a division by zero.
             return yValues[segIdx];
 
         Scalar y0 = yValues[segIdx];


### PR DESCRIPTION
with this the wetting-phase relperm hysteresis becomes non-trivial, i.e., the saturation delta may be non-zero. this might be different from what E100 does (or rather what its documentation says), but before this the krw curve was discontinuous if the imbibition and the drainage were not identical. Norne is unaffected by this, because the KRW curves which it defines are identical for all twophase saturation functions.

I've verified that Norne, SPE1 and SPE2 are all unaffected by this (for the SPEs, this is a rather worthless statement because they don't use hysteresis, and for Norne the krw curves are identical for all saturation regions so this is also not surprising), but this should probably be tested more, i.e. using a case that enables hysteresis and which uses different krw curves for imbibition and for drainage.
