### PR TITLE
Use the JFUNC implementation in opm-parser

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -468,17 +468,7 @@ private:
     template <class Evaluation>
     static Evaluation unscaledToScaledPcnw_(const Params &params, const Evaluation& unscaledPcnw)
     {
-        if (params.config().enableLeverettScaling()) {
-            // HACK: we need to divide the "unscaled capillary pressure" by the
-            // conversion factor for deck to SI pressures because this quantity is
-            // actually *not* a pressure but the (dimensionless) value of the
-            // J-function. Since opm-parser currently always treads this column as a
-            // pressure, it multiplies it with the conversion factor and we have to
-            // revert this here.
-            Scalar alpha = params.scaledPoints().leverettFactor();
-            return unscaledPcnw*(alpha/params.config().deckPressureConversionFactor());
-        }
-        else if (params.config().enablePcScaling()) {
+        if (params.config().enablePcScaling()) {
             Scalar alpha = params.scaledPoints().maxPcnw()/params.unscaledPoints().maxPcnw();
             return unscaledPcnw*alpha;
         }
@@ -489,14 +479,7 @@ private:
     template <class Evaluation>
     static Evaluation scaledToUnscaledPcnw_(const Params &params, const Evaluation& scaledPcnw)
     {
-        if (params.config().enableLeverettScaling()) {
-            // HACK: we need to multiply the "scaled capillary pressure" by the conversion
-            // factor for deck to SI pressures because this quantity is actually *not* a
-            // pressure but the (dimensionless) value of the J-function.
-            Scalar alpha = params.scaledPoints().leverettFactor();
-            return scaledPcnw*(params.config().deckPressureConversionFactor()/alpha);
-        }
-        else if (params.config().enablePcScaling()) {
+        if (params.config().enablePcScaling()) {
             Scalar alpha = params.unscaledPoints().maxPcnw()/params.scaledPoints().maxPcnw();
             return scaledPcnw/alpha;
         }


### PR DESCRIPTION
Use the JFUNC implementation from opm-parser (depends on OPM/opm-parser#970).

The implementation in opm-parser gives the correctly scaled tables.

It's easy to code when there are no tests, or: I have no idea what I'm doing.
@andlaus could you add a test case for the JFUNC scenario that you have?
