### PR TITLE
properly initialize the VAPPAR parameters for wet gas and live oil

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -55,6 +55,11 @@ class LiveOilPvt
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
 public:
+    LiveOilPvt()
+    {
+        vapPar2_ = 0.0;
+    }
+
 #if HAVE_OPM_PARSER
     /*!
      * \brief Initialize the oil parameters via the data specified by the PVTO ECL keyword.

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -55,6 +55,11 @@ class WetGasPvt
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
 public:
+    WetGasPvt()
+    {
+        vapPar1_ = 0.0;
+    }
+
 #if HAVE_OPM_PARSER
     /*!
      * \brief Initialize the parameters for wet gas using an ECL deck.


### PR DESCRIPTION
valgrind complained about it. this is only relevant if initFromDeck() is **not** used to initialize these objects. (e.g., this is the case for the reservoir_blackoil_* tests of eWoms.)