### PR TITLE
Use tabdims from EclipseState.

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -117,8 +117,7 @@ public:
                       const std::vector<int>& compressedToCartesianElemIdx)
     {
         // get the number of saturation regions and the number of cells in the deck
-        int ntsFun = deck.getKeyword("TABDIMS").getRecord(0).getItem("NTSFUN").get<int>(0);
-        unsigned numSatRegions = static_cast<unsigned>(ntsFun);
+        const size_t numSatRegions = eclState.runspec().tabdims().getNumSatTables();
         size_t numCompressedElems = compressedToCartesianElemIdx.size();
 
         // copy the SATNUM grid property. in some cases this is not necessary, but it
@@ -321,7 +320,7 @@ private:
                                 const std::vector<int>& compressedToCartesianElemIdx,
                                 const std::vector<int>& satnumRegionArray)
     {
-        unsigned numSatRegions = static_cast<unsigned>(deck.getKeyword("TABDIMS").getRecord(0).getItem("NTSFUN").get<int>(0));
+        const size_t numSatRegions = eclState.runspec().tabdims().getNumSatTables();
         unsigned numCompressedElems = static_cast<unsigned>(compressedToCartesianElemIdx.size());
 
         // read the end point scaling configuration. this needs to be done only once per


### PR DESCRIPTION
This makes it possible to use the EclMaterialLawManager without explicit TABDIMS in the deck.

Requires OPM/opm-parser#983.

Only very limited testing has been done (other than a full compile): I have verified that this solves my problem with the old case decks without TABDIMS, and that Norne still starts up properly.