### PR TITLE
change Evaluation to accessor methods

### DIFF
--- a/opm/material/constraintsolvers/ImmiscibleFlash.hpp
+++ b/opm/material/constraintsolvers/ImmiscibleFlash.hpp
@@ -190,9 +190,9 @@ public:
             // the linear system of equations.
             for (unsigned eqIdx = 0; eqIdx < numEq; ++ eqIdx) {
                 for (unsigned pvIdx = 0; pvIdx < numEq; ++ pvIdx)
-                    J[eqIdx][pvIdx] = defect[eqIdx].derivatives[pvIdx];
+                    J[eqIdx][pvIdx] = defect[eqIdx].derivative(pvIdx);
 
-                b[eqIdx] = defect[eqIdx].value;
+                b[eqIdx] = defect[eqIdx].value();
             }
             Valgrind::CheckDefined(J);
             Valgrind::CheckDefined(b);
@@ -274,7 +274,7 @@ protected:
         FlashEval Slast = InputToolbox::createConstant(1.0);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx) {
             FlashEval S = inputFluidState.saturation(phaseIdx);
-            S.derivatives[S0PvIdx + phaseIdx] = 1.0;
+            S.setDerivative(S0PvIdx + phaseIdx, 1.0);
 
             Slast -= S;
 
@@ -285,7 +285,7 @@ protected:
         // copy the pressures: the first pressure is the first primary variable, the
         // remaining ones are given as p_beta = p_alpha + p_calpha,beta
         FlashEval p0 = inputFluidState.pressure(0);
-        p0.derivatives[p0PvIdx] = 1.0;
+        p0.setDerivative(p0PvIdx, 1.0);
 
         std::array<FlashEval, numPhases> pc;
         MaterialLaw::capillaryPressures(pc, matParams, flashFluidState);
@@ -305,17 +305,17 @@ protected:
     static void assignOutputFluidState_(const FlashFluidState& flashFluidState,
                                         OutputFluidState& outputFluidState)
     {
-        outputFluidState.setTemperature(flashFluidState.temperature(/*phaseIdx=*/0).value);
+        outputFluidState.setTemperature(flashFluidState.temperature(/*phaseIdx=*/0).value());
 
         // copy the saturations, pressures and densities
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            const auto& S = flashFluidState.saturation(phaseIdx).value;
+            const auto& S = flashFluidState.saturation(phaseIdx).value();
             outputFluidState.setSaturation(phaseIdx, S);
 
-            const auto& p = flashFluidState.pressure(phaseIdx).value;
+            const auto& p = flashFluidState.pressure(phaseIdx).value();
             outputFluidState.setPressure(phaseIdx, p);
 
-            const auto& rho = flashFluidState.density(phaseIdx).value;
+            const auto& rho = flashFluidState.density(phaseIdx).value();
             outputFluidState.setDensity(phaseIdx, rho);
         }
     }
@@ -387,8 +387,8 @@ protected:
             else if (isPressureIdx_(pvIdx)) {
                 // dampen to at most 30% change in pressure per
                 // iteration
-                delta = InnerEvalToolbox::min(0.5*fluidState.pressure(0).value,
-                                              InnerEvalToolbox::max(-0.50*fluidState.pressure(0).value, delta));
+                delta = InnerEvalToolbox::min(0.5*fluidState.pressure(0).value(),
+                                              InnerEvalToolbox::max(-0.50*fluidState.pressure(0).value(), delta));
             }
 
             tmp -= delta;

--- a/opm/material/densead/Evaluation.hpp
+++ b/opm/material/densead/Evaluation.hpp
@@ -116,6 +116,15 @@ public:
             os << " " << derivatives[varIdx];
     }
 
+    void clearDerivatives()
+    { std::fill(derivatives_.begin(), derivatives_.end(), 0.0); }
+
+    void copyDerivatives(const Evaluation& other)
+    {
+        std::copy(other.derivatives_.begin(),
+                  other.derivatives_.end(),
+                  derivatives_.begin());
+    }
 
     Evaluation& operator+=(const Evaluation& other)
     {

--- a/opm/material/densead/Math.hpp
+++ b/opm/material/densead/Math.hpp
@@ -45,72 +45,19 @@ class Evaluation;
 // provide some algebraic functions
 template <class ValueType, int numVars>
 Evaluation<ValueType, numVars> abs(const Evaluation<ValueType, numVars>& x)
-{
-    Evaluation<ValueType, numVars> result;
-
-    if (x.value < 0.0) {
-        result.value = -x.value;
-        for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-            result.derivatives[curVarIdx] = -x.derivatives[curVarIdx];
-    }
-    else {
-        result.value = x.value;
-        for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-            result.derivatives[curVarIdx] = x.derivatives[curVarIdx];
-    }
-
-    return result;
-}
+{ return (x > 0.0)?x:-x; }
 
 template <class ValueType, int numVars>
 Evaluation<ValueType, numVars> min(const Evaluation<ValueType, numVars>& x1,
                                    const Evaluation<ValueType, numVars>& x2)
-{
-    Evaluation<ValueType, numVars> result;
-
-    if (x1.value < x2.value) {
-        result.value = x1.value;
-
-        std::copy(x1.derivatives.begin(),
-                  x1.derivatives.end(),
-                  result.derivatives.begin());
-    }
-    else  {
-        result.value = x2.value;
-
-        std::copy(x2.derivatives.begin(),
-                  x2.derivatives.end(),
-                  result.derivatives.begin());
-    }
-
-    return result;
-}
+{ return (x1 < x2)?x1:x2; }
 
 template <class Arg1ValueType, class ValueType, int numVars>
 Evaluation<ValueType, numVars> min(const Arg1ValueType& x1,
                                    const Evaluation<ValueType, numVars>& x2)
-{
-    Evaluation<ValueType, numVars> result;
+{ return (x1 < x2)?x1:x2; }
 
-    if (x1 < x2.value) {
-        result.value = x1;
-
-        std::fill(result.derivatives.begin(),
-                  result.derivatives.end(),
-                  0.0);
-    }
-    else  {
-        result.value = x2.value;
-
-        std::copy(x2.derivatives.begin(),
-                  x2.derivatives.end(),
-                  result.derivatives.begin());
-    }
-
-    return result;
-}
-
-template <class Arg2ValueType, class ValueType, int numVars>
+template <class ValueType, int numVars, class Arg2ValueType>
 Evaluation<ValueType, numVars> min(const Evaluation<ValueType, numVars>& x1,
                                    const Arg2ValueType& x2)
 { return min(x2, x1); }
@@ -118,52 +65,14 @@ Evaluation<ValueType, numVars> min(const Evaluation<ValueType, numVars>& x1,
 template <class ValueType, int numVars>
 Evaluation<ValueType, numVars> max(const Evaluation<ValueType, numVars>& x1,
                                    const Evaluation<ValueType, numVars>& x2)
-{
-    Evaluation<ValueType, numVars> result;
-
-    if (x1.value > x2.value) {
-        result.value = x1.value;
-
-        std::copy(x1.derivatives.begin(),
-                  x1.derivatives.end(),
-                  result.derivatives.begin());
-    }
-    else  {
-        result.value = x2.value;
-
-        std::copy(x2.derivatives.begin(),
-                  x2.derivatives.end(),
-                  result.derivatives.begin());
-    }
-
-    return result;
-}
+{ return (x1 > x2)?x1:x2; }
 
 template <class Arg1ValueType, class ValueType, int numVars>
 Evaluation<ValueType, numVars> max(const Arg1ValueType& x1,
                                    const Evaluation<ValueType, numVars>& x2)
-{
-    Evaluation<ValueType, numVars> result;
+{ return (x1 > x2)?x1:x2; }
 
-    if (x1 > x2.value) {
-        result.value = x1;
-
-        std::fill(result.derivatives.begin(),
-                  result.derivatives.end(),
-                  0.0);
-    }
-    else  {
-        result.value = x2.value;
-
-        std::copy(x2.derivatives.begin(),
-                  x2.derivatives.end(),
-                  result.derivatives.begin());
-    }
-
-    return result;
-}
-
-template <class Arg2ValueType, class ValueType, int numVars>
+template <class ValueType, int numVars, class Arg2ValueType>
 Evaluation<ValueType, numVars> max(const Evaluation<ValueType, numVars>& x1,
                                    const Arg2ValueType& x2)
 { return max(x2, x1); }

--- a/opm/material/densead/Math.hpp
+++ b/opm/material/densead/Math.hpp
@@ -84,13 +84,13 @@ Evaluation<ValueType, numVars> tan(const Evaluation<ValueType, numVars>& x)
 
     Evaluation<ValueType, numVars> result;
 
-    const ValueType& tmp = ValueTypeToolbox::tan(x.value);
-    result.value = tmp;
+    const ValueType& tmp = ValueTypeToolbox::tan(x.value());
+    result.setValue(tmp);
 
     // derivatives use the chain rule
     const ValueType& df_dx = 1 + tmp*tmp;
-    for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-        result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
+    for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx)
+        result.setDerivative(curVarIdx, df_dx*x.derivative(curVarIdx));
 
     return result;
 }
@@ -102,12 +102,12 @@ Evaluation<ValueType, numVars> atan(const Evaluation<ValueType, numVars>& x)
 
     Evaluation<ValueType, numVars> result;
 
-    result.value = ValueTypeToolbox::atan(x.value);
+    result.setValue(ValueTypeToolbox::atan(x.value()));
 
     // derivatives use the chain rule
-    const ValueType& df_dx = 1/(1 + x.value*x.value);
-    for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-        result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
+    const ValueType& df_dx = 1/(1 + x.value()*x.value());
+    for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx)
+        result.setDerivative(curVarIdx, df_dx*x.derivative(curVarIdx));
 
     return result;
 }
@@ -120,15 +120,14 @@ Evaluation<ValueType, numVars> atan2(const Evaluation<ValueType, numVars>& x,
 
     Evaluation<ValueType, numVars> result;
 
-    result.value = ValueTypeToolbox::atan2(x.value, y.value);
+    result.setValue(ValueTypeToolbox::atan2(x.value(), y.value()));
 
     // derivatives use the chain rule
-    const ValueType& alpha = 1/(1 + (x.value*x.value)/(y.value*y.value));
-    for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx) {
-        result.derivatives[curVarIdx] =
-            alpha
-            /(y.value*y.value)
-            *(x.derivatives[curVarIdx]*y.value - x.value*y.derivatives[curVarIdx]);
+    const ValueType& alpha = 1/(1 + (x.value()*x.value())/(y.value()*y.value()));
+    for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx) {
+        result.setDerivative(curVarIdx,
+                             alpha/(y.value()*y.value())
+                             *(x.derivative(curVarIdx)*y.value() - x.value()*y.derivative(curVarIdx)));
     }
 
     return result;
@@ -141,12 +140,12 @@ Evaluation<ValueType, numVars> sin(const Evaluation<ValueType, numVars>& x)
 
     Evaluation<ValueType, numVars> result;
 
-    result.value = ValueTypeToolbox::sin(x.value);
+    result.setValue(ValueTypeToolbox::sin(x.value()));
 
     // derivatives use the chain rule
-    const ValueType& df_dx = ValueTypeToolbox::cos(x.value);
-    for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-        result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
+    const ValueType& df_dx = ValueTypeToolbox::cos(x.value());
+    for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx)
+        result.setDerivative(curVarIdx, df_dx*x.derivative(curVarIdx));
 
     return result;
 }
@@ -158,12 +157,12 @@ Evaluation<ValueType, numVars> asin(const Evaluation<ValueType, numVars>& x)
 
     Evaluation<ValueType, numVars> result;
 
-    result.value = ValueTypeToolbox::asin(x.value);
+    result.setValue(ValueTypeToolbox::asin(x.value()));
 
     // derivatives use the chain rule
-    const ValueType& df_dx = 1.0/ValueTypeToolbox::sqrt(1 - x.value*x.value);
-    for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-        result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
+    const ValueType& df_dx = 1.0/ValueTypeToolbox::sqrt(1 - x.value()*x.value());
+    for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx)
+        result.setDerivative(curVarIdx, df_dx*x.derivative(curVarIdx));
 
     return result;
 }
@@ -175,12 +174,12 @@ Evaluation<ValueType, numVars> cos(const Evaluation<ValueType, numVars>& x)
 
     Evaluation<ValueType, numVars> result;
 
-    result.value = ValueTypeToolbox::cos(x.value);
+    result.setValue(ValueTypeToolbox::cos(x.value()));
 
     // derivatives use the chain rule
-    const ValueType& df_dx = -ValueTypeToolbox::sin(x.value);
-    for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-        result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
+    const ValueType& df_dx = -ValueTypeToolbox::sin(x.value());
+    for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx)
+        result.setDerivative(curVarIdx, df_dx*x.derivative(curVarIdx));
 
     return result;
 }
@@ -192,12 +191,12 @@ Evaluation<ValueType, numVars> acos(const Evaluation<ValueType, numVars>& x)
 
     Evaluation<ValueType, numVars> result;
 
-    result.value = ValueTypeToolbox::acos(x.value);
+    result.setValue(ValueTypeToolbox::acos(x.value()));
 
     // derivatives use the chain rule
-    const ValueType& df_dx = - 1.0/ValueTypeToolbox::sqrt(1 - x.value*x.value);
-    for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-        result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
+    const ValueType& df_dx = - 1.0/ValueTypeToolbox::sqrt(1 - x.value()*x.value());
+    for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx)
+        result.setDerivative(curVarIdx, df_dx*x.derivative(curVarIdx));
 
     return result;
 }
@@ -209,13 +208,13 @@ Evaluation<ValueType, numVars> sqrt(const Evaluation<ValueType, numVars>& x)
 
     Evaluation<ValueType, numVars> result;
 
-    const ValueType& sqrt_x = ValueTypeToolbox::sqrt(x.value);
-    result.value = sqrt_x;
+    const ValueType& sqrt_x = ValueTypeToolbox::sqrt(x.value());
+    result.setValue(sqrt_x);
 
     // derivatives use the chain rule
     ValueType df_dx = 0.5/sqrt_x;
-    for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx) {
-        result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
+    for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx) {
+        result.setDerivative(curVarIdx, df_dx*x.derivative(curVarIdx));
     }
 
     return result;
@@ -227,13 +226,13 @@ Evaluation<ValueType, numVars> exp(const Evaluation<ValueType, numVars>& x)
     typedef MathToolbox<ValueType> ValueTypeToolbox;
     Evaluation<ValueType, numVars> result;
 
-    const ValueType& exp_x = ValueTypeToolbox::exp(x.value);
-    result.value = exp_x;
+    const ValueType& exp_x = ValueTypeToolbox::exp(x.value());
+    result.setValue(exp_x);
 
     // derivatives use the chain rule
     const ValueType& df_dx = exp_x;
-    for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-        result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
+    for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx)
+        result.setDerivative(curVarIdx, df_dx*x.derivative(curVarIdx));
 
     return result;
 }
@@ -246,8 +245,8 @@ Evaluation<ValueType, numVars> pow(const Evaluation<ValueType, numVars>& base,
     typedef MathToolbox<ValueType> ValueTypeToolbox;
     Evaluation<ValueType, numVars> result;
 
-    const ValueType& pow_x = ValueTypeToolbox::pow(base.value, exp);
-    result.value = pow_x;
+    const ValueType& pow_x = ValueTypeToolbox::pow(base.value(), exp);
+    result.setValue(pow_x);
 
     if (base == 0.0) {
         // we special case the base 0 case because 0.0 is in the valid range of the
@@ -256,9 +255,9 @@ Evaluation<ValueType, numVars> pow(const Evaluation<ValueType, numVars>& base,
     }
     else {
         // derivatives use the chain rule
-        const ValueType& df_dx = pow_x/base.value*exp;
-        for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-            result.derivatives[curVarIdx] = df_dx*base.derivatives[curVarIdx];
+        const ValueType& df_dx = pow_x/base.value()*exp;
+        for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx)
+            result.setDerivative(curVarIdx, df_dx*base.derivative(curVarIdx));
     }
 
     return result;
@@ -280,12 +279,12 @@ Evaluation<ValueType, numVars> pow(const BaseType& base,
     }
     else {
         const ValueType& lnBase = ValueTypeToolbox::log(base);
-        result.value = ValueTypeToolbox::exp(lnBase*exp.value);
+        result.setValue(ValueTypeToolbox::exp(lnBase*exp.value()));
 
         // derivatives use the chain rule
-        const ValueType& df_dx = lnBase*result.value;
-        for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-            result.derivatives[curVarIdx] = df_dx*exp.derivatives[curVarIdx];
+        const ValueType& df_dx = lnBase*result.value();
+        for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx)
+            result.setDerivative(curVarIdx, df_dx*exp.derivative(curVarIdx));
     }
 
     return result;
@@ -307,18 +306,18 @@ Evaluation<ValueType, numVars> pow(const Evaluation<ValueType, numVars>& base,
         result = 0.0;
     }
     else {
-        ValueType valuePow = ValueTypeToolbox::pow(base.value, exp.value);
-        result.value = valuePow;
+        ValueType valuePow = ValueTypeToolbox::pow(base.value(), exp.value());
+        result.setValue(valuePow);
 
         // use the chain rule for the derivatives. since both, the base and the exponent can
         // potentially depend on the variable set, calculating these is quite elaborate...
-        const ValueType& f = base.value;
-        const ValueType& g = exp.value;
+        const ValueType& f = base.value();
+        const ValueType& g = exp.value();
         const ValueType& logF = ValueTypeToolbox::log(f);
-        for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx) {
-            const ValueType& fPrime = base.derivatives[curVarIdx];
-            const ValueType& gPrime = exp.derivatives[curVarIdx];
-            result.derivatives[curVarIdx] = (g*fPrime/f + logF*gPrime) * valuePow;
+        for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx) {
+            const ValueType& fPrime = base.derivative(curVarIdx);
+            const ValueType& gPrime = exp.derivative(curVarIdx);
+            result.setDerivative(curVarIdx, (g*fPrime/f + logF*gPrime) * valuePow);
         }
     }
 
@@ -332,12 +331,12 @@ Evaluation<ValueType, numVars> log(const Evaluation<ValueType, numVars>& x)
 
     Evaluation<ValueType, numVars> result;
 
-    result.value = ValueTypeToolbox::log(x.value);
+    result.setValue(ValueTypeToolbox::log(x.value()));
 
     // derivatives use the chain rule
-    const ValueType& df_dx = 1/x.value;
-    for (unsigned curVarIdx = 0; curVarIdx < result.derivatives.size(); ++curVarIdx)
-        result.derivatives[curVarIdx] = df_dx*x.derivatives[curVarIdx];
+    const ValueType& df_dx = 1/x.value();
+    for (unsigned curVarIdx = 0; curVarIdx < result.size; ++curVarIdx)
+        result.setDerivative(curVarIdx, df_dx*x.derivative(curVarIdx));
 
     return result;
 }
@@ -357,10 +356,10 @@ public:
     typedef Opm::DenseAd::Evaluation<ValueType, numVars> Evaluation;
 
     static ValueType value(const Evaluation& eval)
-    { return eval.value; }
+    { return eval.value(); }
 
     static decltype(InnerToolbox::scalarValue(0.0)) scalarValue(const Evaluation& eval)
-    { return InnerToolbox::scalarValue(eval.value); }
+    { return InnerToolbox::scalarValue(eval.value()); }
 
     static Evaluation createConstant(ValueType value)
     { return Evaluation::createConstant(value); }
@@ -384,7 +383,7 @@ public:
     static typename std::enable_if<std::is_floating_point<LhsEval>::value,
                                    LhsEval>::type
     decay(const Evaluation& eval)
-    { return eval.value; }
+    { return eval.value(); }
 
     // comparison
     static bool isSame(const Evaluation& a, const Evaluation& b, Scalar tolerance)
@@ -392,12 +391,12 @@ public:
         typedef MathToolbox<ValueType> ValueTypeToolbox;
 
         // make sure that the value of the evaluation is identical
-        if (!ValueTypeToolbox::isSame(a.value, b.value, tolerance))
+        if (!ValueTypeToolbox::isSame(a.value(), b.value(), tolerance))
             return false;
 
         // make sure that the derivatives are identical
         for (unsigned curVarIdx = 0; curVarIdx < numVars; ++curVarIdx)
-            if (!ValueTypeToolbox::isSame(a.derivatives[curVarIdx], b.derivatives[curVarIdx], tolerance))
+            if (!ValueTypeToolbox::isSame(a.derivative(curVarIdx), b.derivative(curVarIdx), tolerance))
                 return false;
 
         return true;

--- a/tests/test_densead.cpp
+++ b/tests/test_densead.cpp
@@ -66,6 +66,34 @@ void testOperators(const Scalar tolerance)
     const Eval xEval = Eval::createVariable(x, 0);
     const Eval yEval = Eval::createVariable(y, 1);
 
+    Eval xyEval = xEval;
+    Eval yxEval = yEval;
+
+    xyEval.copyDerivatives(yxEval);
+    yxEval.clearDerivatives();
+
+    for (int i = 0; i < numVars; ++i) {
+        if (i == 0 && xEval.derivative(i) != 1.0)
+            throw std::logic_error("oops: createVariable");
+        else if (i == 1 && yEval.derivative(i) != 1.0)
+            throw std::logic_error("oops: createVariable");
+        else if (i == 1 && xyEval.derivative(i) != 1.0)
+            throw std::logic_error("oops: copyDerivatives");
+        else continue;
+
+        // the remaining derivatives must be zero
+        if (xEval.derivative(i) != 0.0)
+            throw std::logic_error("oops: createVariable");
+        if (yEval.derivative(i) != 0.0)
+            throw std::logic_error("oops: createVariable");
+        if (cEval.derivative(i) != 0.0)
+            throw std::logic_error("oops: createConstant");
+        if (xyEval.derivative(i) != 0.0)
+            throw std::logic_error("oops: copyDerivatives");
+        if (xyEval.derivative(i) != 0.0)
+            throw std::logic_error("oops: clearDerivatives");
+    }
+
     // test the non-inplace operators
     {
         Eval a = xEval + yEval;

--- a/tests/test_densead.cpp
+++ b/tests/test_densead.cpp
@@ -97,57 +97,57 @@ void testOperators(const Scalar tolerance)
     // test the non-inplace operators
     {
         Eval a = xEval + yEval;
-        if (std::abs(a.value - (x + y)) > tolerance)
+        if (std::abs(a.value() - (x + y)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval b = xEval + c;
-        if (std::abs(b.value - (x + c)) > tolerance)
+        if (std::abs(b.value() - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval d = xEval + cEval;
-        if (std::abs(d.value - (x + c)) > tolerance)
+        if (std::abs(d.value() - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
     }
 
     {
         Eval a = xEval - yEval;
-        if (std::abs(a.value - (x - y)) > tolerance)
+        if (std::abs(a.value() - (x - y)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval b = xEval - c;
-        if (std::abs(b.value - (x - c)) > tolerance)
+        if (std::abs(b.value() - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval d = xEval - cEval;
-        if (std::abs(d.value - (x - c)) > tolerance)
+        if (std::abs(d.value() - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
     }
 
     {
         Eval a = xEval*yEval;
-        if (std::abs(a.value - (x*y)) > tolerance)
+        if (std::abs(a.value() - (x*y)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval b = xEval*c;
-        if (std::abs(b.value - (x*c)) > tolerance)
+        if (std::abs(b.value() - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval d = xEval*cEval;
-        if (std::abs(d.value - (x*c)) > tolerance)
+        if (std::abs(d.value() - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
     }
 
     {
         Eval a = xEval/yEval;
-        if (std::abs(a.value - (x/y)) > tolerance)
+        if (std::abs(a.value() - (x/y)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval b = xEval/c;
-        if (std::abs(b.value - (x/c)) > tolerance)
+        if (std::abs(b.value() - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval d = xEval/cEval;
-        if (std::abs(d.value - (x/c)) > tolerance)
+        if (std::abs(d.value() - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
     }
 
@@ -155,68 +155,68 @@ void testOperators(const Scalar tolerance)
     {
         Eval a = xEval;
         a += yEval;
-        if (std::abs(a.value - (x + y)) > tolerance)
+        if (std::abs(a.value() - (x + y)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval b = xEval;
         b += c;
-        if (std::abs(b.value - (x + c)) > tolerance)
+        if (std::abs(b.value() - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
 
         Eval d = xEval;
         d += cEval;
-        if (std::abs(d.value - (x + c)) > tolerance)
+        if (std::abs(d.value() - (x + c)) > tolerance)
             throw std::logic_error("oops: operator+");
     }
 
     {
         Eval a = xEval;
         a -= yEval;
-        if (std::abs(a.value - (x - y)) > tolerance)
+        if (std::abs(a.value() - (x - y)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval b = xEval;
         b -= c;
-        if (std::abs(b.value - (x - c)) > tolerance)
+        if (std::abs(b.value() - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
 
         Eval d = xEval;
         d -= cEval;
-        if (std::abs(d.value - (x - c)) > tolerance)
+        if (std::abs(d.value() - (x - c)) > tolerance)
             throw std::logic_error("oops: operator-");
     }
 
     {
         Eval a = xEval;
         a *= yEval;
-        if (std::abs(a.value - (x*y)) > tolerance)
+        if (std::abs(a.value() - (x*y)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval b = xEval;
         b *= c;
-        if (std::abs(b.value - (x*c)) > tolerance)
+        if (std::abs(b.value() - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
 
         Eval d = xEval;
         d *= cEval;
-        if (std::abs(d.value - (x*c)) > tolerance)
+        if (std::abs(d.value() - (x*c)) > tolerance)
             throw std::logic_error("oops: operator*");
     }
 
     {
         Eval a = xEval;
         a /= yEval;
-        if (std::abs(a.value - (x/y)) > tolerance)
+        if (std::abs(a.value() - (x/y)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval b = xEval;
         b /= c;
-        if (std::abs(b.value - (x/c)) > tolerance)
+        if (std::abs(b.value() - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
 
         Eval d = xEval;
         d /= cEval;
-        if (std::abs(d.value - (x/c)) > tolerance)
+        if (std::abs(d.value() - (x/c)) > tolerance)
             throw std::logic_error("oops: operator/");
     }
 
@@ -276,16 +276,16 @@ void test1DFunction(AdFn* adFn, ClassicFn* classicFn, Scalar xMin = 1e-6, Scalar
         Scalar yStar2 = classicFn(x + eps);
         Scalar yPrime = (yStar2 - yStar1)/(2*eps);
 
-        if (std::abs(y-yEval.value) > 5e-14)
+        if (std::abs(y-yEval.value()) > 5e-14)
             throw std::logic_error("oops: value");
 
-        Scalar deltaAbs = std::abs(yPrime - yEval.derivatives[0]);
+        Scalar deltaAbs = std::abs(yPrime - yEval.derivative(0));
         Scalar deltaRel = std::abs(deltaAbs/yPrime);
         if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
             throw std::logic_error("oops: derivative @"+std::to_string((long double) x)+": "
                                    + std::to_string((long double) yPrime) + " vs "
-                                   + std::to_string((long double) yEval.derivatives[0])
-                                   + " delta: " + std::to_string((long double) std::abs(yPrime - yEval.derivatives[0])));
+                                   + std::to_string((long double) yEval.derivative(0))
+                                   + " delta: " + std::to_string((long double) std::abs(yPrime - yEval.derivative(0))));
     }
 }
 
@@ -312,17 +312,17 @@ void test2DFunction1(AdFn* adFn, ClassicFn* classicFn, Scalar xMin, Scalar xMax,
         Scalar zStar2 = classicFn(x + eps, y);
         Scalar zPrime = (zStar2 - zStar1)/(2.*eps);
 
-        if (std::abs(z - zEval.value)/std::abs(z + zEval.value)
+        if (std::abs(z - zEval.value())/std::abs(z + zEval.value())
             > std::numeric_limits<Scalar>::epsilon()*1e2)
             throw std::logic_error("oops: value");
 
-        Scalar deltaAbs = std::abs(zPrime - zEval.derivatives[0]);
+        Scalar deltaAbs = std::abs(zPrime - zEval.derivative(0));
         Scalar deltaRel = std::abs(deltaAbs/zPrime);
         if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
             throw std::logic_error("oops: derivative @"+std::to_string((long double) x)+": "
                                    + std::to_string((long double) zPrime) + " vs "
-                                   + std::to_string((long double) zEval.derivatives[0])
-                                   + " delta: " + std::to_string((long double) std::abs(zPrime - zEval.derivatives[0])));
+                                   + std::to_string((long double) zEval.derivative(0))
+                                   + " delta: " + std::to_string((long double) std::abs(zPrime - zEval.derivative(0))));
     }
 }
 
@@ -349,17 +349,17 @@ void test2DFunction2(AdFn* adFn, ClassicFn* classicFn, Scalar x, Scalar yMin, Sc
         Scalar zStar2 = classicFn(x, y + eps);
         Scalar zPrime = (zStar2 - zStar1)/(2*eps);
 
-        if (std::abs(z - zEval.value)/std::abs(z + zEval.value)
+        if (std::abs(z - zEval.value())/std::abs(z + zEval.value())
             > std::numeric_limits<Scalar>::epsilon()*1e2)
             throw std::logic_error("oops: value");
 
-        Scalar deltaAbs = std::abs(zPrime - zEval.derivatives[1]);
+        Scalar deltaAbs = std::abs(zPrime - zEval.derivative(1));
         Scalar deltaRel = std::abs(deltaAbs/zPrime);
         if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
             throw std::logic_error("oops: derivative @"+std::to_string((long double) x)+": "
                                    + std::to_string((long double) zPrime) + " vs "
-                                   + std::to_string((long double) zEval.derivatives[1])
-                                   + " delta: " + std::to_string((long double) std::abs(zPrime - zEval.derivatives[1])));
+                                   + std::to_string((long double) zEval.derivative(1))
+                                   + " delta: " + std::to_string((long double) std::abs(zPrime - zEval.derivative(1))));
     }
 }
 
@@ -388,19 +388,19 @@ void testPowBase(Scalar baseMin = 1e-2, Scalar baseMax = 100)
         Scalar zStar2 = pow(base + eps, exp);
         Scalar zPrime = (zStar2 - zStar1)/(2*eps);
 
-        if (std::abs(z - zEval2.value)/std::abs(z + zEval2.value)
+        if (std::abs(z - zEval2.value())/std::abs(z + zEval2.value())
             > std::numeric_limits<Scalar>::epsilon()*1e2)
             throw std::logic_error("oops: value");
 
-        Scalar deltaAbs = std::abs(zPrime - zEval1.derivatives[0]);
+        Scalar deltaAbs = std::abs(zPrime - zEval1.derivative(0));
         Scalar deltaRel = std::abs(deltaAbs/zPrime);
         if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
             throw std::logic_error("oops: derivative @"+std::to_string((long double) base)+": "
                                    + std::to_string((long double) zPrime) + " vs "
-                                   + std::to_string((long double) zEval1.derivatives[0])
-                                   + " delta: " + std::to_string((long double) std::abs(zPrime - zEval1.derivatives[0])));
+                                   + std::to_string((long double) zEval1.derivative(0))
+                                   + " delta: " + std::to_string((long double) std::abs(zPrime - zEval1.derivative(0))));
 
-        if (!EvalToolbox::isSame(zEval1, zEval2, /*tolerance=*/std::numeric_limits<Scalar>::epsilon()*1e3*zEval1.value))
+        if (!EvalToolbox::isSame(zEval1, zEval2, /*tolerance=*/std::numeric_limits<Scalar>::epsilon()*1e3*zEval1.value()))
             throw std::logic_error("oops: pow(Eval, Scalar) != pow(Eval, Eval)");
     }
 }
@@ -430,19 +430,19 @@ void testPowExp(Scalar expMin = -100, Scalar expMax = 100)
         Scalar zStar2 = pow(base, exp + eps);
         Scalar zPrime = (zStar2 - zStar1)/(2*eps);
 
-        if (std::abs(z - zEval2.value)/std::abs(z + zEval2.value)
+        if (std::abs(z - zEval2.value())/std::abs(z + zEval2.value())
             > std::numeric_limits<Scalar>::epsilon()*1e2)
             throw std::logic_error("oops: value");
 
-        Scalar deltaAbs = std::abs(zPrime - zEval1.derivatives[1]);
+        Scalar deltaAbs = std::abs(zPrime - zEval1.derivative(1));
         Scalar deltaRel = std::abs(deltaAbs/zPrime);
         if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
             throw std::logic_error("oops: derivative @"+std::to_string((long double) base)+": "
                                    + std::to_string((long double) zPrime) + " vs "
-                                   + std::to_string((long double) zEval1.derivatives[1])
-                                   + " delta: " + std::to_string((long double) std::abs(zPrime - zEval1.derivatives[1])));
+                                   + std::to_string((long double) zEval1.derivative(1))
+                                   + " delta: " + std::to_string((long double) std::abs(zPrime - zEval1.derivative(1))));
 
-        if (!EvalToolbox::isSame(zEval1, zEval2, /*tolerance=*/std::numeric_limits<Scalar>::epsilon()*1e3*zEval1.value))
+        if (!EvalToolbox::isSame(zEval1, zEval2, /*tolerance=*/std::numeric_limits<Scalar>::epsilon()*1e3*zEval1.value()))
             throw std::logic_error("oops: pow(Eval, Scalar) != pow(Eval, Eval)");
     }
 }
@@ -480,17 +480,17 @@ void testAtan2()
             Scalar zStar2 = atan2(x + eps, y + eps);
             Scalar zPrime = (zStar2 - zStar1)/(2*eps);
 
-            if (std::abs(z - zEval.value)/std::abs(z + zEval.value)
+            if (std::abs(z - zEval.value())/std::abs(z + zEval.value())
                 > std::numeric_limits<Scalar>::epsilon()*1e2)
                 throw std::logic_error("oops: value");
 
-            Scalar deltaAbs = std::abs(zPrime - zEval.derivatives[0]);
+            Scalar deltaAbs = std::abs(zPrime - zEval.derivative(0));
             Scalar deltaRel = std::abs(deltaAbs/zPrime);
             if (deltaAbs > 1000*eps && deltaRel > 1000*eps)
                 throw std::logic_error("oops: derivative @("+std::to_string((long double) x)+","+std::to_string((long double) y)+"): "
                                        + std::to_string((long double) zPrime) + " vs "
-                                       + std::to_string((long double) zEval.derivatives[0])
-                                       + " delta: " + std::to_string((long double) std::abs(zPrime - zEval.derivatives[0])));
+                                       + std::to_string((long double) zEval.derivative(0))
+                                       + " delta: " + std::to_string((long double) std::abs(zPrime - zEval.derivative(0))));
 
         }
     }


### PR DESCRIPTION
besides being the right thing from an API perspective, this change allows some flexibility of how an Evaluation object is represented internally. the main motivation for this is to allow using SIMD instruction which expect special data types as their operands.

note that this change implies "mob up" PRs in opm-core, ewoms and opm-simulators. (and also for the `frankenstein` branch of opm-simulators, but I'll deal with this once the PR is in master.)
