### PR TITLE
implement ECL-like Leverett capillary pressure scaling

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -274,7 +274,6 @@ private:
         oilWaterEclEpsConfig_-> initFromDeck(deck, eclState, Opm::EclOilWaterSystem);
 
         enableEndPointScaling_ = deck.hasKeyword("ENDSCALE");
-
     }
 
     void readGlobalHysteresisOptions_(const Opm::Deck& deck)
@@ -379,12 +378,16 @@ private:
             readGasOilScaledPoints_(gasOilScaledInfoVector,
                                     gasOilScaledPointsVector,
                                     gasOilConfig,
+                                    deck,
+                                    eclState,
                                     epsGridProperties,
                                     elemIdx,
                                     cartElemIdx);
             readOilWaterScaledPoints_(oilWaterScaledEpsInfoDrainage_,
                                       oilWaterScaledEpsPointsDrainage,
                                       oilWaterConfig,
+                                      deck,
+                                      eclState,
                                       epsGridProperties,
                                       elemIdx,
                                       cartElemIdx);
@@ -393,12 +396,16 @@ private:
                 readGasOilScaledPoints_(gasOilScaledImbInfoVector,
                                         gasOilScaledImbPointsVector,
                                         gasOilConfig,
+                                        deck,
+                                        eclState,
                                         epsImbGridProperties,
                                         elemIdx,
                                         cartElemIdx);
                 readOilWaterScaledPoints_(oilWaterScaledImbInfoVector,
                                           oilWaterScaledImbPointsVector,
                                           oilWaterConfig,
+                                          deck,
+                                          eclState,
                                           epsImbGridProperties,
                                           elemIdx,
                                           cartElemIdx);
@@ -771,6 +778,8 @@ private:
     void readGasOilScaledPoints_(InfoContainer& destInfo,
                                  PointsContainer& destPoints,
                                  std::shared_ptr<EclEpsConfig> config,
+                                 const Opm::Deck& deck,
+                                 const Opm::EclipseState& eclState,
                                  const EclEpsGridProperties& epsGridProperties,
                                  unsigned elemIdx,
                                  unsigned cartElemIdx)
@@ -778,7 +787,7 @@ private:
         unsigned satnumIdx = static_cast<unsigned>((*epsGridProperties.satnum)[cartElemIdx]) - 1; // ECL uses Fortran indices!
 
         destInfo[elemIdx] = std::make_shared<EclEpsScalingPointsInfo<Scalar> >(unscaledEpsInfo_[satnumIdx]);
-        destInfo[elemIdx]->extractScaled(epsGridProperties, cartElemIdx);
+        destInfo[elemIdx]->extractScaled(deck, eclState, epsGridProperties, cartElemIdx);
 
         destPoints[elemIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
         destPoints[elemIdx]->init(*destInfo[elemIdx], *config, EclGasOilSystem);
@@ -788,6 +797,8 @@ private:
     void readOilWaterScaledPoints_(InfoContainer& destInfo,
                                    PointsContainer& destPoints,
                                    std::shared_ptr<EclEpsConfig> config,
+                                   const Opm::Deck& deck,
+                                   const Opm::EclipseState& eclState,
                                    const EclEpsGridProperties& epsGridProperties,
                                    unsigned elemIdx,
                                    unsigned cartElemIdx)
@@ -795,7 +806,7 @@ private:
         unsigned satnumIdx = static_cast<unsigned>((*epsGridProperties.satnum)[cartElemIdx]) - 1; // ECL uses Fortran indices!
 
         destInfo[elemIdx] = std::make_shared<EclEpsScalingPointsInfo<Scalar> >(unscaledEpsInfo_[satnumIdx]);
-        destInfo[elemIdx]->extractScaled(epsGridProperties, cartElemIdx);
+        destInfo[elemIdx]->extractScaled(deck, eclState, epsGridProperties, cartElemIdx);
 
         destPoints[elemIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
         destPoints[elemIdx]->init(*destInfo[elemIdx], *config, EclOilWaterSystem);


### PR DESCRIPTION
i.e., this patch deals with the JFUNC ECL keyword.

This is a "stand-alone" version of the functionality which does not make use of the unit system in opm-parser/core because there emerged some problems (cf. OPM/opm-parser#936). Also note that since the JFUNC keyword makes the meaning capillary pressure columns of the base saturation keywords (SGOF, SWOF, SWFN, etc.) context dependent but currently these columns are always treated as pressures by opm-parser, the automatic conversion to SI units done by opm-parser is manually reversed. (at least for now.)

Also note that a minor opm-core fix-up PR is needed due to a API change.