### PR TITLE
quad.hh: include the correct header for std::runtime_error

### DIFF
--- a/opm/material/common/quad.hpp
+++ b/opm/material/common/quad.hpp
@@ -39,7 +39,7 @@
 
 #include <cmath>
 #include <string>
-#include <exception>
+#include <stdexcept>
 #include <limits>
 #include <iostream>
 #include <type_traits>


### PR DESCRIPTION
thanks to @bska for pointing this out.