### PR TITLE
fix a compiler warning that appeared in some jenkins setups

### DIFF
--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -579,6 +579,11 @@ protected:
         {
             unsigned phaseIdx = (pvIdx - numPhases)/numComponents;
             unsigned compIdx = (pvIdx - numPhases)%numComponents;
+
+            if (phaseIdx >= numPhases)
+                OPM_THROW(std::runtime_error,
+                          "The phase index must be smaller than the number of phases");
+
             return fluidState.moleFraction(phaseIdx, compIdx);
         }
     }
@@ -607,6 +612,11 @@ protected:
             assert(pvIdx < numPhases + numPhases*numComponents);
             unsigned phaseIdx = (pvIdx - numPhases)/numComponents;
             unsigned compIdx = (pvIdx - numPhases)%numComponents;
+
+            if (phaseIdx >= numPhases)
+                OPM_THROW(std::runtime_error,
+                          "The phase index must be smaller than the number of phases");
+
             fluidState.setMoleFraction(phaseIdx, compIdx, value);
         }
     }

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -183,6 +183,7 @@ public:
             fs.setSaturation(gasPhaseIdx, 0);
             fs.setSaturation(oilPhaseIdx, 0);
             Scalar pc[numPhases];
+            std::fill(&pc[0], &pc[numPhases], 0.0);
             MaterialLaw::capillaryPressures(pc, materialLawParams(elemIdx), fs);
 
             Scalar pcowAtSw = pc[oilPhaseIdx] - pc[waterPhaseIdx];


### PR DESCRIPTION
the warning can be examined e.g. here:

https://ci.opm-project.org/job/ewoms-PR-builder/12/console

it is a false positive (in the sense that the code is never executed
with uninitialized values), but it is annoying for sure. The fix here
probably comes with a small runtime penalty, but I bet its effect
can't be measured.