### PR TITLE
fix some pedantic compiler warnings

### DIFF
--- a/opm/material/common/MathToolbox.hpp
+++ b/opm/material/common/MathToolbox.hpp
@@ -108,7 +108,7 @@ public:
      * regard to x. For scalars (which do not consider derivatives), this method does
      * nothing.
      */
-    static Scalar createVariable(Scalar value, int /*varIdx*/)
+    static Scalar createVariable(Scalar value, unsigned /*varIdx*/)
     { return value; }
 
     /*!
@@ -225,7 +225,7 @@ Evaluation constant(const Scalar& value)
 { return Opm::MathToolbox<Evaluation>::createConstant(value); }
 
 template <class Evaluation, class Scalar>
-Evaluation variable(const Scalar& value, int idx)
+Evaluation variable(const Scalar& value, unsigned idx)
 { return Opm::MathToolbox<Evaluation>::createVariable(value, idx); }
 
 template <class ResultEval, class Evaluation>

--- a/opm/material/common/PolynomialUtils.hpp
+++ b/opm/material/common/PolynomialUtils.hpp
@@ -48,9 +48,9 @@ namespace Opm {
  * \param b The coefficient for the constant term
  */
 template <class Scalar, class SolContainer>
-int invertLinearPolynomial(SolContainer &sol,
-                           Scalar a,
-                           Scalar b)
+unsigned invertLinearPolynomial(SolContainer &sol,
+                                Scalar a,
+                                Scalar b)
 {
     typedef MathToolbox<Scalar> Toolbox;
     if (std::abs(Toolbox::scalarValue(a)) < 1e-30)
@@ -77,10 +77,10 @@ int invertLinearPolynomial(SolContainer &sol,
  * \param c The coefficient for the constant term
  */
 template <class Scalar, class SolContainer>
-int invertQuadraticPolynomial(SolContainer &sol,
-                              Scalar a,
-                              Scalar b,
-                              Scalar c)
+unsigned invertQuadraticPolynomial(SolContainer &sol,
+                                   Scalar a,
+                                   Scalar b,
+                                   Scalar c)
 {
     typedef MathToolbox<Scalar> Toolbox;
 
@@ -150,11 +150,11 @@ void invertCubicPolynomialPostProcess_(SolContainer &sol,
  * \param d The coefficient for the constant term
  */
 template <class Scalar, class SolContainer>
-int invertCubicPolynomial(SolContainer *sol,
-                          Scalar a,
-                          Scalar b,
-                          Scalar c,
-                          Scalar d)
+unsigned invertCubicPolynomial(SolContainer *sol,
+                               Scalar a,
+                               Scalar b,
+                               Scalar c,
+                               Scalar d)
 {
     typedef MathToolbox<Scalar> Toolbox;
 

--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -476,7 +476,7 @@ public:
         setNumSamples_(points.size());
         typename XYContainer::const_iterator it = points.begin();
         typename XYContainer::const_iterator endIt = points.end();
-        for (int i = 0; it != endIt; ++i, ++it) {
+        for (unsigned i = 0; it != endIt; ++i, ++it) {
             xPos_[i] = std::get<0>(*it);
             yPos_[i] = std::get<1>(*it);
         }
@@ -721,13 +721,13 @@ public:
     /*!
      * \brief Return the x value of a given sampling point.
      */
-    Scalar xAt(int sampleIdx) const
+    Scalar xAt(size_t sampleIdx) const
     { return x_(sampleIdx); }
 
     /*!
      * \brief Return the x value of a given sampling point.
      */
-    Scalar valueAt(int sampleIdx) const
+    Scalar valueAt(size_t sampleIdx) const
     { return y_(sampleIdx); }
 
     /*!
@@ -807,10 +807,11 @@ public:
                 Scalar y0 = y_(0);
                 return y0 + m*(x - xAt(0));
             }
-            else if (x > xAt(numSamples() - 1)) {
-                Scalar m = evalDerivative_(xAt(numSamples() - 1), /*segmentIdx=*/numSamples()-2);
-                Scalar y0 = y_(numSamples() - 1);
-                return y0 + m*(x - xAt(numSamples() - 1));
+            else if (x > xAt(static_cast<size_t>(static_cast<long int>(numSamples()) - 1))) {
+                Scalar m = evalDerivative_(xAt(static_cast<size_t>(numSamples() - 1)),
+                                           /*segmentIdx=*/static_cast<size_t>(numSamples()-2));
+                Scalar y0 = y_(static_cast<size_t>(numSamples() - 1));
+                return y0 + m*(x - xAt(static_cast<size_t>(numSamples() - 1)));
             }
         }
 
@@ -1169,14 +1170,14 @@ protected:
                                DestVector &destY,
                                const SourceVector &srcX,
                                const SourceVector &srcY,
-                               int nSamples)
+                               unsigned nSamples)
     {
         assert(nSamples >= 2);
 
         // copy sample points, make sure that the first x value is
         // smaller than the last one
-        for (int i = 0; i < nSamples; ++i) {
-            int idx = i;
+        for (unsigned i = 0; i < nSamples; ++i) {
+            unsigned idx = i;
             if (srcX[0] > srcX[nSamples - 1])
                 idx = nSamples - i - 1;
             destX[i] = srcX[idx];
@@ -1189,7 +1190,7 @@ protected:
                               DestVector &destY,
                               const ListIterator &srcBegin,
                               const ListIterator &srcEnd,
-                              int nSamples)
+                              unsigned nSamples)
     {
         assert(nSamples >= 2);
 
@@ -1202,8 +1203,8 @@ protected:
         --it;
 
         // loop over all sampling points
-        for (int i = 0; it != srcEnd; ++i, ++it) {
-            int idx = i;
+        for (unsigned i = 0; it != srcEnd; ++i, ++it) {
+            unsigned idx = i;
             if (reverse)
                 idx = nSamples - i - 1;
             destX[i] = (*it)[0];
@@ -1223,7 +1224,7 @@ protected:
                               DestVector &destY,
                               ListIterator srcBegin,
                               ListIterator srcEnd,
-                              int nSamples)
+                              unsigned nSamples)
     {
         assert(nSamples >= 2);
 
@@ -1239,8 +1240,8 @@ protected:
         --it;
 
         // loop over all sampling points
-        for (int i = 0; it != srcEnd; ++i, ++it) {
-            int idx = i;
+        for (unsigned i = 0; it != srcEnd; ++i, ++it) {
+            unsigned idx = i;
             if (reverse)
                 idx = nSamples - i - 1;
             destX[i] = std::get<0>(*it);
@@ -1708,17 +1709,18 @@ protected:
                              const Evaluation& d,
                              Scalar x0 = -1e30, Scalar x1 = 1e30) const
     {
-        int n = Opm::invertCubicPolynomial(sol,
-                                           a_(segIdx) - a,
-                                           b_(segIdx) - b,
-                                           c_(segIdx) - c,
-                                           d_(segIdx) - d);
+        unsigned n =
+            Opm::invertCubicPolynomial(sol,
+                                       a_(segIdx) - a,
+                                       b_(segIdx) - b,
+                                       c_(segIdx) - c,
+                                       d_(segIdx) - d);
         x0 = std::max(x_(segIdx), x0);
         x1 = std::min(x_(segIdx+1), x1);
 
         // filter the intersections outside of the specified interval
         size_t k = 0;
-        for (int j = 0; j < n; ++j) {
+        for (unsigned j = 0; j < n; ++j) {
             if (x0 <= sol[j] && sol[j] <= x1) {
                 sol[k] = sol[j];
                 ++k;

--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -191,7 +191,7 @@ public:
         resizeArrays_(points.size());
         typename XYContainer::const_iterator it = points.begin();
         typename XYContainer::const_iterator endIt = points.end();
-        for (int i = 0; it != endIt; ++i, ++it) {
+        for (unsigned i = 0; it != endIt; ++i, ++it) {
             xValues_[i] = std::get<0>(*it);
             yValues_[i] = std::get<1>(*it);
         }
@@ -285,7 +285,7 @@ public:
     template <class Evaluation>
     Evaluation evalDerivative(const Evaluation& x, bool /*extrapolate*/=false) const
     {
-        int segIdx = findSegmentIndex_(x);
+        unsigned segIdx = findSegmentIndex_(x);
 
         return evalDerivative(x, segIdx);
     }
@@ -423,7 +423,7 @@ public:
      "function.csv" using 1:3 w l ti "Derivative"
      ----------- snap -----------
     */
-    void printCSV(Scalar xi0, Scalar xi1, int k, std::ostream &os = std::cout) const
+    void printCSV(Scalar xi0, Scalar xi1, unsigned k, std::ostream &os = std::cout) const
     {
         Scalar x0 = std::min(xi0, xi1);
         Scalar x1 = std::max(xi0, xi1);
@@ -484,7 +484,7 @@ private:
     }
 
     template <class Evaluation>
-    Evaluation evalDerivative_(OPM_UNUSED const Evaluation& x, int segIdx) const
+    Evaluation evalDerivative_(OPM_UNUSED const Evaluation& x, size_t segIdx) const
     {
         Scalar x0 = xValues_[segIdx];
         Scalar x1 = xValues_[segIdx + 1];
@@ -501,9 +501,9 @@ private:
     //
     // 3: function is constant within interval [x0, x1]
     // 1: function is monotonously increasing in the specified interval
-    // 9: function is not monotonic in the specified interval
+    // 0: function is not monotonic in the specified interval
     // -1: function is monotonously decreasing in the specified interval
-    int updateMonotonicity_(int i, int &r) const
+    int updateMonotonicity_(size_t i, int &r) const
     {
         if (yValues_[i] < yValues_[i + 1]) {
             // monotonically increasing?

--- a/opm/material/common/TridiagonalMatrix.hpp
+++ b/opm/material/common/TridiagonalMatrix.hpp
@@ -184,7 +184,7 @@ public:
      */
     Scalar at(size_t rowIdx, size_t colIdx) const
     {
-        int n = size();
+        size_t n = size();
 
         // special cases
         if (rowIdx == 0 && colIdx == n - 1)
@@ -192,7 +192,7 @@ public:
         if (rowIdx == n - 1 && colIdx == 0)
             return diag_[0][n - 1];
 
-        int diagIdx = 1 + colIdx - rowIdx;
+        size_t diagIdx = 1 + colIdx - rowIdx;
         // make sure that the requested column is in range
         assert(0 <= diagIdx && diagIdx < 3);
         return diag_[diagIdx][colIdx];
@@ -203,7 +203,7 @@ public:
      */
     TridiagonalMatrix &operator=(const TridiagonalMatrix &source)
     {
-        for (int diagIdx = 0; diagIdx < 3; ++ diagIdx)
+        for (unsigned diagIdx = 0; diagIdx < 3; ++ diagIdx)
             diag_[diagIdx] = source.diag_[diagIdx];
 
         return *this;
@@ -214,7 +214,7 @@ public:
      */
     TridiagonalMatrix &operator=(Scalar value)
     {
-        for (int diagIdx = 0; diagIdx < 3; ++ diagIdx)
+        for (unsigned diagIdx = 0; diagIdx < 3; ++ diagIdx)
             diag_[diagIdx].assign(size(), value);
 
         return *this;
@@ -255,9 +255,9 @@ public:
      */
     TridiagonalMatrix &operator*=(Scalar alpha)
     {
-        int n = size();
-        for (int diagIdx = 0; diagIdx < 3; ++ diagIdx) {
-            for (int i = 0; i < n; ++i) {
+        unsigned n = size();
+        for (unsigned diagIdx = 0; diagIdx < 3; ++ diagIdx) {
+            for (unsigned i = 0; i < n; ++i) {
                 diag_[diagIdx][i] *= alpha;
             }
         }
@@ -271,9 +271,9 @@ public:
     TridiagonalMatrix &operator/=(Scalar alpha)
     {
         alpha = 1.0/alpha;
-        int n = size();
-        for (int diagIdx = 0; diagIdx < 3; ++ diagIdx) {
-            for (int i = 0; i < n; ++i) {
+        unsigned n = size();
+        for (unsigned diagIdx = 0; diagIdx < 3; ++ diagIdx) {
+            for (unsigned i = 0; i < n; ++i) {
                 diag_[diagIdx][i] *= alpha;
             }
         }
@@ -311,9 +311,9 @@ public:
     {
         assert(size() == other.size());
 
-        int n = size();
-        for (int diagIdx = 0; diagIdx < 3; ++ diagIdx)
-            for (int i = 0; i < n; ++ i)
+        unsigned n = size();
+        for (unsigned diagIdx = 0; diagIdx < 3; ++ diagIdx)
+            for (unsigned i = 0; i < n; ++ i)
                 diag_[diagIdx][i] += alpha * other[diagIdx][i];
 
         return *this;
@@ -339,8 +339,8 @@ public:
         assert(size() > 1);
 
         // deal with rows 1 .. n-2
-        int n = size();
-        for (int i = 1; i < n - 1; ++ i) {
+        unsigned n = size();
+        for (unsigned i = 1; i < n - 1; ++ i) {
             dest[i] =
                 diag_[0][i - 1]*source[i-1] +
                 diag_[1][i]*source[i] +
@@ -379,8 +379,8 @@ public:
         assert(size() > 1);
 
         // deal with rows 1 .. n-2
-        int n = size();
-        for (int i = 1; i < n - 1; ++ i) {
+        unsigned n = size();
+        for (unsigned i = 1; i < n - 1; ++ i) {
             dest[i] +=
                 diag_[0][i - 1]*source[i-1] +
                 diag_[1][i]*source[i] +
@@ -419,8 +419,8 @@ public:
         assert(size() > 1);
 
         // deal with rows 1 .. n-2
-        int n = size();
-        for (int i = 1; i < n - 1; ++ i) {
+        unsigned n = size();
+        for (unsigned i = 1; i < n - 1; ++ i) {
             dest[i] -=
                 diag_[0][i - 1]*source[i-1] +
                 diag_[1][i]*source[i] +
@@ -459,8 +459,8 @@ public:
         assert(size() > 1);
 
         // deal with rows 1 .. n-2
-        int n = size();
-        for (int i = 1; i < n - 1; ++ i) {
+        unsigned n = size();
+        for (unsigned i = 1; i < n - 1; ++ i) {
             dest[i] +=
                 alpha*(
                     diag_[0][i - 1]*source[i-1] +
@@ -502,8 +502,8 @@ public:
         assert(size() > 1);
 
         // deal with rows 1 .. n-2
-        int n = size();
-        for (int i = 1; i < n - 1; ++ i) {
+        unsigned n = size();
+        for (unsigned i = 1; i < n - 1; ++ i) {
             dest[i] =
                 diag_[2][i + 1]*source[i-1] +
                 diag_[1][i]*source[i] +
@@ -542,8 +542,8 @@ public:
         assert(size() > 1);
 
         // deal with rows 1 .. n-2
-        int n = size();
-        for (int i = 1; i < n - 1; ++ i) {
+        unsigned n = size();
+        for (unsigned i = 1; i < n - 1; ++ i) {
             dest[i] +=
                 diag_[2][i + 1]*source[i-1] +
                 diag_[1][i]*source[i] +
@@ -582,8 +582,8 @@ public:
         assert(size() > 1);
 
         // deal with rows 1 .. n-2
-        int n = size();
-        for (int i = 1; i < n - 1; ++ i) {
+        unsigned n = size();
+        for (unsigned i = 1; i < n - 1; ++ i) {
             dest[i] -=
                 diag_[2][i + 1]*source[i-1] +
                 diag_[1][i]*source[i] +
@@ -622,8 +622,8 @@ public:
         assert(size() > 1);
 
         // deal with rows 1 .. n-2
-        int n = size();
-        for (int i = 1; i < n - 1; ++ i) {
+        unsigned n = size();
+        for (unsigned i = 1; i < n - 1; ++ i) {
             dest[i] +=
                 alpha*(
                     diag_[2][i + 1]*source[i-1] +
@@ -663,9 +663,9 @@ public:
     {
         Scalar result = 0;
 
-        int n = size();
-        for (int i = 0; i < n; ++ i)
-            for (int diagIdx = 0; diagIdx < 3; ++ diagIdx)
+        unsigned n = size();
+        for (unsigned i = 0; i < n; ++ i)
+            for (unsigned diagIdx = 0; diagIdx < 3; ++ diagIdx)
                 result += diag_[diagIdx][i];
 
         return result;
@@ -681,8 +681,8 @@ public:
         Scalar result=0;
 
         // deal with rows 1 .. n-2
-        int n = size();
-        for (int i = 1; i < n - 1; ++ i) {
+        unsigned n = size();
+        for (unsigned i = 1; i < n - 1; ++ i) {
             result = std::max(result,
                               std::abs(diag_[0][i - 1]) +
                               std::abs(diag_[1][i]) +
@@ -724,7 +724,7 @@ public:
      */
     void print(std::ostream &os = std::cout) const
     {
-        int n = size();
+        size_t n = size();
 
         // row 0
         os << at(0, 0) << "\t"
@@ -737,7 +737,7 @@ public:
         os << "\n";
 
         // row 1 .. n - 2
-        for (int rowIdx = 1; rowIdx < n-1; ++rowIdx) {
+        for (unsigned rowIdx = 1; rowIdx < n-1; ++rowIdx) {
             if (rowIdx > 1)
                 os << "\t";
             if (rowIdx == n - 2)

--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -198,10 +198,14 @@ public:
         Evaluation alpha = xToI(x);
         Evaluation beta = yToJ(y);
 
-        int i = std::max<int>(0, std::min(static_cast<int>(numX()) - 2,
-                                          static_cast<int>(Toolbox::scalarValue(alpha))));
-        int j = std::max<int>(0, std::min(static_cast<int>(numY()) - 2,
-                                          static_cast<int>(Toolbox::scalarValue(beta))));
+        unsigned i =
+            static_cast<unsigned>(
+                std::max(0, std::min(static_cast<int>(numX()) - 2,
+                                     static_cast<int>(Toolbox::scalarValue(alpha)))));
+        unsigned j =
+            static_cast<unsigned>(
+                std::max(0, std::min(static_cast<int>(numY()) - 2,
+                                     static_cast<int>(Toolbox::scalarValue(beta)))));
 
         alpha -= i;
         beta -= j;

--- a/opm/material/common/Valgrind.hpp
+++ b/opm/material/common/Valgrind.hpp
@@ -33,6 +33,12 @@
 #include <valgrind/memcheck.h>
 #endif
 
+#if HAVE_VALGRIND
+#define OPM_VALGRIND_OPTIM_UNUSED OPM_OPTIM_UNUSED
+#else
+#define OPM_VALGRIND_OPTIM_UNUSED OPM_UNUSED
+#endif
+
 namespace Valgrind
 {
 /*!
@@ -73,7 +79,7 @@ inline bool IsRunning()
  *         occupied by the object.
  */
 template <class T>
-inline bool CheckDefined(const T& value OPM_UNUSED)
+inline bool CheckDefined(const T& value OPM_VALGRIND_OPTIM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto tmp = VALGRIND_CHECK_MEM_IS_DEFINED(&value, sizeof(T));
@@ -105,7 +111,7 @@ inline bool CheckDefined(const T& value OPM_UNUSED)
  *         occupied by the object.
  */
 template <class T>
-inline bool CheckAddressable(const T& value OPM_UNUSED)
+inline bool CheckAddressable(const T& value OPM_VALGRIND_OPTIM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto tmp = VALGRIND_CHECK_MEM_IS_ADDRESSABLE(&value, sizeof(T));
@@ -141,7 +147,7 @@ inline bool CheckAddressable(const T& value OPM_UNUSED)
  *         occupied by the array.
  */
 template <class T>
-inline bool CheckDefined(const T* value OPM_UNUSED, int size OPM_UNUSED)
+inline bool CheckDefined(const T* value OPM_VALGRIND_OPTIM_UNUSED, int size OPM_VALGRIND_OPTIM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
     auto tmp = VALGRIND_CHECK_MEM_IS_DEFINED(value, size*sizeof(T));
@@ -169,10 +175,10 @@ inline bool CheckDefined(const T* value OPM_UNUSED, int size OPM_UNUSED)
  * \param value The object which's memory valgrind should be told is undefined
  */
 template <class T>
-inline void SetUndefined(const T &value OPM_UNUSED)
+inline void SetUndefined(const T &value OPM_VALGRIND_OPTIM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
-    auto OPM_UNUSED result = VALGRIND_MAKE_MEM_UNDEFINED(&value, sizeof(T));
+    VALGRIND_MAKE_MEM_UNDEFINED(&value, sizeof(T));
 #endif
 }
 
@@ -195,10 +201,10 @@ inline void SetUndefined(const T &value OPM_UNUSED)
  * \param size The size of the array in number of objects
  */
 template <class T>
-inline void SetUndefined(const T* value OPM_UNUSED, int size OPM_UNUSED)
+inline void SetUndefined(const T* value OPM_VALGRIND_OPTIM_UNUSED, int size OPM_VALGRIND_OPTIM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
-    auto OPM_UNUSED result = VALGRIND_MAKE_MEM_UNDEFINED(value, size*sizeof(T));
+    VALGRIND_MAKE_MEM_UNDEFINED(value, size*sizeof(T));
 #endif
 }
 
@@ -219,10 +225,10 @@ inline void SetUndefined(const T* value OPM_UNUSED, int size OPM_UNUSED)
  * \param value The object which's memory valgrind should consider as defined
  */
 template <class T>
-inline void SetDefined(const T& value OPM_UNUSED)
+inline void SetDefined(const T& value OPM_VALGRIND_OPTIM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
-    auto OPM_UNUSED result = VALGRIND_MAKE_MEM_DEFINED(&value, sizeof(T));
+    VALGRIND_MAKE_MEM_DEFINED(&value, sizeof(T));
 #endif
 }
 
@@ -245,10 +251,10 @@ inline void SetDefined(const T& value OPM_UNUSED)
  * \param n The size of the array in number of objects
  */
 template <class T>
-inline void SetDefined(const T *value OPM_UNUSED, int n OPM_UNUSED)
+inline void SetDefined(const T *value OPM_VALGRIND_OPTIM_UNUSED, int n OPM_VALGRIND_OPTIM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
-    auto OPM_UNUSED result = VALGRIND_MAKE_MEM_DEFINED(value, n*sizeof(T));
+    VALGRIND_MAKE_MEM_DEFINED(value, n*sizeof(T));
 #endif
 }
 
@@ -269,10 +275,10 @@ inline void SetDefined(const T *value OPM_UNUSED, int n OPM_UNUSED)
  * \param value The object which's memory valgrind should complain if accessed
  */
 template <class T>
-inline void SetNoAccess(const T &value OPM_UNUSED)
+inline void SetNoAccess(const T &value OPM_VALGRIND_OPTIM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
-    auto OPM_UNUSED result = VALGRIND_MAKE_MEM_NOACCESS(&value, sizeof(T));
+    VALGRIND_MAKE_MEM_NOACCESS(&value, sizeof(T));
 #endif
 }
 
@@ -293,10 +299,10 @@ inline void SetNoAccess(const T &value OPM_UNUSED)
  * \param size The size of the array in number of objects
  */
 template <class T>
-inline void SetNoAccess(const T *value OPM_UNUSED, int size OPM_UNUSED)
+inline void SetNoAccess(const T *value OPM_VALGRIND_OPTIM_UNUSED, int size OPM_VALGRIND_OPTIM_UNUSED)
 {
 #if !defined NDEBUG && HAVE_VALGRIND
-    auto OPM_UNUSED result = VALGRIND_MAKE_MEM_NOACCESS(value, size*sizeof(T));
+    VALGRIND_MAKE_MEM_NOACCESS(value, size*sizeof(T));
 #endif
 }
 

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -563,9 +563,8 @@ private:
         typedef MathToolbox<Evaluation> Toolbox;
 
         Evaluation alphaT = tempIdx_(T);
-        if (alphaT < 0 || alphaT >= nTemp_ - 1) {
+        if (alphaT < 0 || alphaT >= nTemp_ - 1)
             return Toolbox::createConstant(std::numeric_limits<Scalar>::quiet_NaN());
-        }
 
         size_t iT = static_cast<size_t>(Toolbox::scalarValue(alphaT));
         alphaT -= iT;
@@ -574,27 +573,15 @@ private:
         Evaluation alphaP2 = pressLiquidIdx_(p, iT + 1);
 
         size_t iP1 =
-            std::max<int>(0,
-                             std::min<int>(nPress_ - 2,
-                                           static_cast<int>(Toolbox::scalarValue(alphaP1))));
+            static_cast<size_t>(
+                std::max<int>(0, std::min(static_cast<int>(nPress_) - 2,
+                                          static_cast<int>(Toolbox::scalarValue(alphaP1)))));
         size_t iP2 =
-            std::max<int>(0,
-                          std::min<int>(nPress_ - 2,
-                                        static_cast<int>(Toolbox::scalarValue(alphaP2))));
+            static_cast<size_t>(
+                std::max(0, std::min(static_cast<int>(nPress_) - 2,
+                                     static_cast<int>(Toolbox::scalarValue(alphaP2)))));
         alphaP1 -= iP1;
         alphaP2 -= iP2;
-
-#if 0 && !defined NDEBUG
-        if(!(0 <= alphaT && alphaT <= 1.0))
-            OPM_THROW(NumericalProblem, "Temperature out of range: "
-                      << "T=" << T << " range: [" << tempMin_ << ", " << tempMax_ << "]");
-        if(!(0 <= alphaP1 && alphaP1 <= 1.0))
-            OPM_THROW(NumericalProblem, "First liquid pressure out of range: "
-                      << "p=" << p << " range: [" << minLiquidPressure_(tempIdx_(T)) << ", " << maxLiquidPressure_(tempIdx_(T)) << "]");
-        if(!(0 <= alphaP2 && alphaP2 <= 1.0))
-            OPM_THROW(NumericalProblem, "Second liquid pressure out of range: "
-                      << "p=" << p << " range: [" << minLiquidPressure_(tempIdx_(T) + 1) << ", " << maxLiquidPressure_(tempIdx_(T) + 1) << "]");
-#endif
 
         return
             values[(iT    ) + (iP1    )*nTemp_]*(1 - alphaT)*(1 - alphaP1) +
@@ -611,39 +598,27 @@ private:
         typedef MathToolbox<Evaluation> Toolbox;
 
         Evaluation alphaT = tempIdx_(T);
-        if (alphaT < 0 || alphaT >= nTemp_ - 1) {
+        if (alphaT < 0 || alphaT >= nTemp_ - 1)
             return Toolbox::createConstant(std::numeric_limits<Scalar>::quiet_NaN());
-        }
 
         size_t iT =
-            std::max<int>(0,
-                          std::min<int>(nTemp_ - 2,
-                                        static_cast<int>(Toolbox::scalarValue(alphaT))));
+            static_cast<size_t>(
+                std::max(0, std::min(static_cast<int>(nTemp_) - 2,
+                                     static_cast<int>(Toolbox::scalarValue(alphaT)))));
         alphaT -= iT;
 
         Evaluation alphaP1 = pressGasIdx_(p, iT);
         Evaluation alphaP2 = pressGasIdx_(p, iT + 1);
         size_t iP1 =
-            std::max<int>(0, std::min<int>(nPress_ - 2,
-                                           static_cast<int>(Toolbox::scalarValue(alphaP1))));
+            static_cast<size_t>(
+                std::max(0, std::min(static_cast<int>(nPress_) - 2,
+                                     static_cast<int>(Toolbox::scalarValue(alphaP1)))));
         size_t iP2 =
-            std::max<int>(0,
-                          std::min<int>(nPress_ - 2,
-                                        static_cast<int>(Toolbox::scalarValue(alphaP2))));
+            static_cast<size_t>(
+                std::max(0, std::min(static_cast<int>(nPress_) - 2,
+                                     static_cast<int>(Toolbox::scalarValue(alphaP2)))));
         alphaP1 -= iP1;
         alphaP2 -= iP2;
-
-#if 0 && !defined NDEBUG
-        if(!(0 <= alphaT && alphaT <= 1.0))
-            OPM_THROW(NumericalProblem, "Temperature out of range: "
-                      << "T=" << T << " range: [" << tempMin_ << ", " << tempMax_ << "]");
-        if(!(0 <= alphaP1 && alphaP1 <= 1.0))
-            OPM_THROW(NumericalProblem, "First gas pressure out of range: "
-                      << "p=" << p << " range: [" << minGasPressure_(tempIdx_(T)) << ", " << maxGasPressure_(tempIdx_(T)) << "]");
-        if(!(0 <= alphaP2 && alphaP2 <= 1.0))
-            OPM_THROW(NumericalProblem, "Second gas pressure out of range: "
-                      << "p=" << p << " range: [" << minGasPressure_(tempIdx_(T) + 1) << ", " << maxGasPressure_(tempIdx_(T) + 1) << "]");
-#endif
 
         return
             values[(iT    ) + (iP1    )*nTemp_]*(1 - alphaT)*(1 - alphaP1) +
@@ -658,13 +633,21 @@ private:
     static Evaluation interpolateGasTRho_(const Scalar *values, const Evaluation& T, const Evaluation& rho)
     {
         Evaluation alphaT = tempIdx_(T);
-        unsigned iT = std::max<int>(0, std::min<int>(nTemp_ - 2, (int) alphaT));
+        unsigned iT = std::max(0,
+                               std::min(static_cast<int>(nTemp_ - 2),
+                                        static_cast<int>(alphaT)));
         alphaT -= iT;
 
         Evaluation alphaP1 = densityGasIdx_(rho, iT);
         Evaluation alphaP2 = densityGasIdx_(rho, iT + 1);
-        unsigned iP1 = std::max<int>(0, std::min<int>(nDensity_ - 2, (int) alphaP1));
-        unsigned iP2 = std::max<int>(0, std::min<int>(nDensity_ - 2, (int) alphaP2));
+        unsigned iP1 =
+            std::max(0,
+                     std::min(static_cast<int>(nDensity_ - 2),
+                              static_cast<int>(alphaP1)));
+        unsigned iP2 =
+            std::max(0,
+                     std::min(static_cast<int>(nDensity_ - 2),
+                              static_cast<int>(alphaP2)));
         alphaP1 -= iP1;
         alphaP2 -= iP2;
 

--- a/opm/material/densead/Evaluation.hpp
+++ b/opm/material/densead/Evaluation.hpp
@@ -47,7 +47,7 @@ namespace DenseAd {
  * \brief Represents a function evaluation and its derivatives w.r.t. a fixed set of
  *        variables.
  */
-template <class ValueT, int numVars>
+template <class ValueT, unsigned numVars>
 class Evaluation
 {
 public:
@@ -55,18 +55,18 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    static constexpr int size = numVars;
+    static constexpr unsigned size = numVars;
 
 protected:
     //! length of internal data vector
-    static constexpr int length_ = numVars + 1 ;
+    static constexpr unsigned length_ = numVars + 1 ;
 
     //! position index for value
-    static constexpr int valuepos_ = 0;
+    static constexpr unsigned valuepos_ = 0;
     //! start index for derivatives
-    static constexpr int dstart_   = 1;
+    static constexpr unsigned dstart_   = 1;
     //! end+1 index for derivatives
-    static constexpr int dend_     = length_ ;
+    static constexpr unsigned dend_     = length_ ;
 public:
 
     //! default constructor
@@ -95,29 +95,27 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, const int varPos)
+    Evaluation(const RhsValueType& c, unsigned varPos)
     {
         setValue( c );
         clearDerivatives();
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < numVars);
 
-        data_[ varPos + dstart_ ] = 1.0;
-        Valgrind::CheckDefined( data_ );
+        data_[varPos + dstart_] = 1.0;
+        Valgrind::CheckDefined(data_);
     }
 
     // set all derivatives to zero
     void clearDerivatives()
     {
-        for( int i=dstart_; i<dend_; ++i )
-        {
+        for (unsigned i = dstart_; i < dend_; ++i)
             data_[ i ] = 0.0;
-        }
     }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, const int varPos)
+    static Evaluation createVariable(const RhsValueType& value, unsigned varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -138,18 +136,15 @@ public:
         // print value
         os << "v: " << value() << " / d:";
         // print derivatives
-        for (int varIdx = 0; varIdx < numVars; ++varIdx) {
+        for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
             os << " " << derivative(varIdx);
-        }
     }
 
     // copy all derivatives from other
     void copyDerivatives(const Evaluation& other)
     {
-        for( int varIdx = dstart_; varIdx < dend_; ++varIdx )
-        {
+        for (unsigned varIdx = dstart_; varIdx < dend_; ++varIdx)
             data_[ varIdx ] = other.data_[ varIdx ];
-        }
     }
 
 
@@ -157,7 +152,7 @@ public:
     Evaluation& operator+=(const Evaluation& other)
     {
         // value and derivatives are added
-        for( int varIdx = 0 ; varIdx < length_ ; ++ varIdx )
+        for (unsigned varIdx = 0; varIdx < length_; ++ varIdx)
             data_[ varIdx ] += other.data_[ varIdx ];
 
         return *this;
@@ -168,7 +163,7 @@ public:
     Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
-        data_[ valuepos_ ] += other;
+        data_[valuepos_] += other;
         return *this;
     }
 
@@ -176,8 +171,8 @@ public:
     Evaluation& operator-=(const Evaluation& other)
     {
         // value and derivatives are subtracted
-        for( int varIdx = 0 ; varIdx < length_ ; ++ varIdx )
-            data_[ varIdx ] -= other.data_[ varIdx ];
+        for (unsigned idx = 0 ; idx < length_ ; ++ idx)
+            data_[idx] -= other.data_[idx];
 
         return *this;
     }
@@ -199,11 +194,11 @@ public:
         // i.e., (u*v)' = (v'u + u'v).
         ValueType& u = data_[ valuepos_ ];
         const ValueType& v = other.value();
-        for (int varIdx = dstart_; varIdx < dend_; ++varIdx) {
-            const ValueType& uPrime = data_[varIdx];
-            const ValueType& vPrime = other.data_[varIdx];
+        for (unsigned idx = dstart_; idx < dend_; ++idx) {
+            const ValueType& uPrime = data_[idx];
+            const ValueType& vPrime = other.data_[idx];
 
-            data_[varIdx] = (v*uPrime + u*vPrime);
+            data_[idx] = (v*uPrime + u*vPrime);
         }
         u *= v;
 
@@ -215,8 +210,8 @@ public:
     Evaluation& operator*=(RhsValueType other)
     {
         // values and derivatives are multiplied
-        for( int varIdx = 0 ; varIdx < length_ ; ++ varIdx )
-            data_[ varIdx ] *= other;
+        for (unsigned idx = 0 ; idx < length_ ; ++ idx)
+            data_[idx] *= other;
 
         return *this;
     }
@@ -228,11 +223,11 @@ public:
         // u'v)/v^2.
         ValueType& u = data_[ valuepos_ ];
         const ValueType& v = other.value();
-        for (int varIdx = dstart_; varIdx < dend_; ++varIdx) {
-            const ValueType& uPrime = data_[varIdx];
-            const ValueType& vPrime = other.data_[varIdx];
+        for (unsigned idx = dstart_; idx < dend_; ++idx) {
+            const ValueType& uPrime = data_[idx];
+            const ValueType& vPrime = other.data_[idx];
 
-            data_[varIdx] = (v*uPrime - u*vPrime)/(v*v);
+            data_[idx] = (v*uPrime - u*vPrime)/(v*v);
         }
         u /= v;
 
@@ -245,8 +240,8 @@ public:
     {
         // values and derivatives are divided
         ValueType factor = (1.0/other);
-        for( int varIdx = 0 ; varIdx < length_ ; ++ varIdx )
-            data_[ varIdx ] *= factor;
+        for (unsigned idx = 0; idx < length_; ++idx)
+            data_[idx] *= factor;
 
         return *this;
     }
@@ -290,8 +285,8 @@ public:
     {
         Evaluation result;
         // set value and derivatives to negative
-        for (int varIdx = 0; varIdx < length_; ++varIdx)
-            result.data_[varIdx] = - data_[varIdx];
+        for (unsigned idx = 0; idx < length_; ++idx)
+            result.data_[idx] = - data_[idx];
 
         return result;
     }
@@ -347,8 +342,8 @@ public:
 
     bool operator==(const Evaluation& other) const
     {
-        for (int varIdx = 0; varIdx < length_; ++varIdx)
-            if (data_[ varIdx] != other.data_[varIdx])
+        for (unsigned idx = 0; idx < length_; ++idx)
+            if (data_[idx] != other.data_[idx])
                 return false;
 
         return true;
@@ -387,51 +382,51 @@ public:
 
     // return value of variable
     const ValueType& value() const
-    { return data_[ valuepos_ ]; }
+    { return data_[valuepos_]; }
 
     // set value of variable
     void setValue(const ValueType& val)
-    { data_[ valuepos_ ] = val; }
+    { data_[valuepos_] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(const int varIdx) const
+    const ValueType& derivative(unsigned varIdx) const
     {
         assert(varIdx < numVars);
-        return data_[ varIdx + dstart_ ];
+        return data_[varIdx + dstart_];
     }
 
     // set derivative at position varIdx
-    void setDerivative(const int varIdx, const ValueType& derVal)
+    void setDerivative(unsigned varIdx, const ValueType& derVal)
     {
         assert(varIdx < numVars);
-        data_[ varIdx + dstart_ ] = derVal;
+        data_[varIdx + dstart_] = derVal;
     }
 
 protected:
-    std::array< ValueType, length_ > data_;
+    std::array<ValueType, length_> data_;
 };
 
-template <class RhsValueType, class ValueType, int numVars>
+template <class RhsValueType, class ValueType, unsigned numVars>
 bool operator<(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 { return b > a; }
 
-template <class RhsValueType, class ValueType, int numVars>
+template <class RhsValueType, class ValueType, unsigned numVars>
 bool operator>(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 { return b < a; }
 
-template <class RhsValueType, class ValueType, int numVars>
+template <class RhsValueType, class ValueType, unsigned numVars>
 bool operator<=(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 { return b >= a; }
 
-template <class RhsValueType, class ValueType, int numVars>
+template <class RhsValueType, class ValueType, unsigned numVars>
 bool operator>=(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 { return b <= a; }
 
-template <class RhsValueType, class ValueType, int numVars>
+template <class RhsValueType, class ValueType, unsigned numVars>
 bool operator!=(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 { return a != b.value(); }
 
-template <class RhsValueType, class ValueType, int numVars>
+template <class RhsValueType, class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> operator+(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 {
     Evaluation<ValueType, numVars> result(b);
@@ -441,19 +436,19 @@ Evaluation<ValueType, numVars> operator+(const RhsValueType& a, const Evaluation
     return result;
 }
 
-template <class RhsValueType, class ValueType, int numVars>
+template <class RhsValueType, class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> operator-(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 {
     Evaluation<ValueType, numVars> result;
 
     result.setValue(a - b.value());
-    for (int varIdx = 0; varIdx < numVars; ++varIdx)
+    for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
         result.setDerivative(varIdx, - b.derivative(varIdx));
 
     return result;
 }
 
-template <class RhsValueType, class ValueType, int numVars>
+template <class RhsValueType, class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> operator/(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 {
     Evaluation<ValueType, numVars> result;
@@ -462,25 +457,25 @@ Evaluation<ValueType, numVars> operator/(const RhsValueType& a, const Evaluation
 
     // outer derivative
     const ValueType& df_dg = - a/(b.value()*b.value());
-    for (int varIdx = 0; varIdx < numVars; ++varIdx)
+    for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
         result.setDerivative(varIdx, df_dg*b.derivative(varIdx));
 
     return result;
 }
 
-template <class RhsValueType, class ValueType, int numVars>
+template <class RhsValueType, class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> operator*(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
 {
     Evaluation<ValueType, numVars> result;
 
     result.setValue(a*b.value());
-    for (int varIdx = 0; varIdx < numVars; ++varIdx)
+    for (unsigned varIdx = 0; varIdx < numVars; ++varIdx)
         result.setDerivative(varIdx, a*b.derivative(varIdx));
 
     return result;
 }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 std::ostream& operator<<(std::ostream& os, const Evaluation<ValueType, numVars>& eval)
 {
     os << eval.value();
@@ -516,12 +511,12 @@ std::ostream& operator<<(std::ostream& os, const Evaluation<ValueType, numVars>&
 
 namespace Opm {
 namespace DenseAd {
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> abs(const Evaluation<ValueType, numVars>&);
 }}
 
 namespace std {
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 const Opm::DenseAd::Evaluation<ValueType, numVars> abs(const Opm::DenseAd::Evaluation<ValueType, numVars>& x)
 { return Opm::DenseAd::abs(x); }
 
@@ -540,7 +535,7 @@ const Opm::DenseAd::Evaluation<ValueType, numVars> abs(const Opm::DenseAd::Evalu
 #include <dune/common/ftraits.hh>
 
 namespace Dune {
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 struct FieldTraits<Opm::DenseAd::Evaluation<ValueType, numVars> >
 {
 public:

--- a/opm/material/densead/Math.hpp
+++ b/opm/material/densead/Math.hpp
@@ -39,45 +39,45 @@
 namespace Opm {
 namespace DenseAd {
 // forward declaration of the Evaluation template class
-template <class ValueT, int numVars>
+template <class ValueT, unsigned numVars>
 class Evaluation;
 
 // provide some algebraic functions
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> abs(const Evaluation<ValueType, numVars>& x)
 { return (x > 0.0)?x:-x; }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> min(const Evaluation<ValueType, numVars>& x1,
                                    const Evaluation<ValueType, numVars>& x2)
 { return (x1 < x2)?x1:x2; }
 
-template <class Arg1ValueType, class ValueType, int numVars>
+template <class Arg1ValueType, class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> min(const Arg1ValueType& x1,
                                    const Evaluation<ValueType, numVars>& x2)
 { return (x1 < x2)?x1:x2; }
 
-template <class ValueType, int numVars, class Arg2ValueType>
+template <class ValueType, unsigned numVars, class Arg2ValueType>
 Evaluation<ValueType, numVars> min(const Evaluation<ValueType, numVars>& x1,
                                    const Arg2ValueType& x2)
 { return min(x2, x1); }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> max(const Evaluation<ValueType, numVars>& x1,
                                    const Evaluation<ValueType, numVars>& x2)
 { return (x1 > x2)?x1:x2; }
 
-template <class Arg1ValueType, class ValueType, int numVars>
+template <class Arg1ValueType, class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> max(const Arg1ValueType& x1,
                                    const Evaluation<ValueType, numVars>& x2)
 { return (x1 > x2)?x1:x2; }
 
-template <class ValueType, int numVars, class Arg2ValueType>
+template <class ValueType, unsigned numVars, class Arg2ValueType>
 Evaluation<ValueType, numVars> max(const Evaluation<ValueType, numVars>& x1,
                                    const Arg2ValueType& x2)
 { return max(x2, x1); }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> tan(const Evaluation<ValueType, numVars>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -95,7 +95,7 @@ Evaluation<ValueType, numVars> tan(const Evaluation<ValueType, numVars>& x)
     return result;
 }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> atan(const Evaluation<ValueType, numVars>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -112,7 +112,7 @@ Evaluation<ValueType, numVars> atan(const Evaluation<ValueType, numVars>& x)
     return result;
 }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> atan2(const Evaluation<ValueType, numVars>& x,
                                      const Evaluation<ValueType, numVars>& y)
 {
@@ -133,7 +133,7 @@ Evaluation<ValueType, numVars> atan2(const Evaluation<ValueType, numVars>& x,
     return result;
 }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> sin(const Evaluation<ValueType, numVars>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -150,7 +150,7 @@ Evaluation<ValueType, numVars> sin(const Evaluation<ValueType, numVars>& x)
     return result;
 }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> asin(const Evaluation<ValueType, numVars>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -167,7 +167,7 @@ Evaluation<ValueType, numVars> asin(const Evaluation<ValueType, numVars>& x)
     return result;
 }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> cos(const Evaluation<ValueType, numVars>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -184,7 +184,7 @@ Evaluation<ValueType, numVars> cos(const Evaluation<ValueType, numVars>& x)
     return result;
 }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> acos(const Evaluation<ValueType, numVars>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -201,7 +201,7 @@ Evaluation<ValueType, numVars> acos(const Evaluation<ValueType, numVars>& x)
     return result;
 }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> sqrt(const Evaluation<ValueType, numVars>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -220,7 +220,7 @@ Evaluation<ValueType, numVars> sqrt(const Evaluation<ValueType, numVars>& x)
     return result;
 }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> exp(const Evaluation<ValueType, numVars>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -238,7 +238,7 @@ Evaluation<ValueType, numVars> exp(const Evaluation<ValueType, numVars>& x)
 }
 
 // exponentiation of arbitrary base with a fixed constant
-template <class ValueType, int numVars, class ExpType>
+template <class ValueType, unsigned numVars, class ExpType>
 Evaluation<ValueType, numVars> pow(const Evaluation<ValueType, numVars>& base,
                                    const ExpType& exp)
 {
@@ -264,7 +264,7 @@ Evaluation<ValueType, numVars> pow(const Evaluation<ValueType, numVars>& base,
 }
 
 // exponentiation of constant base with an arbitrary exponent
-template <class BaseType, class ValueType, int numVars>
+template <class BaseType, class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> pow(const BaseType& base,
                                    const Evaluation<ValueType, numVars>& exp)
 {
@@ -292,7 +292,7 @@ Evaluation<ValueType, numVars> pow(const BaseType& base,
 
 // this is the most expensive power function. Computationally it is pretty expensive, so
 // one of the above two variants above should be preferred if possible.
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> pow(const Evaluation<ValueType, numVars>& base,
                                    const Evaluation<ValueType, numVars>& exp)
 {
@@ -324,7 +324,7 @@ Evaluation<ValueType, numVars> pow(const Evaluation<ValueType, numVars>& base,
     return result;
 }
 
-template <class ValueType, int numVars>
+template <class ValueType, unsigned numVars>
 Evaluation<ValueType, numVars> log(const Evaluation<ValueType, numVars>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -345,7 +345,7 @@ Evaluation<ValueType, numVars> log(const Evaluation<ValueType, numVars>& x)
 
 // a kind of traits class for the automatic differentiation case. (The toolbox for the
 // scalar case is provided by the MathToolbox.hpp header file.)
-template <class ValueT, int numVars>
+template <class ValueT, unsigned numVars>
 struct MathToolbox<Opm::DenseAd::Evaluation<ValueT, numVars> >
 {
 private:
@@ -364,7 +364,7 @@ public:
     static Evaluation createConstant(ValueType value)
     { return Evaluation::createConstant(value); }
 
-    static Evaluation createVariable(ValueType value, int varIdx)
+    static Evaluation createVariable(ValueType value, unsigned varIdx)
     { return Evaluation::createVariable(value, varIdx); }
 
     template <class LhsEval>
@@ -457,11 +457,11 @@ public:
 
     static bool isfinite(const Evaluation& arg)
     {
-        if (!InnerToolbox::isfinite(arg.value))
+        if (!InnerToolbox::isfinite(arg.value()))
             return false;
 
-        for (int i = 0; i < numVars; ++i)
-            if (!InnerToolbox::isfinite(arg.derivatives[i]))
+        for (unsigned i = 0; i < numVars; ++i)
+            if (!InnerToolbox::isfinite(arg.derivative(i)))
                 return false;
 
         return true;
@@ -469,11 +469,11 @@ public:
 
     static bool isnan(const Evaluation& arg)
     {
-        if (InnerToolbox::isnan(arg.value))
+        if (InnerToolbox::isnan(arg.value()))
             return true;
 
-        for (int i = 0; i < numVars; ++i)
-            if (InnerToolbox::isnan(arg.derivatives[i]))
+        for (unsigned i = 0; i < numVars; ++i)
+            if (InnerToolbox::isnan(arg.derivative(i)))
                 return true;
 
         return false;

--- a/opm/material/fluidmatrixinteractions/NullMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/NullMaterial.hpp
@@ -52,7 +52,7 @@ public:
     typedef typename Traits::Scalar Scalar;
 
     //! The number of fluid phases
-    static const int numPhases = Traits::numPhases;
+    static const unsigned numPhases = Traits::numPhases;
 
     //! Specify whether this material law implements the two-phase
     //! convenience API
@@ -93,7 +93,7 @@ public:
                                    const Params &/*params*/,
                                    const FluidState &/*fluidState*/)
     {
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             values[phaseIdx] = 0.0;
     }
 

--- a/opm/material/fluidstates/FluidStateCompositionModules.hpp
+++ b/opm/material/fluidstates/FluidStateCompositionModules.hpp
@@ -185,7 +185,7 @@ class FluidStateImmiscibleCompositionModule
 
 public:
     enum { numComponents = FluidSystem::numComponents };
-    static_assert((int) numPhases == (int) numComponents,
+    static_assert(static_cast<int>(numPhases) == static_cast<int>(numComponents),
                   "The number of phases must be the same as the number of (pseudo-) components if you assume immiscibility");
 
     FluidStateImmiscibleCompositionModule()
@@ -266,13 +266,13 @@ public:
     /*!
      * \brief The mole fraction of a component in a phase []
      */
-    Scalar moleFraction(int /* phaseIdx */, int /* compIdx */) const
+    Scalar moleFraction(unsigned /* phaseIdx */, unsigned /* compIdx */) const
     { OPM_THROW(std::logic_error, "Mole fractions are not provided by this fluid state"); }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
-    Scalar massFraction(int /* phaseIdx */, int /* compIdx */) const
+    Scalar massFraction(unsigned /* phaseIdx */, unsigned /* compIdx */) const
     { OPM_THROW(std::logic_error, "Mass fractions are not provided by this fluid state"); }
 
     /*!
@@ -283,7 +283,7 @@ public:
      * component's molar masses weighted by the current mole fraction:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
-    Scalar averageMolarMass(int /* phaseIdx */) const
+    Scalar averageMolarMass(unsigned /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Mean molar masses are not provided by this fluid state"); }
 
     /*!
@@ -295,7 +295,7 @@ public:
      *
      * http://en.wikipedia.org/wiki/Concentration
      */
-    Scalar molarity(int /* phaseIdx */, int /* compIdx */) const
+    Scalar molarity(unsigned /* phaseIdx */, unsigned /* compIdx */) const
     { OPM_THROW(std::logic_error, "Molarities are not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStateDensityModules.hpp
+++ b/opm/material/fluidstates/FluidStateDensityModules.hpp
@@ -43,7 +43,7 @@ namespace Opm {
  *       densities explicitly.
  */
 template <class Scalar,
-          int numPhases,
+          unsigned numPhases,
           class Implementation>
 class FluidStateExplicitDensityModule
 {
@@ -114,7 +114,7 @@ protected:
  *        densities but throws std::logic_error instead.
  */
 template <class Scalar,
-          int numPhases,
+          unsigned numPhases,
           class Implementation>
 class FluidStateNullDensityModule
 {
@@ -125,19 +125,19 @@ public:
     /*!
      * \brief The density of a fluid phase [kg/m^3]
      */
-    const Scalar& density(int /* phaseIdx */) const
+    const Scalar& density(unsigned /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Density is not provided by this fluid state"); }
 
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
-    const Scalar& molarDensity(int /* phaseIdx */) const
+    const Scalar& molarDensity(unsigned /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Molar density is not provided by this fluid state"); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
-    const Scalar& molarVolume(int /* phaseIdx */) const
+    const Scalar& molarVolume(unsigned /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Molar volume is not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
+++ b/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
@@ -42,7 +42,7 @@ namespace Opm {
  *       enthalpies explicitly.
  */
 template <class Scalar,
-          int numPhases,
+          unsigned numPhases,
           class Implementation>
 class FluidStateExplicitEnthalpyModule
 {
@@ -108,7 +108,7 @@ protected:
  *
  * Also, the returned values are marked as undefined in Valgrind... */
 template <class Scalar,
-          int numPhases,
+          unsigned numPhases,
           class Implementation>
 class FluidStateNullEnthalpyModule
 {
@@ -119,7 +119,7 @@ public:
     /*!
      * \brief The specific internal energy of a fluid phase [J/kg]
      */
-    const Scalar& internalEnergy(int /* phaseIdx */) const
+    const Scalar& internalEnergy(unsigned /* phaseIdx */) const
     {
         static Scalar tmp = 0;
         Valgrind::SetUndefined(tmp);
@@ -129,7 +129,7 @@ public:
     /*!
      * \brief The specific enthalpy of a fluid phase [J/kg]
      */
-    const Scalar& enthalpy(int /* phaseIdx */) const
+    const Scalar& enthalpy(unsigned /* phaseIdx */) const
     {
         static Scalar tmp = 0;
         Valgrind::SetUndefined(tmp);

--- a/opm/material/fluidstates/FluidStateFugacityModules.hpp
+++ b/opm/material/fluidstates/FluidStateFugacityModules.hpp
@@ -43,8 +43,8 @@ namespace Opm {
  *        phase fugacity coefficients explicitly.
  */
 template <class Scalar,
-          int numPhases,
-          int numComponents,
+          unsigned numPhases,
+          unsigned numComponents,
           class Implementation>
 class FluidStateExplicitFugacityModule
 {
@@ -111,12 +111,12 @@ protected:
  *        fugacity coefficients explicitly assuming immiscibility.
  */
 template <class Scalar,
-          int numPhases,
-          int numComponents,
+          unsigned numPhases,
+          unsigned numComponents,
           class Implementation>
 class FluidStateImmiscibleFugacityModule
 {
-    static_assert((int) numPhases == (int) numComponents,
+    static_assert(numPhases == numComponents,
                   "The number of phases must be the same as the number of (pseudo-) components if you assume immiscibility");
 
 public:
@@ -187,13 +187,13 @@ public:
     /*!
      * \brief The fugacity coefficient of a component in a phase []
      */
-    const Scalar& fugacityCoefficient(int /* phaseIdx */, int /* compIdx */) const
+    const Scalar& fugacityCoefficient(unsigned /* phaseIdx */, unsigned /* compIdx */) const
     { OPM_THROW(std::logic_error, "Fugacity coefficients are not provided by this fluid state"); }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
-    const Scalar& fugacity(int /* phaseIdx */, int /* compIdx */) const
+    const Scalar& fugacity(unsigned /* phaseIdx */, unsigned /* compIdx */) const
     { OPM_THROW(std::logic_error, "Fugacities coefficients are not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStatePressureModules.hpp
+++ b/opm/material/fluidstates/FluidStatePressureModules.hpp
@@ -42,7 +42,7 @@ namespace Opm {
  *       pressures explicitly.
  */
 template <class Scalar,
-          int numPhases,
+          unsigned numPhases,
           class Implementation>
 class FluidStateExplicitPressureModule
 {
@@ -108,7 +108,7 @@ public:
     /*!
      * \brief The pressure of a fluid phase [Pa]
      */
-    const Scalar& pressure(int /* phaseIdx */) const
+    const Scalar& pressure(unsigned /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Pressure is not provided by this fluid state"); }
 
 

--- a/opm/material/fluidstates/FluidStateSaturationModules.hpp
+++ b/opm/material/fluidstates/FluidStateSaturationModules.hpp
@@ -43,7 +43,7 @@ namespace Opm {
  *       saturations explicitly.
  */
 template <class Scalar,
-          int numPhases,
+          unsigned numPhases,
           class Implementation>
 class FluidStateExplicitSaturationModule
 {
@@ -60,7 +60,7 @@ public:
     /*!
      * \brief Returns true iff a fluid phase shall be assumed to be present.
      */
-    bool phaseIsPresent(int phaseIdx) const
+    bool phaseIsPresent(unsigned phaseIdx) const
     { return saturation_[phaseIdx] > 0.0; }
 
     /*!
@@ -114,13 +114,13 @@ public:
     /*!
      * \brief The saturation of a fluid phase [-]
      */
-    const Scalar& saturation(int /* phaseIdx */) const
+    const Scalar& saturation(unsigned /* phaseIdx */) const
     { OPM_THROW(std::runtime_error, "Saturation is not provided by this fluid state"); }
 
     /*!
      * \brief Returns true iff a fluid phase shall be assumed to be present.
      */
-    bool phaseIsPresent(int /* phaseIdx */) const
+    bool phaseIsPresent(unsigned /* phaseIdx */) const
     { OPM_THROW(std::runtime_error, "phaseIsPresent() is not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/FluidStateTemperatureModules.hpp
+++ b/opm/material/fluidstates/FluidStateTemperatureModules.hpp
@@ -44,7 +44,7 @@ namespace Opm {
  *       temperatures explicitly.
  */
 template <class Scalar,
-          int numPhases,
+          unsigned numPhases,
           class Implementation>
 class FluidStateExplicitTemperatureModule
 {
@@ -98,7 +98,7 @@ protected:
  *        temperatures explicitly and assumes thermal equilibrium.
  */
 template <class Scalar,
-          int numPhases,
+          unsigned numPhases,
           class Implementation>
 class FluidStateEquilibriumTemperatureModule
 {

--- a/opm/material/fluidstates/FluidStateViscosityModules.hpp
+++ b/opm/material/fluidstates/FluidStateViscosityModules.hpp
@@ -42,7 +42,7 @@ namespace Opm {
  *       viscosities explicitly.
  */
 template <class Scalar,
-          int numPhases,
+          unsigned numPhases,
           class Implementation>
 class FluidStateExplicitViscosityModule
 {
@@ -98,7 +98,7 @@ protected:
  *        viscosities but throws std::logic_error instead.
  */
 template <class Scalar,
-          int numPhases,
+          unsigned numPhases,
           class Implementation>
 class FluidStateNullViscosityModule
 {
@@ -109,7 +109,7 @@ public:
     /*!
      * \brief The viscosity of a fluid phase [-]
      */
-    const Scalar& viscosity(int /* phaseIdx */) const
+    const Scalar& viscosity(unsigned /* phaseIdx */) const
     { OPM_THROW(std::logic_error, "Viscosity is not provided by this fluid state"); }
 
     /*!

--- a/opm/material/fluidstates/ModularFluidState.hpp
+++ b/opm/material/fluidstates/ModularFluidState.hpp
@@ -50,8 +50,8 @@ namespace Opm {
  * set of requested thermodynamic quantities.
  */
 template <class ScalarT,
-          int numPhasesV,
-          int numComponentsV,
+          unsigned numPhasesV,
+          unsigned numComponentsV,
           class PressureModule,
           class TemperatureModule,
           class CompositionModule,

--- a/opm/material/fluidstates/SimpleModularFluidState.hpp
+++ b/opm/material/fluidstates/SimpleModularFluidState.hpp
@@ -63,8 +63,8 @@ namespace Opm {
  * ModularFluidState. Except for this, it is identical.
  */
 template <class ScalarT,
-          int numPhasesV,
-          int numComponentsV,
+          unsigned numPhasesV,
+          unsigned numComponentsV,
           class FluidSystem, // only needed if the compositional stuff enabled
           bool storePressure,
           bool storeTemperature,

--- a/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
@@ -173,7 +173,7 @@ public:
     /*!
      * \brief The temperature of a fluid phase [K]
      */
-    const Scalar& temperature(int /*phaseIdx*/) const
+    const Scalar& temperature(unsigned /*phaseIdx*/) const
     { return temperature_; }
 
     /*!

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -119,7 +119,7 @@ public:
         typedef EvaluationT Evaluation;
 
     public:
-        ParameterCache(Scalar maxOilSat = 1.0, int regionIdx=0)
+        ParameterCache(Scalar maxOilSat = 1.0, unsigned regionIdx=0)
         {
             maxOilSat_ = maxOilSat;
             regionIdx_ = regionIdx;
@@ -308,14 +308,14 @@ public:
      ****************************************/
 
     //! \copydoc BaseFluidSystem::numPhases
-    static const int numPhases = 3;
+    static const unsigned numPhases = 3;
 
     //! Index of the water phase
-    static const int waterPhaseIdx = 0;
+    static const unsigned waterPhaseIdx = 0;
     //! Index of the oil phase
-    static const int oilPhaseIdx = 1;
+    static const unsigned oilPhaseIdx = 1;
     //! Index of the gas phase
-    static const int gasPhaseIdx = 2;
+    static const unsigned gasPhaseIdx = 2;
 
     //! The pressure at the surface
     static const Scalar surfacePressure;
@@ -344,14 +344,14 @@ public:
      ****************************************/
 
     //! \copydoc BaseFluidSystem::numComponents
-    static const int numComponents = 3;
+    static const unsigned numComponents = 3;
 
     //! Index of the oil component
-    static const int oilCompIdx = 0;
+    static const unsigned oilCompIdx = 0;
     //! Index of the water component
-    static const int waterCompIdx = 1;
+    static const unsigned waterCompIdx = 1;
     //! Index of the gas component
-    static const int gasCompIdx = 2;
+    static const unsigned gasCompIdx = 2;
 
 protected:
     static const int phaseToSolventCompIdx_[3];
@@ -359,12 +359,12 @@ protected:
 
 public:
     //! \brief returns the index of "primary" component of a phase (solvent)
-    static constexpr int solventComponentIndex(unsigned phaseIdx)
-    { return phaseToSolventCompIdx_[phaseIdx]; }
+    static constexpr unsigned solventComponentIndex(unsigned phaseIdx)
+    { return static_cast<unsigned>(phaseToSolventCompIdx_[phaseIdx]); }
 
     //! \brief returns the index of "secondary" component of a phase (solute)
-    static constexpr int soluteComponentIndex(unsigned phaseIdx)
-    { return phaseToSoluteCompIdx_[phaseIdx]; }
+    static constexpr unsigned soluteComponentIndex(unsigned phaseIdx)
+    { return static_cast<unsigned>(phaseToSoluteCompIdx_[phaseIdx]); }
 
     //! \copydoc BaseFluidSystem::componentName
     static const char *componentName(unsigned compIdx)

--- a/opm/material/heatconduction/DummyHeatConductionLaw.hpp
+++ b/opm/material/heatconduction/DummyHeatConductionLaw.hpp
@@ -54,8 +54,8 @@ public:
      * If this method is called an exception is thrown at run time.
      */
     template <class FluidState, class Evaluation = Scalar>
-    static Scalar heatConductivity(const Params &params,
-                                   const FluidState &fluidState)
+    static Scalar heatConductivity(const Params& OPM_UNUSED params,
+                                   const FluidState& OPM_UNUSED fluidState)
     {
         OPM_THROW(std::logic_error,
                    "No heat conduction law specified!");

--- a/opm/material/heatconduction/FluidConduction.hpp
+++ b/opm/material/heatconduction/FluidConduction.hpp
@@ -54,8 +54,8 @@ public:
      *        medium.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation heatConductivity(const Params &params,
-                                       const FluidState &fluidState)
+    static Evaluation heatConductivity(const Params& OPM_UNUSED params,
+                                       const FluidState& fluidState)
     {
         typename FluidSystem::template ParameterCache<Evaluation> paramCache;
         paramCache.updatePhase(fluidState, phaseIdx);

--- a/opm/material/heatconduction/Somerton.hpp
+++ b/opm/material/heatconduction/Somerton.hpp
@@ -95,7 +95,7 @@ public:
         Valgrind::CheckDefined(params.vacuumLambda());
 
         Evaluation lambda = 0;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             Valgrind::CheckDefined(params.fullySaturatedLambda(phaseIdx));
 
             if (FluidSystem::isLiquid(phaseIdx)) {

--- a/opm/material/heatconduction/SomertonParams.hpp
+++ b/opm/material/heatconduction/SomertonParams.hpp
@@ -35,7 +35,7 @@ namespace Opm {
  * \brief The default implementation of a parameter object for the
  *        Somerton heatconduction law.
  */
-template <int numPhases, class ScalarT>
+template <unsigned numPhases, class ScalarT>
 class SomertonParams
 {
     // do not copy!
@@ -55,7 +55,7 @@ public:
      * In this context "fully saturated" means that the whole pore
      * space of the porous medium is filled by a given fluid phase.
      */
-    Scalar fullySaturatedLambda(int phaseIdx) const
+    Scalar fullySaturatedLambda(unsigned phaseIdx) const
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -69,7 +69,7 @@ public:
      * In this context "fully saturated" means that the whole pore
      * space of the porous medium is filled by a given fluid phase.
      */
-    void setFullySaturatedLambda(int phaseIdx, Scalar value)
+    void setFullySaturatedLambda(unsigned phaseIdx, Scalar value)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
         assert(value > 0);


### PR DESCRIPTION
this allows the test suite of eWoms to be compiled on clang++ 3.8
using the following warning flags

```
    -Weverything
    -Wno-documentation
    -Wno-documentation-unknown-command
    -Wno-c++98-compat
    -Wno-c++98-compat-pedantic
    -Wno-undef
    -Wno-padded
    -Wno-global-constructors
    -Wno-exit-time-destructors
    -Wno-weak-vtables
    -Wno-float-equal
```

without triggering warnings in opm-material or eWoms.

Note that the test-suite for opm-material does *not* yet pass without
warnings with these flags because with these flags clang likes to
complain about reducing or increasing floating point precision which
results in a formidable nightmare. I will see what I can do about
these warnings in a separate PR.