### PR TITLE
MathToolbox: add isfinite() and isnan() methods

### DIFF
--- a/opm/material/common/MathToolbox.hpp
+++ b/opm/material/common/MathToolbox.hpp
@@ -201,6 +201,14 @@ public:
     //! Exponentiation to an arbitrary base
     static Scalar pow(Scalar base, Scalar exp)
     { return std::pow(base, exp); }
+
+    //! Return true iff the argument's value and all its derivatives are finite values
+    static bool isfinite(Scalar arg)
+    { return std::isfinite(arg); }
+
+    //! Return true iff the argument's value or any of its derivatives are NaN values
+    static bool isnan(Scalar arg)
+    { return std::isnan(arg); }
 };
 
 template <class Eval1, class Eval2>
@@ -294,6 +302,14 @@ template <class Evaluation1, class Evaluation2>
 typename ReturnEval_<Evaluation1, Evaluation2>::type
 pow(const Evaluation1& base, const Evaluation2& exp)
 { return Opm::MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::pow(base, exp); }
+
+template <class Evaluation>
+Evaluation isfinite(const Evaluation& value)
+{ return Opm::MathToolbox<Evaluation>::isfinite(value); }
+
+template <class Evaluation>
+Evaluation isnan(const Evaluation& value)
+{ return Opm::MathToolbox<Evaluation>::isnan(value); }
 
 } // namespace Opm
 

--- a/opm/material/densead/Math.hpp
+++ b/opm/material/densead/Math.hpp
@@ -546,6 +546,30 @@ public:
 
     static Evaluation pow(const Evaluation& arg1, const Evaluation& arg2)
     { return Opm::DenseAd::pow(arg1, arg2); }
+
+    static bool isfinite(const Evaluation& arg)
+    {
+        if (!InnerToolbox::isfinite(arg.value))
+            return false;
+
+        for (int i = 0; i < numVars; ++i)
+            if (!InnerToolbox::isfinite(arg.derivatives[i]))
+                return false;
+
+        return true;
+    }
+
+    static bool isnan(const Evaluation& arg)
+    {
+        if (InnerToolbox::isnan(arg.value))
+            return true;
+
+        for (int i = 0; i < numVars; ++i)
+            if (InnerToolbox::isnan(arg.derivatives[i]))
+                return true;
+
+        return false;
+    }
 };
 
 }


### PR DESCRIPTION
for primitive floating point objects, these correspond to
std::isfinite() and std::isnan() while for evaluations, they trigger
on the evaluation's value or any of its derivatives being non-finite
or NaN. (i.e., for evaluations they should be better called
containsnonfinite(), containsnan().)