### PR TITLE
add missing "inline" to __float128 specialization of className()

### DIFF
--- a/opm/material/common/ClassName.hpp
+++ b/opm/material/common/ClassName.hpp
@@ -69,7 +69,7 @@ std::string className()
 // specialize for quad precision floating point values to avoid
 // needing a type_info structure
 template <>
-std::string className<__float128>()
+inline std::string className<__float128>()
 { return "quad"; }
 #endif
 


### PR DESCRIPTION
if this specialization is not marked as "inline" it leads to linker errors due to multiple definitions of the `Opm::className<__float128>()` symbol. I consider this pretty surprising behaviour of the C++ language because template functions do not need to declared as `inline`.