### PR TITLE
EclTwoPhaseMaterial: do not update the oil-water hysteresis parameters for non-existing objects

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -336,7 +336,6 @@ public:
         case EclTwoPhaseGasOil: {
             Scalar So = FsToolbox::scalarValue(fluidState.saturation(oilPhaseIdx));
 
-            params.oilWaterParams().update(/*pcSw=*/0.0, /*krwSw=*/0.0, /*krnSw=*/0.0);
             params.gasOilParams().update(/*pcSw=*/So, /*krwSw=*/So, /*krnSw=*/So);
             break;
         }
@@ -345,7 +344,6 @@ public:
             Scalar Sw = FsToolbox::scalarValue(fluidState.saturation(waterPhaseIdx));
 
             params.oilWaterParams().update(/*pcSw=*/Sw, /*krwSw=*/Sw, /*krnSw=*/Sw);
-            params.gasOilParams().update(/*pcSw=*/0.0, /*krwSw=*/0.0, /*krnSw=*/0.0);
             break;
         }
 


### PR DESCRIPTION
we must not update these parameters because the respective objects do not exist in these cases. As far as I can see, both saturation function objects need to exist for the gas-water twophase case despide the fact
that there is no oil because the capillary pressure between water and gas is the sum of the capillary pressures between gas+oil and oil+water. (also, I am not aware of any ECL keywords to provide the
gas-water saturation functions directly.)

@atgeirr: if this fixes the issues which you recently encountered, please press Green!
