### PR TITLE
Consistency improvements

### DIFF
--- a/opm/material/binarycoefficients/FullerMethod.hpp
+++ b/opm/material/binarycoefficients/FullerMethod.hpp
@@ -53,8 +53,8 @@ namespace BinaryCoeff {
  * edition, McGraw-Hill, 1987, pp. 587-588
  */
 template <class Scalar, class Evaluation = Scalar>
-inline Evaluation fullerMethod(const Scalar *M, // molar masses [g/mol]
-                               const Scalar *SigmaNu, // atomic diffusion volume
+inline Evaluation fullerMethod(const Scalar* M, // molar masses [g/mol]
+                               const Scalar* SigmaNu, // atomic diffusion volume
                                const Evaluation& temperature, // [K]
                                const Evaluation& pressure) // [Pa]
 {

--- a/opm/material/checkFluidSystem.hpp
+++ b/opm/material/checkFluidSystem.hpp
@@ -231,7 +231,7 @@ private:
 };
 
 template <class Scalar, class BaseFluidState>
-void checkFluidState(const BaseFluidState &fs)
+void checkFluidState(const BaseFluidState& fs)
 {
     // fluid states must be copy-able
     BaseFluidState tmpFs(fs);

--- a/opm/material/checkFluidSystem.hpp
+++ b/opm/material/checkFluidSystem.hpp
@@ -261,7 +261,7 @@ void checkFluidState(const BaseFluidState &fs)
         val = fs.molarVolume(/*phaseIdx=*/0);
         val = fs.density(/*phaseIdx=*/0);
         val = fs.saturation(/*phaseIdx=*/0);
-        OPM_UNUSED bool b = fs.phaseIsPresent(/*phaseIdx=*/0);
+        bool b OPM_UNUSED = fs.phaseIsPresent(/*phaseIdx=*/0);
         val = fs.fugacity(/*phaseIdx=*/0, /*compIdx=*/0);
         val = fs.fugacityCoefficient(/*phaseIdx=*/0, /*compIdx=*/0);
         val = fs.enthalpy(/*phaseIdx=*/0);
@@ -372,7 +372,7 @@ void checkFluidSystem()
 
     // test for phaseName(), isLiquid() and isIdealGas()
     for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
-        std::string OPM_UNUSED name = FluidSystem::phaseName(phaseIdx);
+        std::string name OPM_UNUSED = FluidSystem::phaseName(phaseIdx);
         bool bVal = FluidSystem::isLiquid(phaseIdx);
         bVal = FluidSystem::isIdealGas(phaseIdx);
         bVal = !bVal; // get rid of GCC warning (only occurs with paranoid warning flags)

--- a/opm/material/common/PolynomialUtils.hpp
+++ b/opm/material/common/PolynomialUtils.hpp
@@ -48,7 +48,7 @@ namespace Opm {
  * \param b The coefficient for the constant term
  */
 template <class Scalar, class SolContainer>
-unsigned invertLinearPolynomial(SolContainer &sol,
+unsigned invertLinearPolynomial(SolContainer& sol,
                                 Scalar a,
                                 Scalar b)
 {
@@ -77,7 +77,7 @@ unsigned invertLinearPolynomial(SolContainer &sol,
  * \param c The coefficient for the constant term
  */
 template <class Scalar, class SolContainer>
-unsigned invertQuadraticPolynomial(SolContainer &sol,
+unsigned invertQuadraticPolynomial(SolContainer& sol,
                                    Scalar a,
                                    Scalar b,
                                    Scalar c)
@@ -105,7 +105,7 @@ unsigned invertQuadraticPolynomial(SolContainer &sol,
 
 //! \cond SKIP_THIS
 template <class Scalar, class SolContainer>
-void invertCubicPolynomialPostProcess_(SolContainer &sol,
+void invertCubicPolynomialPostProcess_(SolContainer& sol,
                                        int numSol,
                                        Scalar a,
                                        Scalar b,
@@ -150,7 +150,7 @@ void invertCubicPolynomialPostProcess_(SolContainer &sol,
  * \param d The coefficient for the constant term
  */
 template <class Scalar, class SolContainer>
-unsigned invertCubicPolynomial(SolContainer *sol,
+unsigned invertCubicPolynomial(SolContainer* sol,
                                Scalar a,
                                Scalar b,
                                Scalar c,

--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -950,7 +950,7 @@ public:
      * In the corner case that the spline is constant within the given
      * interval, this method returns 3.
      */
-    int monotonic(Scalar x0, Scalar x1, OPM_OPTIM_UNUSED bool extrapolate = false) const
+    int monotonic(Scalar x0, Scalar x1, bool extrapolate OPM_OPTIM_UNUSED = false) const
     {
         assert(std::abs(x0 - x1) > 1e-30);
 

--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -139,8 +139,8 @@ public:
      */
     template <class ScalarArrayX, class ScalarArrayY>
     Spline(size_t nSamples,
-           const ScalarArrayX &x,
-           const ScalarArrayY &y,
+           const ScalarArrayX& x,
+           const ScalarArrayY& y,
            SplineType splineType = Natural,
            bool sortInputs = false)
     { this->setXYArrays(nSamples, x, y, splineType, sortInputs); }
@@ -154,7 +154,7 @@ public:
      */
     template <class PointArray>
     Spline(size_t nSamples,
-           const PointArray &points,
+           const PointArray& points,
            SplineType splineType = Natural,
            bool sortInputs = false)
     { this->setArrayOfPoints(nSamples, points, splineType, sortInputs); }
@@ -167,8 +167,8 @@ public:
      * \param periodic Indicates whether a natural or a periodic spline should be created
      */
     template <class ScalarContainer>
-    Spline(const ScalarContainer &x,
-           const ScalarContainer &y,
+    Spline(const ScalarContainer& x,
+           const ScalarContainer& y,
            SplineType splineType = Natural,
            bool sortInputs = false)
     { this->setXYContainers(x, y, splineType, sortInputs); }
@@ -180,7 +180,7 @@ public:
      * \param periodic Indicates whether a natural or a periodic spline should be created
      */
     template <class PointContainer>
-    Spline(const PointContainer &points,
+    Spline(const PointContainer& points,
            SplineType splineType = Natural,
            bool sortInputs = false)
     { this->setContainerOfPoints(points, splineType, sortInputs); }
@@ -197,8 +197,8 @@ public:
      */
     template <class ScalarArray>
     Spline(size_t nSamples,
-           const ScalarArray &x,
-           const ScalarArray &y,
+           const ScalarArray& x,
+           const ScalarArray& y,
            Scalar m0,
            Scalar m1,
            bool sortInputs = false)
@@ -215,7 +215,7 @@ public:
      */
     template <class PointArray>
     Spline(size_t nSamples,
-           const PointArray &points,
+           const PointArray& points,
            Scalar m0,
            Scalar m1,
            bool sortInputs = false)
@@ -231,8 +231,8 @@ public:
      * \param sortInputs Indicates whether the sample points should be sorted (this is not necessary if they are already sorted in ascending or descending order)
      */
     template <class ScalarContainerX, class ScalarContainerY>
-    Spline(const ScalarContainerX &x,
-           const ScalarContainerY &y,
+    Spline(const ScalarContainerX& x,
+           const ScalarContainerY& y,
            Scalar m0,
            Scalar m1,
            bool sortInputs = false)
@@ -247,7 +247,7 @@ public:
      * \param sortInputs Indicates whether the sample points should be sorted (this is not necessary if they are already sorted in ascending or descending order)
      */
     template <class PointContainer>
-    Spline(const PointContainer &points,
+    Spline(const PointContainer& points,
            Scalar m0,
            Scalar m1,
            bool sortInputs = false)
@@ -321,8 +321,8 @@ public:
      */
     template <class ScalarArrayX, class ScalarArrayY>
     void setXYArrays(size_t nSamples,
-                     const ScalarArrayX &x,
-                     const ScalarArrayY &y,
+                     const ScalarArrayX& x,
+                     const ScalarArrayY& y,
                      Scalar m0, Scalar m1,
                      bool sortInputs = false)
     {
@@ -354,8 +354,8 @@ public:
      * and the Y containers must be equal and larger than 1.
      */
     template <class ScalarContainerX, class ScalarContainerY>
-    void setXYContainers(const ScalarContainerX &x,
-                         const ScalarContainerY &y,
+    void setXYContainers(const ScalarContainerX& x,
+                         const ScalarContainerY& y,
                          Scalar m0, Scalar m1,
                          bool sortInputs = false)
     {
@@ -389,7 +389,7 @@ public:
      */
     template <class PointArray>
     void setArrayOfPoints(size_t nSamples,
-                          const PointArray &points,
+                          const PointArray& points,
                           Scalar m0,
                           Scalar m1,
                           bool sortInputs = false)
@@ -425,7 +425,7 @@ public:
      * in the X and the Y containers must be equal and larger than 1.
      */
     template <class XYContainer>
-    void setContainerOfPoints(const XYContainer &points,
+    void setContainerOfPoints(const XYContainer& points,
                               Scalar m0,
                               Scalar m1,
                               bool sortInputs = false)
@@ -467,7 +467,7 @@ public:
      * and the Y containers must be equal and larger than 1.
      */
     template <class XYContainer>
-    void setContainerOfTuples(const XYContainer &points,
+    void setContainerOfTuples(const XYContainer& points,
                               Scalar m0,
                               Scalar m1,
                               bool sortInputs = false)
@@ -509,8 +509,8 @@ public:
      */
     template <class ScalarArrayX, class ScalarArrayY>
     void setXYArrays(size_t nSamples,
-                     const ScalarArrayX &x,
-                     const ScalarArrayY &y,
+                     const ScalarArrayX& x,
+                     const ScalarArrayY& y,
                      SplineType splineType = Natural,
                      bool sortInputs = false)
     {
@@ -549,8 +549,8 @@ public:
      * and the Y containers must be equal and larger than 1.
      */
     template <class ScalarContainerX, class ScalarContainerY>
-    void setXYContainers(const ScalarContainerX &x,
-                         const ScalarContainerY &y,
+    void setXYContainers(const ScalarContainerX& x,
+                         const ScalarContainerY& y,
                          SplineType splineType = Natural,
                          bool sortInputs = false)
     {
@@ -590,7 +590,7 @@ public:
      */
     template <class PointArray>
     void setArrayOfPoints(size_t nSamples,
-                          const PointArray &points,
+                          const PointArray& points,
                           SplineType splineType = Natural,
                           bool sortInputs = false)
     {
@@ -631,7 +631,7 @@ public:
      * in the X and the Y containers must be equal and larger than 1.
      */
     template <class XYContainer>
-    void setContainerOfPoints(const XYContainer &points,
+    void setContainerOfPoints(const XYContainer& points,
                               SplineType splineType = Natural,
                               bool sortInputs = false)
     {
@@ -677,7 +677,7 @@ public:
      * and the Y containers must be equal and larger than 1.
      */
     template <class XYContainer>
-    void setContainerOfTuples(const XYContainer &points,
+    void setContainerOfTuples(const XYContainer& points,
                               SplineType splineType = Natural,
                               bool sortInputs = false)
     {
@@ -747,7 +747,7 @@ public:
      "spline.csv" using 1:4 w p ti "Monotonic"
      ----------- snap -----------
     */
-    void printCSV(Scalar xi0, Scalar xi1, size_t k, std::ostream &os = std::cout) const
+    void printCSV(Scalar xi0, Scalar xi1, size_t k, std::ostream& os = std::cout) const
     {
         Scalar x0 = std::min(xi0, xi1);
         Scalar x1 = std::max(xi0, xi1);
@@ -1025,14 +1025,14 @@ protected:
      */
     struct ComparatorX_
     {
-        ComparatorX_(const std::vector<Scalar> &x)
+        ComparatorX_(const std::vector<Scalar>& x)
             : x_(x)
         {}
 
         bool operator ()(unsigned idxA, unsigned idxB) const
         { return x_.at(idxA) < x_.at(idxB); }
 
-        const std::vector<Scalar> &x_;
+        const std::vector<Scalar>& x_;
     };
 
     /*!
@@ -1166,10 +1166,10 @@ protected:
      * although the input must be ordered already!
      */
     template <class DestVector, class SourceVector>
-    void assignSamplingPoints_(DestVector &destX,
-                               DestVector &destY,
-                               const SourceVector &srcX,
-                               const SourceVector &srcY,
+    void assignSamplingPoints_(DestVector& destX,
+                               DestVector& destY,
+                               const SourceVector& srcX,
+                               const SourceVector& srcY,
                                unsigned nSamples)
     {
         assert(nSamples >= 2);
@@ -1186,10 +1186,10 @@ protected:
     }
 
     template <class DestVector, class ListIterator>
-    void assignFromArrayList_(DestVector &destX,
-                              DestVector &destY,
-                              const ListIterator &srcBegin,
-                              const ListIterator &srcEnd,
+    void assignFromArrayList_(DestVector& destX,
+                              DestVector& destY,
+                              const ListIterator& srcBegin,
+                              const ListIterator& srcEnd,
                               unsigned nSamples)
     {
         assert(nSamples >= 2);
@@ -1220,8 +1220,8 @@ protected:
      * if the sampling point.
      */
     template <class DestVector, class ListIterator>
-    void assignFromTupleList_(DestVector &destX,
-                              DestVector &destY,
+    void assignFromTupleList_(DestVector& destX,
+                              DestVector& destY,
                               ListIterator srcBegin,
                               ListIterator srcEnd,
                               unsigned nSamples)
@@ -1254,7 +1254,7 @@ protected:
      *        in the moments of the full spline.
      */
     template <class Vector, class Matrix>
-    void makeFullSystem_(Matrix &M, Vector &d, Scalar m0, Scalar m1)
+    void makeFullSystem_(Matrix& M, Vector& d, Scalar m0, Scalar m1)
     {
         makeNaturalSystem_(M, d);
 
@@ -1278,7 +1278,7 @@ protected:
      *        in the moments of the natural spline.
      */
     template <class Vector, class Matrix>
-    void makeNaturalSystem_(Matrix &M, Vector &d)
+    void makeNaturalSystem_(Matrix& M, Vector& d)
     {
         M = 0.0;
 
@@ -1324,7 +1324,7 @@ protected:
      *        in the moments of the periodic spline.
      */
     template <class Matrix, class Vector>
-    void makePeriodicSystem_(Matrix &M, Vector &d)
+    void makePeriodicSystem_(Matrix& M, Vector& d)
     {
         M = 0.0;
 
@@ -1386,7 +1386,7 @@ protected:
      * http://en.wikipedia.org/wiki/Monotone_cubic_interpolation
      */
     template <class Vector>
-    void makeMonotonicSpline_(Vector &slopes)
+    void makeMonotonicSpline_(Vector& slopes)
     {
         auto n = numSamples();
 
@@ -1435,7 +1435,7 @@ protected:
      * not continuous.
      */
     template <class MomentsVector, class SlopeVector>
-    void setSlopesFromMoments_(SlopeVector &slopes, const MomentsVector &moments)
+    void setSlopesFromMoments_(SlopeVector& slopes, const MomentsVector& moments)
     {
         size_t n = numSamples();
 
@@ -1633,7 +1633,7 @@ protected:
     // 1: spline is monotonously increasing in the specified interval
     // 0: spline is not monotonic (or constant) in the specified interval
     // -1: spline is monotonously decreasing in the specified interval
-    int monotonic_(size_t i, Scalar x0, Scalar x1, int &r) const
+    int monotonic_(size_t i, Scalar x0, Scalar x1, int& r) const
     {
         // coefficients of derivative in monomial basis
         Scalar a = 3*a_(i);
@@ -1701,7 +1701,7 @@ protected:
      *        with a cubic polynomial within a specified interval.
      */
     template <class Evaluation>
-    size_t intersectSegment_(Evaluation *sol,
+    size_t intersectSegment_(Evaluation* sol,
                              size_t segIdx,
                              const Evaluation& a,
                              const Evaluation& b,

--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -305,7 +305,7 @@ public:
      *                    cause a failed assertation.
      */
     template <class Evaluation>
-    Evaluation evalSecondDerivative(OPM_OPTIM_UNUSED const Evaluation& x, OPM_OPTIM_UNUSED bool extrapolate=false) const
+    Evaluation evalSecondDerivative(const Evaluation OPM_OPTIM_UNUSED& x, bool extrapolate OPM_OPTIM_UNUSED = false) const
     {
         assert(extrapolate || applies(x));
         return 0.0;
@@ -326,7 +326,7 @@ public:
      *                    cause a failed assertation.
      */
     template <class Evaluation>
-    Evaluation evalThirdDerivative(OPM_OPTIM_UNUSED const Evaluation& x, OPM_OPTIM_UNUSED bool extrapolate=false) const
+    Evaluation evalThirdDerivative(const Evaluation OPM_OPTIM_UNUSED& x, bool extrapolate OPM_OPTIM_UNUSED = false) const
     {
         assert(extrapolate || applies(x));
         return 0.0;
@@ -484,7 +484,7 @@ private:
     }
 
     template <class Evaluation>
-    Evaluation evalDerivative_(OPM_UNUSED const Evaluation& x, size_t segIdx) const
+    Evaluation evalDerivative_(const Evaluation &x OPM_UNUSED, size_t segIdx) const
     {
         Scalar x0 = xValues_[segIdx];
         Scalar x1 = xValues_[segIdx + 1];

--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -64,8 +64,8 @@ public:
      */
     template <class ScalarArrayX, class ScalarArrayY>
     Tabulated1DFunction(size_t nSamples,
-                        const ScalarArrayX &x,
-                        const ScalarArrayY &y,
+                        const ScalarArrayX& x,
+                        const ScalarArrayY& y,
                         bool sortInputs = false)
     { this->setXYArrays(nSamples, x, y, sortInputs); }
 
@@ -78,8 +78,8 @@ public:
      *          (must have a size() method)
      */
     template <class ScalarContainer>
-    Tabulated1DFunction(const ScalarContainer &x,
-                        const ScalarContainer &y,
+    Tabulated1DFunction(const ScalarContainer& x,
+                        const ScalarContainer& y,
                         bool sortInputs = false)
     { this->setXYContainers(x, y, sortInputs); }
 
@@ -90,7 +90,7 @@ public:
      *               have a size() method)
      */
     template <class PointContainer>
-    Tabulated1DFunction(const PointContainer &points,
+    Tabulated1DFunction(const PointContainer& points,
                         bool sortInputs = false)
     { this->setContainerOfTuples(points, sortInputs); }
 
@@ -101,8 +101,8 @@ public:
      */
     template <class ScalarArrayX, class ScalarArrayY>
     void setXYArrays(size_t nSamples,
-                     const ScalarArrayX &x,
-                     const ScalarArrayY &y,
+                     const ScalarArrayX& x,
+                     const ScalarArrayY& y,
                      bool sortInputs = false)
     {
         assert(nSamples > 1);
@@ -125,8 +125,8 @@ public:
      * This method takes STL compatible containers as arguments.
      */
     template <class ScalarContainerX, class ScalarContainerY>
-    void setXYContainers(const ScalarContainerX &x,
-                         const ScalarContainerY &y,
+    void setXYContainers(const ScalarContainerX& x,
+                         const ScalarContainerY& y,
                          bool sortInputs = false)
     {
         assert(x.size() == y.size());
@@ -147,7 +147,7 @@ public:
      */
     template <class PointArray>
     void setArrayOfPoints(size_t nSamples,
-                          const PointArray &points,
+                          const PointArray& points,
                           bool sortInputs = false)
     {
         // a linear function with less than two sampling points? what an incredible
@@ -181,7 +181,7 @@ public:
      * and the Y containers must be equal and larger than 1.
      */
     template <class XYContainer>
-    void setContainerOfTuples(const XYContainer &points,
+    void setContainerOfTuples(const XYContainer& points,
                               bool sortInputs = false)
     {
         // a linear function with less than two sampling points? what an incredible
@@ -423,7 +423,7 @@ public:
      "function.csv" using 1:3 w l ti "Derivative"
      ----------- snap -----------
     */
-    void printCSV(Scalar xi0, Scalar xi1, unsigned k, std::ostream &os = std::cout) const
+    void printCSV(Scalar xi0, Scalar xi1, unsigned k, std::ostream& os = std::cout) const
     {
         Scalar x0 = std::min(xi0, xi1);
         Scalar x1 = std::max(xi0, xi1);
@@ -484,7 +484,7 @@ private:
     }
 
     template <class Evaluation>
-    Evaluation evalDerivative_(const Evaluation &x OPM_UNUSED, size_t segIdx) const
+    Evaluation evalDerivative_(const Evaluation& x OPM_UNUSED, size_t segIdx) const
     {
         Scalar x0 = xValues_[segIdx];
         Scalar x1 = xValues_[segIdx + 1];
@@ -503,7 +503,7 @@ private:
     // 1: function is monotonously increasing in the specified interval
     // 0: function is not monotonic in the specified interval
     // -1: function is monotonously decreasing in the specified interval
-    int updateMonotonicity_(size_t i, int &r) const
+    int updateMonotonicity_(size_t i, int& r) const
     {
         if (yValues_[i] < yValues_[i + 1]) {
             // monotonically increasing?
@@ -530,14 +530,14 @@ private:
      */
     struct ComparatorX_
     {
-        ComparatorX_(const std::vector<Scalar> &x)
+        ComparatorX_(const std::vector<Scalar>& x)
             : x_(x)
         {}
 
         bool operator ()(size_t idxA, size_t idxB) const
         { return x_.at(idxA) < x_.at(idxB); }
 
-        const std::vector<Scalar> &x_;
+        const std::vector<Scalar>& x_;
     };
 
     /*!

--- a/opm/material/common/TridiagonalMatrix.hpp
+++ b/opm/material/common/TridiagonalMatrix.hpp
@@ -50,12 +50,12 @@ template <class Scalar>
 class TridiagonalMatrix
 {
     struct TridiagRow_ {
-        TridiagRow_(TridiagonalMatrix &m, size_t rowIdx)
+        TridiagRow_(TridiagonalMatrix& m, size_t rowIdx)
             : matrix_(m)
             , rowIdx_(rowIdx)
         {}
 
-        Scalar &operator[](size_t colIdx)
+        Scalar& operator[](size_t colIdx)
         { return matrix_.at(rowIdx_, colIdx); }
 
         Scalar operator[](size_t colIdx) const
@@ -64,31 +64,31 @@ class TridiagonalMatrix
         /*!
          * \brief Prefix increment operator
          */
-        TridiagRow_ &operator++()
+        TridiagRow_& operator++()
         { ++ rowIdx_; return *this; }
 
         /*!
          * \brief Prefix decrement operator
          */
-        TridiagRow_ &operator--()
+        TridiagRow_& operator--()
         { -- rowIdx_; return *this; }
 
         /*!
          * \brief Comparision operator
          */
-        bool operator==(const TridiagRow_ &other) const
+        bool operator==(const TridiagRow_& other) const
         { return other.rowIdx_ == rowIdx_ && &other.matrix_ == &matrix_; }
 
         /*!
          * \brief Comparision operator
          */
-        bool operator!=(const TridiagRow_ &other) const
+        bool operator!=(const TridiagRow_& other) const
         { return !operator==(other); }
 
         /*!
          * \brief Dereference operator
          */
-        TridiagRow_ &operator*()
+        TridiagRow_& operator*()
         { return *this; }
 
         /*!
@@ -100,7 +100,7 @@ class TridiagonalMatrix
         { return rowIdx_; }
 
     private:
-        TridiagonalMatrix &matrix_;
+        TridiagonalMatrix& matrix_;
         mutable size_t rowIdx_;
     };
 
@@ -125,7 +125,7 @@ public:
     /*!
      * \brief Copy constructor.
      */
-    TridiagonalMatrix(const TridiagonalMatrix &source)
+    TridiagonalMatrix(const TridiagonalMatrix& source)
     { *this = source; }
 
     /*!
@@ -161,7 +161,7 @@ public:
     /*!
      * \brief Access an entry.
      */
-    Scalar &at(size_t rowIdx, size_t colIdx)
+    Scalar& at(size_t rowIdx, size_t colIdx)
     {
         size_t n = size();
 
@@ -201,7 +201,7 @@ public:
     /*!
      * \brief Assignment operator from another tridiagonal matrix.
      */
-    TridiagonalMatrix &operator=(const TridiagonalMatrix &source)
+    TridiagonalMatrix& operator=(const TridiagonalMatrix& source)
     {
         for (unsigned diagIdx = 0; diagIdx < 3; ++ diagIdx)
             diag_[diagIdx] = source.diag_[diagIdx];
@@ -212,7 +212,7 @@ public:
     /*!
      * \brief Assignment operator from a Scalar.
      */
-    TridiagonalMatrix &operator=(Scalar value)
+    TridiagonalMatrix& operator=(Scalar value)
     {
         for (unsigned diagIdx = 0; diagIdx < 3; ++ diagIdx)
             diag_[diagIdx].assign(size(), value);
@@ -253,7 +253,7 @@ public:
     /*!
      * \brief Multiplication with a Scalar
      */
-    TridiagonalMatrix &operator*=(Scalar alpha)
+    TridiagonalMatrix& operator*=(Scalar alpha)
     {
         unsigned n = size();
         for (unsigned diagIdx = 0; diagIdx < 3; ++ diagIdx) {
@@ -268,7 +268,7 @@ public:
     /*!
      * \brief Division by a Scalar
      */
-    TridiagonalMatrix &operator/=(Scalar alpha)
+    TridiagonalMatrix& operator/=(Scalar alpha)
     {
         alpha = 1.0/alpha;
         unsigned n = size();
@@ -284,13 +284,13 @@ public:
     /*!
      * \brief Subtraction operator
      */
-    TridiagonalMatrix &operator-=(const TridiagonalMatrix &other)
+    TridiagonalMatrix& operator-=(const TridiagonalMatrix& other)
     { return axpy(-1.0, other); }
 
     /*!
      * \brief Addition operator
      */
-    TridiagonalMatrix &operator+=(const TridiagonalMatrix &other)
+    TridiagonalMatrix& operator+=(const TridiagonalMatrix& other)
     { return axpy(1.0, other); }
 
 
@@ -307,7 +307,7 @@ public:
      * A += alpha*C
      * \endcode
      */
-    TridiagonalMatrix &axpy(Scalar alpha, const TridiagonalMatrix &other)
+    TridiagonalMatrix& axpy(Scalar alpha, const TridiagonalMatrix& other)
     {
         assert(size() == other.size());
 
@@ -332,7 +332,7 @@ public:
      * \endcode
      */
     template<class Vector>
-    void mv(const Vector &source, Vector &dest) const
+    void mv(const Vector& source, Vector& dest) const
     {
         assert(source.size() == size());
         assert(dest.size() == size());
@@ -372,7 +372,7 @@ public:
      * \endcode
      */
     template<class Vector>
-    void umv(const Vector &source, Vector &dest) const
+    void umv(const Vector& source, Vector& dest) const
     {
         assert(source.size() == size());
         assert(dest.size() == size());
@@ -412,7 +412,7 @@ public:
      * \endcode
      */
     template<class Vector>
-    void mmv(const Vector &source, Vector &dest) const
+    void mmv(const Vector& source, Vector& dest) const
     {
         assert(source.size() == size());
         assert(dest.size() == size());
@@ -452,7 +452,7 @@ public:
      * \endcode
      */
     template<class Vector>
-    void usmv(Scalar alpha, const Vector &source, Vector &dest) const
+    void usmv(Scalar alpha, const Vector& source, Vector& dest) const
     {
         assert(source.size() == size());
         assert(dest.size() == size());
@@ -495,7 +495,7 @@ public:
      * \endcode
      */
     template<class Vector>
-    void mtv(const Vector &source, Vector &dest) const
+    void mtv(const Vector& source, Vector& dest) const
     {
         assert(source.size() == size());
         assert(dest.size() == size());
@@ -535,7 +535,7 @@ public:
      * \endcode
      */
     template<class Vector>
-    void umtv(const Vector &source, Vector &dest) const
+    void umtv(const Vector& source, Vector& dest) const
     {
         assert(source.size() == size());
         assert(dest.size() == size());
@@ -575,7 +575,7 @@ public:
      * \endcode
      */
     template<class Vector>
-    void mmtv (const Vector &source, Vector &dest) const
+    void mmtv (const Vector& source, Vector& dest) const
     {
         assert(source.size() == size());
         assert(dest.size() == size());
@@ -615,7 +615,7 @@ public:
      * \endcode
      */
     template<class Vector>
-    void usmtv(Scalar alpha, const Vector &source, Vector &dest) const
+    void usmtv(Scalar alpha, const Vector& source, Vector& dest) const
     {
         assert(source.size() == size());
         assert(dest.size() == size());
@@ -711,7 +711,7 @@ public:
      * tridiagonal matrix.
      */
     template <class XVector, class BVector>
-    void solve(XVector &x, const BVector &b) const
+    void solve(XVector& x, const BVector& b) const
     {
         if (size() > 2 && std::abs(diag_[2][0]) < 1e-30)
             solveWithUpperRight_(x, b);
@@ -722,7 +722,7 @@ public:
     /*!
      * \brief Print the matrix to a given output stream.
      */
-    void print(std::ostream &os = std::cout) const
+    void print(std::ostream& os = std::cout) const
     {
         size_t n = size();
 
@@ -761,7 +761,7 @@ public:
 
 private:
     template <class XVector, class BVector>
-    void solveWithUpperRight_(XVector &x, const BVector &b) const
+    void solveWithUpperRight_(XVector& x, const BVector& b) const
     {
         size_t n = size();
 
@@ -802,7 +802,7 @@ private:
     }
 
     template <class XVector, class BVector>
-    void solveWithoutUpperRight_(XVector &x, const BVector &b) const
+    void solveWithoutUpperRight_(XVector& x, const BVector& b) const
     {
         size_t n = size();
 
@@ -846,7 +846,7 @@ private:
 } // namespace Opm
 
 template <class Scalar>
-std::ostream &operator<<(std::ostream &os, const Opm::TridiagonalMatrix<Scalar> &mat)
+std::ostream& operator<<(std::ostream& os, const Opm::TridiagonalMatrix<Scalar>& mat)
 {
     mat.print(os);
     return os;

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -144,7 +144,7 @@ public:
      * sample point.
       */
     template <class Evaluation>
-    Evaluation xToI(const Evaluation& x, OPM_OPTIM_UNUSED bool extrapolate = false) const
+    Evaluation xToI(const Evaluation& x, bool extrapolate OPM_OPTIM_UNUSED = false) const
     {
         assert(extrapolate || (xMin() <= x && x <= xMax()));
 
@@ -186,7 +186,7 @@ public:
      * sample point.
      */
     template <class Evaluation>
-    Evaluation yToJ(size_t i, const Evaluation& y, OPM_OPTIM_UNUSED bool extrapolate = false) const
+    Evaluation yToJ(size_t i, const Evaluation& y, bool extrapolate OPM_OPTIM_UNUSED = false) const
     {
         assert(0 <= i && i < numX());
         const auto &colSamplePoints = samples_.at(i);

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -189,7 +189,7 @@ public:
     Evaluation yToJ(size_t i, const Evaluation& y, bool extrapolate OPM_OPTIM_UNUSED = false) const
     {
         assert(0 <= i && i < numX());
-        const auto &colSamplePoints = samples_.at(i);
+        const auto& colSamplePoints = samples_.at(i);
 
         assert(extrapolate || (yMin(i) <= y && y <= yMax(i)));
 
@@ -226,8 +226,8 @@ public:
             return false;
 
         Scalar i = xToI(x, /*extrapolate=*/false);
-        const auto &col1SamplePoints = samples_.at(unsigned(i));
-        const auto &col2SamplePoints = samples_.at(unsigned(i));
+        const auto& col1SamplePoints = samples_.at(unsigned(i));
+        const auto& col2SamplePoints = samples_.at(unsigned(i));
         Scalar alpha = i - static_cast<int>(i);
 
         Scalar minY =
@@ -350,7 +350,7 @@ public:
      * It will produce the data in CSV format on stdout, so that it can be visualized
      * using e.g. gnuplot.
      */
-    void print(std::ostream &os = std::cout) const
+    void print(std::ostream& os = std::cout) const
     {
         Scalar x0 = xMin();
         Scalar x1 = xMax();

--- a/opm/material/components/Air.hpp
+++ b/opm/material/components/Air.hpp
@@ -58,7 +58,7 @@ public:
     /*!
      * \brief A human readable name for the \f$Air\f$.
      */
-    static const char *name()
+    static const char* name()
     { return "Air"; }
 
     /*!

--- a/opm/material/components/Brine.hpp
+++ b/opm/material/components/Brine.hpp
@@ -51,7 +51,7 @@ public:
     /*!
      * \copydoc Component::name
      */
-    static const char *name()
+    static const char* name()
     { return "Brine"; }
 
     /*!

--- a/opm/material/components/CO2.hpp
+++ b/opm/material/components/CO2.hpp
@@ -60,7 +60,7 @@ public:
     /*!
      * \brief A human readable name for the CO2.
      */
-    static const char *name()
+    static const char* name()
     { return "CO2"; }
 
     /*!

--- a/opm/material/components/Component.hpp
+++ b/opm/material/components/Component.hpp
@@ -84,7 +84,7 @@ public:
     /*!
      * \brief A human readable name for the component.
      */
-    static const char *name()
+    static const char* name()
     { OPM_THROW(std::runtime_error, "Not implemented: Component::name()"); }
 
     /*!

--- a/opm/material/components/Dnapl.hpp
+++ b/opm/material/components/Dnapl.hpp
@@ -50,7 +50,7 @@ public:
     /*!
      * \brief A human readable name for the TCE.
      */
-    static const char *name()
+    static const char* name()
     { return "DNAPL"; }
 
     /*!

--- a/opm/material/components/H2O.hpp
+++ b/opm/material/components/H2O.hpp
@@ -71,7 +71,7 @@ public:
     /*!
      * \brief A human readable name for the water.
      */
-    static const char *name()
+    static const char* name()
     { return "H2O"; }
 
     /*!

--- a/opm/material/components/Lnapl.hpp
+++ b/opm/material/components/Lnapl.hpp
@@ -44,7 +44,7 @@ public:
     /*!
      * \brief A human readable name for the LNAPL.
      */
-    static const char *name()
+    static const char* name()
     { return "LNAPL"; }
 
     /*!

--- a/opm/material/components/Mesitylene.hpp
+++ b/opm/material/components/Mesitylene.hpp
@@ -49,7 +49,7 @@ public:
     /*!
      * \brief A human readable name for the mesitylene
      */
-    static const char *name()
+    static const char* name()
     { return "mesitylene"; }
 
     /*!

--- a/opm/material/components/N2.hpp
+++ b/opm/material/components/N2.hpp
@@ -53,7 +53,7 @@ public:
     /*!
      * \brief A human readable name for nitrogen.
      */
-    static const char *name()
+    static const char* name()
     { return "N2"; }
 
     /*!

--- a/opm/material/components/SimpleCO2.hpp
+++ b/opm/material/components/SimpleCO2.hpp
@@ -53,7 +53,7 @@ public:
     /*!
      * \copydoc Component::name
      */
-    static const char *name()
+    static const char* name()
     { return "CO2"; }
 
     /*!

--- a/opm/material/components/SimpleH2O.hpp
+++ b/opm/material/components/SimpleH2O.hpp
@@ -61,7 +61,7 @@ public:
     /*!
      * \brief A human readable name for the water.
      */
-    static const char *name()
+    static const char* name()
     { return "H2O"; }
 
     /*!

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -215,7 +215,7 @@ public:
     /*!
      * \brief A human readable name for the component.
      */
-    static const char *name()
+    static const char* name()
     { return RawComponent::name(); }
 
     /*!
@@ -539,7 +539,7 @@ public:
 private:
     // returns an interpolated value depending on temperature
     template <class Evaluation>
-    static Evaluation interpolateT_(const Scalar *values, const Evaluation& T)
+    static Evaluation interpolateT_(const Scalar* values, const Evaluation& T)
     {
         typedef Opm::MathToolbox<Evaluation> Toolbox;
 
@@ -558,7 +558,7 @@ private:
     // returns an interpolated value for liquid depending on
     // temperature and pressure
     template <class Evaluation>
-    static Evaluation interpolateLiquidTP_(const Scalar *values, const Evaluation& T, const Evaluation& p)
+    static Evaluation interpolateLiquidTP_(const Scalar* values, const Evaluation& T, const Evaluation& p)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -593,7 +593,7 @@ private:
     // returns an interpolated value for gas depending on
     // temperature and pressure
     template <class Evaluation>
-    static Evaluation interpolateGasTP_(const Scalar *values, const Evaluation& T, const Evaluation& p)
+    static Evaluation interpolateGasTP_(const Scalar* values, const Evaluation& T, const Evaluation& p)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -630,7 +630,7 @@ private:
     // returns an interpolated value for gas depending on
     // temperature and density
     template <class Evaluation>
-    static Evaluation interpolateGasTRho_(const Scalar *values, const Evaluation& T, const Evaluation& rho)
+    static Evaluation interpolateGasTRho_(const Scalar* values, const Evaluation& T, const Evaluation& rho)
     {
         Evaluation alphaT = tempIdx_(T);
         unsigned iT = std::max(0,
@@ -661,7 +661,7 @@ private:
     // returns an interpolated value for liquid depending on
     // temperature and density
     template <class Evaluation>
-    static Evaluation interpolateLiquidTRho_(const Scalar *values, const Evaluation& T, const Evaluation& rho)
+    static Evaluation interpolateLiquidTRho_(const Scalar* values, const Evaluation& T, const Evaluation& rho)
     {
         Evaluation alphaT = tempIdx_(T);
         unsigned iT = std::max<int>(0, std::min<int>(nTemp_ - 2, static_cast<int>(alphaT)));
@@ -789,35 +789,35 @@ private:
     { return maxGasDensity__[tempIdx]; }
 
     // 1D fields with the temperature as degree of freedom
-    static Scalar *vaporPressure_;
+    static Scalar* vaporPressure_;
 
-    static Scalar *minLiquidDensity__;
-    static Scalar *maxLiquidDensity__;
+    static Scalar* minLiquidDensity__;
+    static Scalar* maxLiquidDensity__;
 
-    static Scalar *minGasDensity__;
-    static Scalar *maxGasDensity__;
+    static Scalar* minGasDensity__;
+    static Scalar* maxGasDensity__;
 
     // 2D fields with the temperature and pressure as degrees of
     // freedom
-    static Scalar *gasEnthalpy_;
-    static Scalar *liquidEnthalpy_;
+    static Scalar* gasEnthalpy_;
+    static Scalar* liquidEnthalpy_;
 
-    static Scalar *gasHeatCapacity_;
-    static Scalar *liquidHeatCapacity_;
+    static Scalar* gasHeatCapacity_;
+    static Scalar* liquidHeatCapacity_;
 
-    static Scalar *gasDensity_;
-    static Scalar *liquidDensity_;
+    static Scalar* gasDensity_;
+    static Scalar* liquidDensity_;
 
-    static Scalar *gasViscosity_;
-    static Scalar *liquidViscosity_;
+    static Scalar* gasViscosity_;
+    static Scalar* liquidViscosity_;
 
-    static Scalar *gasThermalConductivity_;
-    static Scalar *liquidThermalConductivity_;
+    static Scalar* gasThermalConductivity_;
+    static Scalar* liquidThermalConductivity_;
 
     // 2D fields with the temperature and density as degrees of
     // freedom
-    static Scalar *gasPressure_;
-    static Scalar *liquidPressure_;
+    static Scalar* gasPressure_;
+    static Scalar* liquidPressure_;
 
     // temperature, pressure and density ranges
     static Scalar tempMin_;

--- a/opm/material/components/Unit.hpp
+++ b/opm/material/components/Unit.hpp
@@ -49,7 +49,7 @@ public:
     /*!
      * \copydoc Component::name
      */
-    static const char *name()
+    static const char* name()
     { return "Unit"; }
 
     /*!

--- a/opm/material/components/Xylene.hpp
+++ b/opm/material/components/Xylene.hpp
@@ -52,7 +52,7 @@ public:
     /*!
      * \brief A human readable name for the xylene
      */
-    static const char *name()
+    static const char* name()
     { return "xylene"; }
 
     /*!

--- a/opm/material/constraintsolvers/CompositionFromFugacities.hpp
+++ b/opm/material/constraintsolvers/CompositionFromFugacities.hpp
@@ -62,9 +62,9 @@ public:
      * \brief Guess an initial value for the composition of the phase.
      */
     template <class FluidState>
-    static void guessInitial(FluidState &fluidState,
+    static void guessInitial(FluidState& fluidState,
                              unsigned phaseIdx,
-                             const ComponentVector &/*fugVec*/)
+                             const ComponentVector& /*fugVec*/)
     {
         if (FluidSystem::isIdealMixture(phaseIdx))
             return;
@@ -85,10 +85,10 @@ public:
      * The phase's fugacities must already be set.
      */
     template <class FluidState>
-    static void solve(FluidState &fluidState,
+    static void solve(FluidState& fluidState,
                       typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                       unsigned phaseIdx,
-                      const ComponentVector &targetFug)
+                      const ComponentVector& targetFug)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -191,10 +191,10 @@ protected:
     // mixture, i.e. the component's fugacity coefficients are
     // independent of the phase's composition.
     template <class FluidState>
-    static void solveIdealMix_(FluidState &fluidState,
+    static void solveIdealMix_(FluidState& fluidState,
                                typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                                unsigned phaseIdx,
-                               const ComponentVector &fugacities)
+                               const ComponentVector& fugacities)
     {
         for (unsigned i = 0; i < numComponents; ++ i) {
             const Evaluation& phi = FluidSystem::fugacityCoefficient(fluidState,
@@ -217,12 +217,12 @@ protected:
     }
 
     template <class FluidState>
-    static Scalar linearize_(Dune::FieldMatrix<Evaluation, numComponents, numComponents> &J,
-                             Dune::FieldVector<Evaluation, numComponents> &defect,
-                             FluidState &fluidState,
+    static Scalar linearize_(Dune::FieldMatrix<Evaluation, numComponents, numComponents>& J,
+                             Dune::FieldVector<Evaluation, numComponents>& defect,
+                             FluidState& fluidState,
                              typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                              unsigned phaseIdx,
-                             const ComponentVector &targetFug)
+                             const ComponentVector& targetFug)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -291,12 +291,12 @@ protected:
     }
 
     template <class FluidState>
-    static Scalar update_(FluidState &fluidState,
+    static Scalar update_(FluidState& fluidState,
                           typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
-                          Dune::FieldVector<Evaluation, numComponents> &x,
-                          Dune::FieldVector<Evaluation, numComponents> &/*b*/,
+                          Dune::FieldVector<Evaluation, numComponents>& x,
+                          Dune::FieldVector<Evaluation, numComponents>& /*b*/,
                           unsigned phaseIdx,
-                          const Dune::FieldVector<Evaluation, numComponents> &targetFug)
+                          const Dune::FieldVector<Evaluation, numComponents>& targetFug)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -340,9 +340,9 @@ protected:
     }
 
     template <class FluidState>
-    static Scalar calculateDefect_(const FluidState &params,
+    static Scalar calculateDefect_(const FluidState& params,
                                    unsigned phaseIdx,
-                                   const ComponentVector &targetFug)
+                                   const ComponentVector& targetFug)
     {
         Scalar result = 0.0;
         for (unsigned i = 0; i < numComponents; ++i) {

--- a/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
+++ b/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
@@ -106,8 +106,8 @@ public:
      *                    should also be set.
      */
     template <class FluidState>
-    static void solve(FluidState &fluidState,
-                      typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache,
+    static void solve(FluidState& fluidState,
+                      typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                       unsigned refPhaseIdx,
                       bool setViscosity,
                       bool setEnthalpy)

--- a/opm/material/constraintsolvers/ImmiscibleFlash.hpp
+++ b/opm/material/constraintsolvers/ImmiscibleFlash.hpp
@@ -91,7 +91,7 @@ public:
      * \brief Guess initial values for all quantities.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static void guessInitial(FluidState &fluidState,
+    static void guessInitial(FluidState& fluidState,
                              const Dune::FieldVector<Evaluation, numComponents>& /*globalMolarities*/)
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
@@ -110,8 +110,8 @@ public:
      * The phase's fugacities must already be set.
      */
     template <class MaterialLaw, class FluidState>
-    static void solve(FluidState &fluidState,
-                      const typename MaterialLaw::Params &matParams,
+    static void solve(FluidState& fluidState,
+                      const typename MaterialLaw::Params& matParams,
                       typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                       const Dune::FieldVector<typename FluidState::Scalar, numComponents>& globalMolarities,
                       Scalar tolerance = -1)
@@ -224,7 +224,7 @@ public:
 
 protected:
     template <class FluidState>
-    static void printFluidState_(const FluidState &fs)
+    static void printFluidState_(const FluidState& fs)
     {
         std::cout << "saturations: ";
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
@@ -321,8 +321,8 @@ protected:
     }
 
     template <class FluidState>
-    static void solveAllIncompressible_(FluidState &fluidState,
-                                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache,
+    static void solveAllIncompressible_(FluidState& fluidState,
+                                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                                         const Dune::FieldVector<typename FluidState::Scalar, numComponents>& globalMolarities)
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
@@ -337,9 +337,9 @@ protected:
     }
 
     template <class FluidState, class FlashDefectVector, class FlashComponentVector>
-    static void evalDefect_(FlashDefectVector &b,
-                            const FluidState &fluidState,
-                            const FlashComponentVector &globalMolarities)
+    static void evalDefect_(FlashDefectVector& b,
+                            const FluidState& fluidState,
+                            const FlashComponentVector& globalMolarities)
     {
         // global molarities are given
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
@@ -401,9 +401,9 @@ protected:
     }
 
     template <class MaterialLaw, class FlashFluidState>
-    static void completeFluidState_(FlashFluidState &flashFluidState,
-                                    typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar> &paramCache,
-                                    const typename MaterialLaw::Params &matParams)
+    static void completeFluidState_(FlashFluidState& flashFluidState,
+                                    typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar>& paramCache,
+                                    const typename MaterialLaw::Params& matParams)
     {
         typedef typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar> ParamCache;
 
@@ -445,7 +445,7 @@ protected:
 
     // retrieves a quantity from the fluid state
     template <class FluidState>
-    static const typename FluidState::Scalar& getQuantity_(const FluidState &fluidState, unsigned pvIdx)
+    static const typename FluidState::Scalar& getQuantity_(const FluidState& fluidState, unsigned pvIdx)
     {
         assert(pvIdx < numEq);
 
@@ -464,7 +464,7 @@ protected:
 
     // set a quantity in the fluid state
     template <class FluidState>
-    static void setQuantity_(FluidState &fluidState,
+    static void setQuantity_(FluidState& fluidState,
                              unsigned pvIdx,
                              const typename FluidState::Scalar& value)
     {
@@ -484,7 +484,7 @@ protected:
     }
 
     template <class FluidState>
-    static Scalar quantityWeight_(const FluidState &/*fluidState*/, unsigned pvIdx)
+    static Scalar quantityWeight_(const FluidState& /*fluidState*/, unsigned pvIdx)
     {
         // first pressure
         if (pvIdx < 1)

--- a/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
+++ b/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
@@ -162,10 +162,10 @@ public:
      * - if the setInternalEnergy parameter is true, also specific enthalpies and internal energies of *all* phases
      */
     template <class FluidState, class ParameterCache>
-    static void solve(FluidState &fluidState,
-                      ParameterCache &paramCache,
+    static void solve(FluidState& fluidState,
+                      ParameterCache& paramCache,
                       int phasePresence,
-                      const MMPCAuxConstraint<Evaluation> *auxConstraints,
+                      const MMPCAuxConstraint<Evaluation>* auxConstraints,
                       unsigned numAuxConstraints,
                       bool setViscosity,
                       bool setInternalEnergy)
@@ -231,7 +231,7 @@ public:
         // phases present.
         unsigned presentPhases = 0;
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            if (!(phasePresence & (1 << phaseIdx)))
+            if (!(phasePresence&  (1 << phaseIdx)))
                 continue;
 
             unsigned rowIdx = numComponents*(numPhases - 1) + presentPhases;
@@ -261,7 +261,7 @@ public:
             Dune::FMatrixPrecision<Scalar>::set_singular_limit(1e-50);
             M.solve(x, b);
         }
-        catch (const Dune::FMatrixError &e) {
+        catch (const Dune::FMatrixError& e) {
             OPM_THROW(NumericalProblem,
                       "Numerical problem in MiscibleMultiPhaseComposition::solve(): " << e.what() << "; M="<<M);
         }
@@ -302,8 +302,8 @@ public:
      * This is a convenience method where no auxiliary constraints are used.
      */
     template <class FluidState, class ParameterCache>
-    static void solve(FluidState &fluidState,
-                      ParameterCache &paramCache,
+    static void solve(FluidState& fluidState,
+                      ParameterCache& paramCache,
                       bool setViscosity,
                       bool setInternalEnergy)
     {

--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -106,7 +106,7 @@ public:
      * \brief Guess initial values for all quantities.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static void guessInitial(FluidState &fluidState,
+    static void guessInitial(FluidState& fluidState,
                              const Dune::FieldVector<Evaluation, numComponents>& globalMolarities)
     {
         // the sum of all molarities
@@ -147,8 +147,8 @@ public:
      * The phase's fugacities must already be set.
      */
     template <class MaterialLaw, class FluidState>
-    static void solve(FluidState &fluidState,
-                      const typename MaterialLaw::Params &matParams,
+    static void solve(FluidState& fluidState,
+                      const typename MaterialLaw::Params& matParams,
                       typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
                       const Dune::FieldVector<typename FluidState::Scalar, numComponents>& globalMolarities,
                       Scalar tolerance = -1.0)
@@ -247,8 +247,8 @@ public:
      * zero...
      */
     template <class FluidState, class ComponentVector>
-    static void solve(FluidState &fluidState,
-                      const ComponentVector &globalMolarities,
+    static void solve(FluidState& fluidState,
+                      const ComponentVector& globalMolarities,
                       Scalar tolerance = 0.0)
     {
         typedef NullMaterialTraits<Scalar, numPhases> MaterialTraits;
@@ -262,7 +262,7 @@ public:
 
 protected:
     template <class FluidState>
-    static void printFluidState_(const FluidState &fluidState)
+    static void printFluidState_(const FluidState& fluidState)
     {
         typedef typename FluidState::Scalar FsScalar;
 
@@ -405,9 +405,9 @@ protected:
     }
 
     template <class FlashFluidState, class FlashDefectVector, class FlashComponentVector>
-    static void evalDefect_(FlashDefectVector &b,
-                            const FlashFluidState &fluidState,
-                            const FlashComponentVector &globalMolarities)
+    static void evalDefect_(FlashDefectVector& b,
+                            const FlashFluidState& fluidState,
+                            const FlashComponentVector& globalMolarities)
     {
         typedef typename FlashFluidState::Scalar FlashEval;
         typedef Opm::MathToolbox<FlashEval> FlashToolbox;
@@ -508,9 +508,9 @@ protected:
     }
 
     template <class MaterialLaw, class FlashFluidState>
-    static void completeFluidState_(FlashFluidState &flashFluidState,
-                                    typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar> &paramCache,
-                                    const typename MaterialLaw::Params &matParams)
+    static void completeFluidState_(FlashFluidState& flashFluidState,
+                                    typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar>& paramCache,
+                                    const typename MaterialLaw::Params& matParams)
     {
         typedef typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar> ParamCache;
 
@@ -560,7 +560,7 @@ protected:
 
     // retrieves a quantity from the fluid state
     template <class FluidState>
-    static const typename FluidState::Scalar& getQuantity_(const FluidState &fluidState, unsigned pvIdx)
+    static const typename FluidState::Scalar& getQuantity_(const FluidState& fluidState, unsigned pvIdx)
     {
         assert(pvIdx < numEq);
 
@@ -585,7 +585,7 @@ protected:
 
     // set a quantity in the fluid state
     template <class FluidState>
-    static void setQuantity_(FluidState &fluidState,
+    static void setQuantity_(FluidState& fluidState,
                              unsigned pvIdx,
                              const typename FluidState::Scalar& value)
     {
@@ -612,7 +612,7 @@ protected:
     }
 
     template <class FluidState>
-    static Scalar quantityWeight_(const FluidState &/*fluidState*/, unsigned pvIdx)
+    static Scalar quantityWeight_(const FluidState& /*fluidState*/, unsigned pvIdx)
     {
         // first pressure
         if (pvIdx < 1)

--- a/opm/material/densead/Evaluation.hpp
+++ b/opm/material/densead/Evaluation.hpp
@@ -407,27 +407,27 @@ protected:
 };
 
 template <class RhsValueType, class ValueType, unsigned numVars>
-bool operator<(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
+bool operator<(const RhsValueType& a, const Evaluation<ValueType, numVars>& b)
 { return b > a; }
 
 template <class RhsValueType, class ValueType, unsigned numVars>
-bool operator>(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
+bool operator>(const RhsValueType& a, const Evaluation<ValueType, numVars>& b)
 { return b < a; }
 
 template <class RhsValueType, class ValueType, unsigned numVars>
-bool operator<=(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
+bool operator<=(const RhsValueType& a, const Evaluation<ValueType, numVars>& b)
 { return b >= a; }
 
 template <class RhsValueType, class ValueType, unsigned numVars>
-bool operator>=(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
+bool operator>=(const RhsValueType& a, const Evaluation<ValueType, numVars>& b)
 { return b <= a; }
 
 template <class RhsValueType, class ValueType, unsigned numVars>
-bool operator!=(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
+bool operator!=(const RhsValueType& a, const Evaluation<ValueType, numVars>& b)
 { return a != b.value(); }
 
 template <class RhsValueType, class ValueType, unsigned numVars>
-Evaluation<ValueType, numVars> operator+(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
+Evaluation<ValueType, numVars> operator+(const RhsValueType& a, const Evaluation<ValueType, numVars>& b)
 {
     Evaluation<ValueType, numVars> result(b);
 
@@ -437,7 +437,7 @@ Evaluation<ValueType, numVars> operator+(const RhsValueType& a, const Evaluation
 }
 
 template <class RhsValueType, class ValueType, unsigned numVars>
-Evaluation<ValueType, numVars> operator-(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
+Evaluation<ValueType, numVars> operator-(const RhsValueType& a, const Evaluation<ValueType, numVars>& b)
 {
     Evaluation<ValueType, numVars> result;
 
@@ -449,7 +449,7 @@ Evaluation<ValueType, numVars> operator-(const RhsValueType& a, const Evaluation
 }
 
 template <class RhsValueType, class ValueType, unsigned numVars>
-Evaluation<ValueType, numVars> operator/(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
+Evaluation<ValueType, numVars> operator/(const RhsValueType& a, const Evaluation<ValueType, numVars>& b)
 {
     Evaluation<ValueType, numVars> result;
 
@@ -464,7 +464,7 @@ Evaluation<ValueType, numVars> operator/(const RhsValueType& a, const Evaluation
 }
 
 template <class RhsValueType, class ValueType, unsigned numVars>
-Evaluation<ValueType, numVars> operator*(const RhsValueType& a, const Evaluation<ValueType, numVars> &b)
+Evaluation<ValueType, numVars> operator*(const RhsValueType& a, const Evaluation<ValueType, numVars>& b)
 {
     Evaluation<ValueType, numVars> result;
 

--- a/opm/material/eos/PengRobinson.hpp
+++ b/opm/material/eos/PengRobinson.hpp
@@ -117,7 +117,7 @@ public:
         // Newton-Raphson method
         for (unsigned i = 0; i < 5; ++i) {
             // calculate the molar densities
-            OPM_OPTIM_UNUSED int numSol = molarVolumes(Vm, params, T, pVap);
+            int numSol OPM_OPTIM_UNUSED = molarVolumes(Vm, params, T, pVap);
             assert(numSol == 3);
 
             const Evaluation& f = fugacityDifference_(params, T, pVap, Vm[0], Vm[2]);
@@ -354,7 +354,7 @@ protected:
             // epsilon was added to the temperature. (this is case
             // rarely happens, though)
             const Scalar eps = - 1e-11;
-            bool OPM_OPTIM_UNUSED hasExtrema = findExtrema_(minVm, maxVm, minP, maxP, a, b, T + eps);
+            bool hasExtrema OPM_OPTIM_UNUSED = findExtrema_(minVm, maxVm, minP, maxP, a, b, T + eps);
             assert(hasExtrema);
             assert(std::isfinite(Toolbox::scalarValue(maxVm)));
             Evaluation fStar = maxVm - minVm;

--- a/opm/material/eos/PengRobinson.hpp
+++ b/opm/material/eos/PengRobinson.hpp
@@ -99,7 +99,7 @@ public:
      * difference between the gas and liquid phase fugacity zero.
      */
     template <class Evaluation, class Params>
-    static Evaluation computeVaporPressure(const Params &params, const Evaluation& T)
+    static Evaluation computeVaporPressure(const Params& params, const Evaluation& T)
     {
         typedef MathToolbox<Evaluation> Toolbox;
         typedef typename Params::Component Component;
@@ -144,8 +144,8 @@ public:
     template <class FluidState, class Params>
     static
     typename FluidState::Scalar
-    computeMolarVolume(const FluidState &fs,
-                       Params &params,
+    computeMolarVolume(const FluidState& fs,
+                       Params& params,
                        unsigned phaseIdx,
                        bool isGasPhase)
     {
@@ -245,7 +245,7 @@ public:
      * \param params Parameters
      */
     template <class Evaluation, class Params>
-    static Evaluation computeFugacityCoeffient(const Params &params)
+    static Evaluation computeFugacityCoeffient(const Params& params)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -279,14 +279,14 @@ public:
      * \param params Parameters
      */
     template <class Evaluation, class Params>
-    static Evaluation computeFugacity(const Params &params)
+    static Evaluation computeFugacity(const Params& params)
     { return params.pressure()*computeFugacityCoeff(params); }
 
 protected:
     template <class FluidState, class Params, class Evaluation = typename FluidState::Scalar>
-    static void handleCriticalFluid_(Evaluation &Vm,
-                                     const FluidState &/*fs*/,
-                                     const Params &params,
+    static void handleCriticalFluid_(Evaluation& Vm,
+                                     const FluidState& /*fs*/,
+                                     const Params& params,
                                      unsigned phaseIdx,
                                      bool isGasPhase)
     {
@@ -308,9 +308,9 @@ protected:
     }
 
     template <class Evaluation>
-    static void findCriticalPoint_(Evaluation &Tcrit,
-                                   Evaluation &pcrit,
-                                   Evaluation &Vcrit,
+    static void findCriticalPoint_(Evaluation& Tcrit,
+                                   Evaluation& pcrit,
+                                   Evaluation& Vcrit,
                                    const Evaluation& a,
                                    const Evaluation& b)
     {
@@ -407,10 +407,10 @@ protected:
     // find the two molar volumes where the EOS exhibits extrema and
     // which are larger than the covolume of the phase
     template <class Evaluation>
-    static bool findExtrema_(Evaluation &Vmin,
-                             Evaluation &Vmax,
-                             Evaluation &/*pMin*/,
-                             Evaluation &/*pMax*/,
+    static bool findExtrema_(Evaluation& Vmin,
+                             Evaluation& Vmax,
+                             Evaluation& /*pMin*/,
+                             Evaluation& /*pMax*/,
                              const Evaluation& a,
                              const Evaluation& b,
                              const Evaluation& T)
@@ -504,7 +504,7 @@ protected:
      * Appl. Chem., 61, 1395-1403, 1989
      */
     template <class Evaluation, class Params>
-    static Evaluation ambroseWalton_(const Params &/*params*/, const Evaluation& T)
+    static Evaluation ambroseWalton_(const Params& /*params*/, const Evaluation& T)
     {
         typedef MathToolbox<Evaluation> Toolbox;
         typedef typename Params::Component Component;
@@ -531,7 +531,7 @@ protected:
      * \param VmGas Molar volume of the gas phase [cm^3/mol]
      */
     template <class Evaluation, class Params>
-    static Evaluation fugacityDifference_(const Params &params,
+    static Evaluation fugacityDifference_(const Params& params,
                                           const Evaluation& T,
                                           const Evaluation& p,
                                           const Evaluation& VmLiquid,

--- a/opm/material/eos/PengRobinsonMixture.hpp
+++ b/opm/material/eos/PengRobinsonMixture.hpp
@@ -62,10 +62,10 @@ public:
      * \return Number of solutions.
      */
     template <class MutableParams, class FluidState>
-    static int computeMolarVolumes(Scalar *Vm,
-                                   const MutableParams &params,
+    static int computeMolarVolumes(Scalar* Vm,
+                                   const MutableParams& params,
                                    unsigned phaseIdx,
-                                   const FluidState &fs)
+                                   const FluidState& fs)
     {
         return PengRobinson::computeMolarVolumes(Vm, params, phaseIdx, fs);
     }
@@ -88,8 +88,8 @@ public:
       * 4th edition, McGraw-Hill, 1987, pp. 42-44, 143-145
       */
     template <class FluidState, class Params, class LhsEval = typename FluidState::Scalar>
-    static LhsEval computeFugacityCoefficient(const FluidState &fs,
-                                              const Params &params,
+    static LhsEval computeFugacityCoefficient(const FluidState& fs,
+                                              const Params& params,
                                               unsigned phaseIdx,
                                               unsigned compIdx)
     {

--- a/opm/material/eos/PengRobinsonParamsMixture.hpp
+++ b/opm/material/eos/PengRobinsonParamsMixture.hpp
@@ -71,7 +71,7 @@ public:
      * \brief Update Peng-Robinson parameters for the pure components.
      */
     template <class FluidState>
-    void updatePure(const FluidState &fluidState)
+    void updatePure(const FluidState& fluidState)
     {
         updatePure(fluidState.temperature(phaseIdx),
                    fluidState.pressure(phaseIdx));
@@ -134,7 +134,7 @@ public:
      * this method!
      */
     template <class FluidState>
-    void updateMix(const FluidState &fs)
+    void updateMix(const FluidState& fs)
     {
         Scalar sumx = 0.0;
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
@@ -186,7 +186,7 @@ public:
      * this method!
      */
     template <class FluidState>
-    void updateSingleMoleFraction(const FluidState &fs,
+    void updateSingleMoleFraction(const FluidState& fs,
                                   unsigned /*compIdx*/)
     {
         updateMix(fs);
@@ -195,13 +195,13 @@ public:
     /*!
      * \brief Return the Peng-Robinson parameters of a pure substance,
      */
-    const PureParams &pureParams(unsigned compIdx) const
+    const PureParams& pureParams(unsigned compIdx) const
     { return pureParams_[compIdx]; }
 
     /*!
      * \brief Returns the Peng-Robinson parameters for a pure component.
      */
-    const PureParams &operator[](unsigned compIdx) const
+    const PureParams& operator[](unsigned compIdx) const
     {
         assert(0 <= compIdx && compIdx < numComponents);
         return pureParams_[compIdx];

--- a/opm/material/fluidmatrixinteractions/BrooksCorey.hpp
+++ b/opm/material/fluidmatrixinteractions/BrooksCorey.hpp
@@ -96,7 +96,7 @@ public:
      * \brief The capillary pressure-saturation curves.
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container &values, const Params &params, const FluidState &fs)
+    static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -109,7 +109,7 @@ public:
      *        their pressure differences.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &values, const Params &params, const FluidState &fs)
+    static void saturations(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -128,7 +128,7 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container &values, const Params &params, const FluidState &fs)
+    static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -150,7 +150,7 @@ public:
      *               (for Brooks-Corey: Entry pressure and shape factor)
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fs)
+    static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -163,7 +163,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -173,7 +173,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnwInv(const Params &params, const Evaluation& pcnw)
+    static Evaluation twoPhaseSatPcnwInv(const Params& params, const Evaluation& pcnw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -195,7 +195,7 @@ public:
      *               (for Brooks-Corey: Entry pressure and shape factor)
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fs)
+    static Evaluation Sw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -206,7 +206,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &params, const Evaluation& pc)
+    static Evaluation twoPhaseSatSw(const Params& params, const Evaluation& pc)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -220,11 +220,11 @@ public:
      *        the phase pressures.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fs)
+    static Evaluation Sn(const Params& params, const FluidState& fs)
     { return 1 - Sw<FluidState, Evaluation>(params, fs); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params &params, const Evaluation& pc)
+    static Evaluation twoPhaseSatSn(const Params& params, const Evaluation& pc)
     { return 1 - twoPhaseSatSw(params, pc); }
     /*!
      * \brief The relative permeability for the wetting phase of
@@ -235,7 +235,7 @@ public:
      *               (for Brooks-Corey: Entry pressure and shape factor)
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fs)
+    static Evaluation krw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -246,7 +246,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -256,7 +256,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrwInv(const Params &params, const Evaluation& krw)
+    static Evaluation twoPhaseSatKrwInv(const Params& params, const Evaluation& krw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -272,7 +272,7 @@ public:
      *               (for Brooks-Corey: Entry pressure and shape factor)
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fs)
+    static Evaluation krn(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -283,7 +283,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -295,7 +295,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrnInv(const Params &params, const Evaluation& krn)
+    static Evaluation twoPhaseSatKrnInv(const Params& params, const Evaluation& krn)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -134,9 +134,9 @@ public:
      * \param state The fluid state
      */
     template <class ContainerT, class FluidState>
-    static void capillaryPressures(ContainerT &values,
-                                   const Params &params,
-                                   const FluidState &state)
+    static void capillaryPressures(ContainerT& values,
+                                   const Params& params,
+                                   const FluidState& state)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         values[gasPhaseIdx] = pcgn<FluidState, Evaluation>(params, state);
@@ -158,8 +158,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcgn(const Params &params,
-                           const FluidState &fs)
+    static Evaluation pcgn(const Params& params,
+                           const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -177,8 +177,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params,
-                           const FluidState &fs)
+    static Evaluation pcnw(const Params& params,
+                           const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -243,9 +243,9 @@ public:
      * technical description.
      */
     template <class ContainerT, class FluidState>
-    static void relativePermeabilities(ContainerT &values,
-                                       const Params &params,
-                                       const FluidState &fluidState)
+    static void relativePermeabilities(ContainerT& values,
+                                       const Params& params,
+                                       const FluidState& fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -258,8 +258,8 @@ public:
      * \brief The relative permeability of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krg(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krg(const Params& params,
+                          const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -271,8 +271,8 @@ public:
      * \brief The relative permeability of the wetting phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krw(const Params& params,
+                          const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -284,8 +284,8 @@ public:
      * \brief The relative permeability of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krn(const Params& params,
+                          const FluidState& fluidState)
     {
         typedef MathToolbox<Evaluation> Toolbox;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -328,7 +328,7 @@ public:
      * error. (But not calling it will still work.)
      */
     template <class FluidState>
-    static void updateHysteresis(Params &params, const FluidState &fluidState)
+    static void updateHysteresis(Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -150,7 +150,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& SwScaled)
+    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& SwScaled)
     {
         const Evaluation& SwUnscaled = scaledToUnscaledSatPc(params, SwScaled);
         const Evaluation& pcUnscaled = EffLaw::twoPhaseSatPcnw(params.effectiveLawParams(), SwUnscaled);
@@ -158,7 +158,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnwInv(const Params &params, const Evaluation& pcnwScaled)
+    static Evaluation twoPhaseSatPcnwInv(const Params& params, const Evaluation& pcnwScaled)
     {
         Evaluation pcnwUnscaled = scaledToUnscaledPcnw_(params, pcnwScaled);
         Evaluation SwUnscaled = EffLaw::twoPhaseSatPcnwInv(params.effectiveLawParams(), pcnwUnscaled);
@@ -228,7 +228,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& SwScaled)
+    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& SwScaled)
     {
         const Evaluation& SwUnscaled = scaledToUnscaledSatKrw(params, SwScaled);
         const Evaluation& krwUnscaled = EffLaw::twoPhaseSatKrw(params.effectiveLawParams(), SwUnscaled);
@@ -236,7 +236,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrwInv(const Params &params, const Evaluation& krwScaled)
+    static Evaluation twoPhaseSatKrwInv(const Params& params, const Evaluation& krwScaled)
     {
         Evaluation krwUnscaled = scaledToUnscaledKrw_(params, krwScaled);
         Evaluation SwUnscaled = EffLaw::twoPhaseSatKrwInv(params.effectiveLawParams(), krwUnscaled);
@@ -254,7 +254,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& SwScaled)
+    static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& SwScaled)
     {
         const Evaluation& SwUnscaled = scaledToUnscaledSatKrn(params, SwScaled);
         const Evaluation& krnUnscaled = EffLaw::twoPhaseSatKrn(params.effectiveLawParams(), SwUnscaled);
@@ -262,7 +262,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrnInv(const Params &params, const Evaluation& krnScaled)
+    static Evaluation twoPhaseSatKrnInv(const Params& params, const Evaluation& krnScaled)
     {
         Evaluation krnUnscaled = scaledToUnscaledKrn_(params, krnScaled);
         Evaluation SwUnscaled = EffLaw::twoPhaseSatKrnInv(params.effectiveLawParams(), krnUnscaled);
@@ -275,7 +275,7 @@ public:
      * The effective saturation is then feed into the "raw" capillary pressure law.
      */
     template <class Evaluation>
-    static Evaluation scaledToUnscaledSatPc(const Params &params, const Evaluation& SwScaled)
+    static Evaluation scaledToUnscaledSatPc(const Params& params, const Evaluation& SwScaled)
     {
         if (!params.config().enableSatScaling())
             return SwScaled;
@@ -288,7 +288,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation unscaledToScaledSatPc(const Params &params, const Evaluation& SwUnscaled)
+    static Evaluation unscaledToScaledSatPc(const Params& params, const Evaluation& SwUnscaled)
     {
         if (!params.config().enableSatScaling())
             return SwUnscaled;
@@ -305,7 +305,7 @@ public:
      *        relperm of the wetting phase.
      */
     template <class Evaluation>
-    static Evaluation scaledToUnscaledSatKrw(const Params &params, const Evaluation& SwScaled)
+    static Evaluation scaledToUnscaledSatKrw(const Params& params, const Evaluation& SwScaled)
     {
         if (!params.config().enableSatScaling())
             return SwScaled;
@@ -323,7 +323,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation unscaledToScaledSatKrw(const Params &params, const Evaluation& SwUnscaled)
+    static Evaluation unscaledToScaledSatKrw(const Params& params, const Evaluation& SwUnscaled)
     {
         if (!params.config().enableSatScaling())
             return SwUnscaled;
@@ -345,7 +345,7 @@ public:
      *        relperm of the non-wetting phase.
      */
     template <class Evaluation>
-    static Evaluation scaledToUnscaledSatKrn(const Params &params, const Evaluation& SwScaled)
+    static Evaluation scaledToUnscaledSatKrn(const Params& params, const Evaluation& SwScaled)
     {
         if (!params.config().enableSatScaling())
             return SwScaled;
@@ -362,7 +362,7 @@ public:
 
 
     template <class Evaluation>
-    static Evaluation unscaledToScaledSatKrn(const Params &params, const Evaluation& SwUnscaled)
+    static Evaluation unscaledToScaledSatKrn(const Params& params, const Evaluation& SwUnscaled)
     {
         if (!params.config().enableSatScaling())
             return SwUnscaled;
@@ -466,7 +466,7 @@ private:
      * \brief Scale the capillary pressure according to the given parameters
      */
     template <class Evaluation>
-    static Evaluation unscaledToScaledPcnw_(const Params &params, const Evaluation& unscaledPcnw)
+    static Evaluation unscaledToScaledPcnw_(const Params& params, const Evaluation& unscaledPcnw)
     {
         if (params.config().enableLeverettScaling()) {
             // HACK: we need to divide the "unscaled capillary pressure" by the
@@ -487,7 +487,7 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation scaledToUnscaledPcnw_(const Params &params, const Evaluation& scaledPcnw)
+    static Evaluation scaledToUnscaledPcnw_(const Params& params, const Evaluation& scaledPcnw)
     {
         if (params.config().enableLeverettScaling()) {
             // HACK: we need to multiply the "scaled capillary pressure" by the conversion
@@ -508,7 +508,7 @@ private:
      * \brief Scale the wetting phase relative permeability of a phase according to the given parameters
      */
     template <class Evaluation>
-    static Evaluation unscaledToScaledKrw_(const Params &params, const Evaluation& unscaledKrw)
+    static Evaluation unscaledToScaledKrw_(const Params& params, const Evaluation& unscaledKrw)
     {
         if (!params.config().enableKrwScaling())
             return unscaledKrw;
@@ -519,7 +519,7 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation scaledToUnscaledKrw_(const Params &params, const Evaluation& scaledKrw)
+    static Evaluation scaledToUnscaledKrw_(const Params& params, const Evaluation& scaledKrw)
     {
         if (!params.config().enableKrwScaling())
             return scaledKrw;
@@ -532,7 +532,7 @@ private:
      * \brief Scale the non-wetting phase relative permeability of a phase according to the given parameters
      */
     template <class Evaluation>
-    static Evaluation unscaledToScaledKrn_(const Params &params, const Evaluation& unscaledKrn)
+    static Evaluation unscaledToScaledKrn_(const Params& params, const Evaluation& unscaledKrn)
     {
         if (!params.config().enableKrnScaling())
             return unscaledKrn;
@@ -543,7 +543,7 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation scaledToUnscaledKrn_(const Params &params, const Evaluation& scaledKrn)
+    static Evaluation scaledToUnscaledKrn_(const Params& params, const Evaluation& scaledKrn)
     {
         if (!params.config().enableKrnScaling())
             return scaledKrn;

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -146,7 +146,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         // TODO: capillary pressure hysteresis
         return EffectiveLaw::twoPhaseSatPcnw(params.drainageParams(), Sw);
@@ -234,7 +234,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
 
         // if no relperm hysteresis is enabled, use the drainage curve
@@ -262,7 +262,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     {
         // if no relperm hysteresis is enabled, use the drainage curve
         if (!params.config().enableHysteresis() || params.config().krHysteresisModel() < 0)

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -743,7 +743,7 @@ private:
 
 
     template <class Container>
-    void readGasOilUnscaledPoints_(Container &dest,
+    void readGasOilUnscaledPoints_(Container& dest,
                                    std::shared_ptr<EclEpsConfig> config,
                                    const Opm::Deck& deck,
                                    const Opm::EclipseState& /* eclState */,
@@ -761,7 +761,7 @@ private:
     }
 
     template <class Container>
-    void readOilWaterUnscaledPoints_(Container &dest,
+    void readOilWaterUnscaledPoints_(Container& dest,
                                      std::shared_ptr<EclEpsConfig> config,
                                      const Opm::Deck& deck,
                                      const Opm::EclipseState& /* eclState */,

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -128,9 +128,9 @@ public:
      * \param state The fluid state
      */
     template <class ContainerT, class FluidState>
-    static void capillaryPressures(ContainerT &values,
-                                   const Params &params,
-                                   const FluidState &fluidState)
+    static void capillaryPressures(ContainerT& values,
+                                   const Params& params,
+                                   const FluidState& fluidState)
     {
         switch (params.approach()) {
         case EclStone1Approach:
@@ -248,9 +248,9 @@ public:
      * technical description.
      */
     template <class ContainerT, class FluidState>
-    static void relativePermeabilities(ContainerT &values,
-                                       const Params &params,
-                                       const FluidState &fluidState)
+    static void relativePermeabilities(ContainerT& values,
+                                       const Params& params,
+                                       const FluidState& fluidState)
     {
         switch (params.approach()) {
         case EclStone1Approach:
@@ -318,7 +318,7 @@ public:
      * error. (But not calling it will still work.)
      */
     template <class FluidState>
-    static void updateHysteresis(Params &params, const FluidState &fluidState)
+    static void updateHysteresis(Params& params, const FluidState& fluidState)
     {
         switch (params.approach()) {
         case EclStone1Approach:

--- a/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
@@ -133,9 +133,9 @@ public:
      * \param state The fluid state
      */
     template <class ContainerT, class FluidState>
-    static void capillaryPressures(ContainerT &values,
-                                   const Params &params,
-                                   const FluidState &state)
+    static void capillaryPressures(ContainerT& values,
+                                   const Params& params,
+                                   const FluidState& state)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         values[gasPhaseIdx] = pcgn<FluidState, Evaluation>(params, state);
@@ -156,8 +156,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcgn(const Params &params,
-                           const FluidState &fs)
+    static Evaluation pcgn(const Params& params,
+                           const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -175,8 +175,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params,
-                           const FluidState &fs)
+    static Evaluation pcnw(const Params& params,
+                           const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -244,9 +244,9 @@ public:
      * technical description.
      */
     template <class ContainerT, class FluidState>
-    static void relativePermeabilities(ContainerT &values,
-                                       const Params &params,
-                                       const FluidState &fluidState)
+    static void relativePermeabilities(ContainerT& values,
+                                       const Params& params,
+                                       const FluidState& fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -259,8 +259,8 @@ public:
      * \brief The relative permeability of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krg(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krg(const Params& params,
+                          const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -272,8 +272,8 @@ public:
      * \brief The relative permeability of the wetting phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krw(const Params& params,
+                          const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -285,8 +285,8 @@ public:
      * \brief The relative permeability of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krn(const Params& params,
+                          const FluidState& fluidState)
     {
         typedef MathToolbox<Evaluation> Toolbox;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -333,7 +333,7 @@ public:
      * error. (But not calling it will still work.)
      */
     template <class FluidState>
-    static void updateHysteresis(Params &params, const FluidState &fluidState)
+    static void updateHysteresis(Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
@@ -134,9 +134,9 @@ public:
      * \param state The fluid state
      */
     template <class ContainerT, class FluidState>
-    static void capillaryPressures(ContainerT &values,
-                                   const Params &params,
-                                   const FluidState &state)
+    static void capillaryPressures(ContainerT& values,
+                                   const Params& params,
+                                   const FluidState& state)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         values[gasPhaseIdx] = pcgn<FluidState, Evaluation>(params, state);
@@ -157,8 +157,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcgn(const Params &params,
-                           const FluidState &fs)
+    static Evaluation pcgn(const Params& params,
+                           const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -176,8 +176,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params,
-                           const FluidState &fs)
+    static Evaluation pcnw(const Params& params,
+                           const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -245,9 +245,9 @@ public:
      * technical description.
      */
     template <class ContainerT, class FluidState>
-    static void relativePermeabilities(ContainerT &values,
-                                       const Params &params,
-                                       const FluidState &fluidState)
+    static void relativePermeabilities(ContainerT& values,
+                                       const Params& params,
+                                       const FluidState& fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -260,8 +260,8 @@ public:
      * \brief The relative permeability of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krg(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krg(const Params& params,
+                          const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -273,8 +273,8 @@ public:
      * \brief The relative permeability of the wetting phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krw(const Params& params,
+                          const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -286,8 +286,8 @@ public:
      * \brief The relative permeability of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params,
-                          const FluidState &fluidState)
+    static Evaluation krn(const Params& params,
+                          const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -312,7 +312,7 @@ public:
      * error. (But not calling it will still work.)
      */
     template <class FluidState>
-    static void updateHysteresis(Params &params, const FluidState &fluidState)
+    static void updateHysteresis(Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -123,9 +123,9 @@ public:
      * \param state The fluid state
      */
     template <class ContainerT, class FluidState>
-    static void capillaryPressures(ContainerT &values,
-                                   const Params &params,
-                                   const FluidState &fluidState)
+    static void capillaryPressures(ContainerT& values,
+                                   const Params& params,
+                                   const FluidState& fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -252,9 +252,9 @@ public:
      * technical description.
      */
     template <class ContainerT, class FluidState>
-    static void relativePermeabilities(ContainerT &values,
-                                       const Params &params,
-                                       const FluidState &fluidState)
+    static void relativePermeabilities(ContainerT& values,
+                                       const Params& params,
+                                       const FluidState& fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -328,7 +328,7 @@ public:
      * error. (But not calling it will still work.)
      */
     template <class FluidState>
-    static void updateHysteresis(Params &params, const FluidState &fluidState)
+    static void updateHysteresis(Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp
@@ -114,7 +114,7 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container &values, const Params &params, const FluidState &fs)
+    static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
     {
         typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
@@ -140,7 +140,7 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container &values, const Params &params, const FluidState &fs)
+    static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
     {
         typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
@@ -167,7 +167,7 @@ public:
      *         Genuchten, linear...)
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fs)
+    static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
@@ -188,7 +188,7 @@ public:
 
     template <class Evaluation>
     static typename std::enable_if<implementsTwoPhaseSatApi, Evaluation>::type
-    twoPhaseSatPcnw(const Params &params, const Evaluation& SwAbs)
+    twoPhaseSatPcnw(const Params& params, const Evaluation& SwAbs)
     {
         const Evaluation& SwEff = effectiveSaturation(params, SwAbs, Traits::wettingPhaseIdx);
 
@@ -199,7 +199,7 @@ public:
      * \brief The saturation-capillary pressure curves.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &values, const Params &params, const FluidState &fs)
+    static void saturations(Container& values, const Params& params, const FluidState& fs)
     {
         EffLaw::template saturations<Container, FluidState>(values, params, fs);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
@@ -212,7 +212,7 @@ public:
      *        the rest of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fs)
+    static Evaluation Sw(const Params& params, const FluidState& fs)
     {
         return absoluteSaturation(params,
                                   EffLaw::template Sw<FluidState, Evaluation>(params, fs),
@@ -221,7 +221,7 @@ public:
 
     template <class Evaluation>
     static typename std::enable_if<implementsTwoPhaseSatApi, Evaluation>::type
-    twoPhaseSatSw(const Params &params, const Evaluation& Sw)
+    twoPhaseSatSw(const Params& params, const Evaluation& Sw)
     { return absoluteSaturation(params,
                                 EffLaw::twoPhaseSatSw(params, Sw),
                                 Traits::wettingPhaseIdx); }
@@ -231,7 +231,7 @@ public:
      *        the rest of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fs)
+    static Evaluation Sn(const Params& params, const FluidState& fs)
     {
         return absoluteSaturation(params,
                                   EffLaw::template Sn<FluidState, Evaluation>(params, fs),
@@ -240,7 +240,7 @@ public:
 
     template <class Evaluation>
     static typename std::enable_if<implementsTwoPhaseSatApi, Evaluation>::type
-    twoPhaseSatSn(const Params &params, const Evaluation& Sw)
+    twoPhaseSatSn(const Params& params, const Evaluation& Sw)
     {
         return absoluteSaturation(params,
                                   EffLaw::twoPhaseSatSn(params, Sw),
@@ -255,7 +255,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if< (Traits::numPhases > 2), Evaluation>::type
-    Sg(const Params &params, const FluidState &fs)
+    Sg(const Params& params, const FluidState& fs)
     {
         return absoluteSaturation(params,
                                   EffLaw::template Sg<FluidState, Evaluation>(params, fs),
@@ -272,7 +272,7 @@ public:
      *
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fs)
+    static Evaluation krw(const Params& params, const FluidState& fs)
     {
         typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
@@ -293,14 +293,14 @@ public:
 
     template <class Evaluation>
     static typename std::enable_if<implementsTwoPhaseSatApi, Evaluation>::type
-    twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     { return EffLaw::twoPhaseSatKrw(params, effectiveSaturation(params, Sw, Traits::nonWettingPhaseIdx)); }
 
     /*!
      * \brief The relative permeability of the non-wetting phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fs)
+    static Evaluation krn(const Params& params, const FluidState& fs)
     {
         typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
@@ -321,7 +321,7 @@ public:
 
     template <class Evaluation>
     static typename std::enable_if<implementsTwoPhaseSatApi, Evaluation>::type
-    twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
+    twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     { return EffLaw::twoPhaseSatKrn(params, effectiveSaturation(params, Sw, Traits::nonWettingPhaseIdx)); }
 
     /*!
@@ -331,7 +331,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if< (Traits::numPhases > 2), Evaluation>::type
-    krg(const Params &params, const FluidState &fs)
+    krg(const Params& params, const FluidState& fs)
     {
         typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
@@ -354,14 +354,14 @@ public:
      * \brief Convert an absolute saturation to an effective one.
      */
     template <class Evaluation>
-    static Evaluation effectiveSaturation(const Params &params, const Evaluation& S, unsigned phaseIdx)
+    static Evaluation effectiveSaturation(const Params& params, const Evaluation& S, unsigned phaseIdx)
     { return (S - params.residualSaturation(phaseIdx))/(1.0 - params.sumResidualSaturations()); }
 
     /*!
      * \brief Convert an effective saturation to an absolute one.
      */
     template <class Evaluation>
-    static Evaluation absoluteSaturation(const Params &params, const Evaluation& S, unsigned phaseIdx)
+    static Evaluation absoluteSaturation(const Params& params, const Evaluation& S, unsigned phaseIdx)
     { return S*(1.0 - params.sumResidualSaturations()) + params.residualSaturation(phaseIdx); }
 
 private:
@@ -373,7 +373,7 @@ private:
      *                  is constructed accordingly. Afterwards the values are set there, too.
      * \return          Derivative of the effective saturation w.r.t. the absolute saturation.
      */
-    static Scalar dSeff_dSabs_(const Params &params, int /*phaseIdx*/)
+    static Scalar dSeff_dSabs_(const Params& params, int /*phaseIdx*/)
     { return 1.0/(1 - params.sumResidualSaturations()); }
 
     /*!
@@ -384,7 +384,7 @@ private:
      *                  is constructed accordingly. Afterwards the values are set there, too.
      * \return          Derivative of the absolute saturation w.r.t. the effective saturation.
      */
-    static Scalar dSabs_dSeff_(const Params &params, int /*phaseIdx*/)
+    static Scalar dSabs_dSeff_(const Params& params, int /*phaseIdx*/)
     { return 1 - params.sumResidualSaturations(); }
 };
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/LinearMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/LinearMaterial.hpp
@@ -97,9 +97,9 @@ public:
      * \param state The fluid state
      */
     template <class ContainerT, class FluidState>
-    static void capillaryPressures(ContainerT &values,
-                                   const Params &params,
-                                   const FluidState &state)
+    static void capillaryPressures(ContainerT& values,
+                                   const Params& params,
+                                   const FluidState& state)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -119,9 +119,9 @@ public:
      * \brief The inverse of the capillary pressure
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &/*values*/,
-                            const Params &/*params*/,
-                            const FluidState &/*state*/)
+    static void saturations(ContainerT& /*values*/,
+                            const Params& /*params*/,
+                            const FluidState& /*state*/)
     {
         OPM_THROW(std::runtime_error, "Not implemented: LinearMaterial::saturations()");
     }
@@ -130,9 +130,9 @@ public:
      * \brief The relative permeability of all phases.
      */
     template <class ContainerT, class FluidState>
-    static void relativePermeabilities(ContainerT &values,
-                                       const Params &/*params*/,
-                                       const FluidState &state)
+    static void relativePermeabilities(ContainerT& values,
+                                       const Params& /*params*/,
+                                       const FluidState& state)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -151,7 +151,7 @@ public:
      * \brief The difference between the pressures of the non-wetting and wetting phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fs)
+    static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         const Evaluation& Sw =
@@ -176,7 +176,7 @@ public:
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
-    twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
+    twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         const Evaluation& wPhasePressure =
             Sw*params.pcMaxSat(Traits::wettingPhaseIdx) +
@@ -194,12 +194,12 @@ public:
      *        of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &/*params*/, const FluidState &/*fs*/)
+    static Evaluation Sw(const Params& /*params*/, const FluidState& /*fs*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Sw()"); }
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
-    twoPhaseSatSw(const Params &/*params*/, const Evaluation& /*Sw*/)
+    twoPhaseSatSw(const Params& /*params*/, const Evaluation& /*Sw*/)
     { OPM_THROW(std::runtime_error, "Not implemented: twoPhaseSatSw()"); }
 
     /*!
@@ -207,12 +207,12 @@ public:
      *        the rest of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &/*params*/, const FluidState &/*fs*/)
+    static Evaluation Sn(const Params& /*params*/, const FluidState& /*fs*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Sn()"); }
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
-    twoPhaseSatSn(const Params &/*params*/, const Evaluation& /*Sw*/)
+    twoPhaseSatSn(const Params& /*params*/, const Evaluation& /*Sw*/)
     { OPM_THROW(std::runtime_error, "Not implemented: twoPhaseSatSn()"); }
 
     /*!
@@ -223,14 +223,14 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if<Traits::numPhases == 3, Evaluation>::type
-    Sg(const Params &/*params*/, const FluidState &/*fs*/)
+    Sg(const Params& /*params*/, const FluidState& /*fs*/)
     { OPM_THROW(std::runtime_error, "Not implemented: Sg()"); }
 
     /*!
      * \brief The relative permability of the wetting phase
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &/*params*/, const FluidState &fs)
+    static Evaluation krw(const Params& /*params*/, const FluidState& fs)
     {
         typedef MathToolbox<Evaluation> Toolbox;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -242,7 +242,7 @@ public:
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
-    twoPhaseSatKrw(const Params &/*params*/, const Evaluation& Sw)
+    twoPhaseSatKrw(const Params& /*params*/, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -253,7 +253,7 @@ public:
      * \brief The relative permability of the liquid non-wetting phase
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &/*params*/, const FluidState &fs)
+    static Evaluation krn(const Params& /*params*/, const FluidState& fs)
     {
         typedef MathToolbox<Evaluation> Toolbox;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -265,7 +265,7 @@ public:
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
-    twoPhaseSatKrn(const Params &/*params*/, const Evaluation& Sw)
+    twoPhaseSatKrn(const Params& /*params*/, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -279,7 +279,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if<Traits::numPhases == 3, Evaluation>::type
-    krg(const Params &/*params*/, const FluidState &fs)
+    krg(const Params& /*params*/, const FluidState& fs)
     {
         typedef MathToolbox<Evaluation> Toolbox;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -296,7 +296,7 @@ public:
      */
     template <class FluidState, class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 3, Evaluation>::type
-    pcgn(const Params &params, const FluidState &fs)
+    pcgn(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 

--- a/opm/material/fluidmatrixinteractions/NullMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/NullMaterial.hpp
@@ -89,9 +89,9 @@ public:
      * \param state The fluid state
      */
     template <class ContainerT, class FluidState>
-    static void capillaryPressures(ContainerT &values,
-                                   const Params &/*params*/,
-                                   const FluidState &/*fluidState*/)
+    static void capillaryPressures(ContainerT& values,
+                                   const Params& /*params*/,
+                                   const FluidState& /*fluidState*/)
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             values[phaseIdx] = 0.0;
@@ -101,18 +101,18 @@ public:
      * \brief The inverse of the capillary pressure
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &/*values*/,
-                            const Params &/*params*/,
-                            const FluidState &/*fluidState*/)
+    static void saturations(ContainerT& /*values*/,
+                            const Params& /*params*/,
+                            const FluidState& /*fluidState*/)
     { OPM_THROW(std::logic_error, "Not defined: NullMaterial::saturations()"); }
 
     /*!
      * \brief The relative permeability of all phases.
      */
     template <class ContainerT, class FluidState>
-    static void relativePermeabilities(ContainerT &values,
-                                       const Params &/*params*/,
-                                       const FluidState &fluidState)
+    static void relativePermeabilities(ContainerT& values,
+                                       const Params& /*params*/,
+                                       const FluidState& fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -130,12 +130,12 @@ public:
      */
     template <class FluidState, class Evaluation  = typename FluidState::Scalar>
     static typename std::enable_if<(numPhases > 1), Evaluation>::type
-    pcnw(const Params &/*params*/, const FluidState &/*fluidState*/)
+    pcnw(const Params& /*params*/, const FluidState& /*fluidState*/)
     { return 0; }
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
-    twoPhaseSatPcnw(const Params &/*params*/, const Evaluation& /*Sw*/)
+    twoPhaseSatPcnw(const Params& /*params*/, const Evaluation& /*Sw*/)
     { return 0; }
 
     /*!
@@ -143,12 +143,12 @@ public:
      *        of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Scalar Sw(const Params &/*params*/, const FluidState &/*fluidState*/)
+    static Scalar Sw(const Params& /*params*/, const FluidState& /*fluidState*/)
     { OPM_THROW(std::logic_error, "Not defined: Sw()"); }
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
-    twoPhaseSatSw(const Params &/*params*/, const Evaluation& /*pcnw*/)
+    twoPhaseSatSw(const Params& /*params*/, const Evaluation& /*pcnw*/)
     { OPM_THROW(std::logic_error, "Not defined: twoPhaseSatSw()"); }
 
     /*!
@@ -156,12 +156,12 @@ public:
      *        rest of the fluid state has been initialized
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Scalar Sn(const Params &/*params*/, const FluidState &/*fluidState*/)
+    static Scalar Sn(const Params& /*params*/, const FluidState& /*fluidState*/)
     { OPM_THROW(std::logic_error, "Not defined: Sn()"); }
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
-    twoPhaseSatSn(const Params &/*params*/, const Evaluation& /*pcnw*/)
+    twoPhaseSatSn(const Params& /*params*/, const Evaluation& /*pcnw*/)
     { OPM_THROW(std::logic_error, "Not defined: twoPhaseSatSn()"); }
 
     /*!
@@ -172,7 +172,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if< (numPhases > 2), Evaluation>::type
-    Sg(const Params &/*params*/, const FluidState &/*fluidState*/)
+    Sg(const Params& /*params*/, const FluidState& /*fluidState*/)
     { OPM_THROW(std::logic_error, "Not defined: Sg()"); }
 
     /*!
@@ -180,7 +180,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if<(numPhases > 1), Evaluation>::type
-    krw(const Params &/*params*/, const FluidState &fluidState)
+    krw(const Params& /*params*/, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -193,7 +193,7 @@ public:
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
-    twoPhaseSatKrw(const Params &/*params*/, const Evaluation& Sw)
+    twoPhaseSatKrw(const Params& /*params*/, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -205,7 +205,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if<(numPhases > 1), Evaluation>::type
-    krn(const Params &/*params*/, const FluidState &fluidState)
+    krn(const Params& /*params*/, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -218,7 +218,7 @@ public:
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
-    twoPhaseSatKrn(const Params &/*params*/, const Evaluation& Sw)
+    twoPhaseSatKrn(const Params& /*params*/, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -232,7 +232,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if< (numPhases > 2), Evaluation>::type
-    krg(const Params &/*params*/, const FluidState &fluidState)
+    krg(const Params& /*params*/, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -250,7 +250,7 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if< (Traits::numPhases > 2), Evaluation>::type
-    pcgn(const Params &/*params*/, const FluidState &/*fluidState*/)
+    pcgn(const Params& /*params*/, const FluidState& /*fluidState*/)
     { return 0; }
 };
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
+++ b/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
@@ -74,8 +74,8 @@ public:
     }
 
 protected:
-    PLScanningCurve(PLScanningCurve *prevSC,
-                    PLScanningCurve *nextSC,
+    PLScanningCurve(PLScanningCurve* prevSC,
+                    PLScanningCurve* nextSC,
                     int loopN,
                     Scalar SwReversal,
                     Scalar pcnwReversal,
@@ -109,14 +109,14 @@ public:
      * \brief Return the previous scanning curve, i.e. the curve
      *        with one less reversal than the current one.
      */
-    PLScanningCurve *prev() const
+    PLScanningCurve* prev() const
     { return prev_; }
 
     /*!
      * \brief Return the next scanning curve, i.e. the curve
      *        with one more reversal than the current one.
      */
-    PLScanningCurve *next() const
+    PLScanningCurve* next() const
     { return next_; }
 
     /*!
@@ -217,8 +217,8 @@ public:
     { return SwMdc_; }
 
 private:
-    PLScanningCurve *prev_;
-    PLScanningCurve *next_;
+    PLScanningCurve* prev_;
+    PLScanningCurve* next_;
 
     int loopNum_;
 
@@ -286,7 +286,7 @@ public:
      * \brief Resets the hysteresis model to the
      *        initial parameters on the main drainage curve
      */
-    static void reset(Params &params)
+    static void reset(Params& params)
     {
         delete params.mdc(); // this will work even if mdc_ == NULL!
         params.setMdc(new ScanningCurve(params.SwrPc()));
@@ -300,7 +300,7 @@ public:
      *        current timestep
      */
     template <class FluidState>
-    static void update(Params &params, const FluidState &fs)
+    static void update(Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -315,7 +315,7 @@ public:
 
         // find the loop number which corrosponds to the
         // given effective saturation
-        ScanningCurve *curve = findScanningCurve_(params, Sw);
+        ScanningCurve* curve = findScanningCurve_(params, Sw);
 
         // calculate the apparent saturation on the MIC and MDC
         // which yield the same capillary pressure as the
@@ -342,7 +342,7 @@ public:
      *        the phase saturations.
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container &values, const Params &params, const FluidState &fs)
+    static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -355,7 +355,7 @@ public:
      *        the phase saturations.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &/*values*/, const Params &/*params*/, const FluidState &/*fs*/)
+    static void saturations(Container& /*values*/, const Params& /*params*/, const FluidState& /*fs*/)
     { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::saturations()"); }
 
     /*!
@@ -363,7 +363,7 @@ public:
      *        dependening on the phase saturations.
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container &values, const Params &params, const FluidState &fs)
+    static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -376,7 +376,7 @@ public:
      *        the phase saturations.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fs)
+    static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -387,12 +387,12 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
         // calculate the current apparent saturation
-        ScanningCurve *sc = findScanningCurve_(params, Toolbox::scalarValue(Sw));
+        ScanningCurve* sc = findScanningCurve_(params, Toolbox::scalarValue(Sw));
 
         // calculate the apparant saturation
         const Evaluation& Sw_app = absoluteToApparentSw_(params, Sw);
@@ -427,11 +427,11 @@ public:
      *        the phase pressures.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &/*params*/, const FluidState &/*fs*/)
+    static Evaluation Sw(const Params& /*params*/, const FluidState& /*fs*/)
     { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::Sw()"); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &/*params*/, const Evaluation& /*pc*/)
+    static Evaluation twoPhaseSatSw(const Params& /*params*/, const Evaluation& /*pc*/)
     { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::twoPhaseSatSw()"); }
 
     /*!
@@ -439,11 +439,11 @@ public:
      *        the phase pressures.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fs)
+    static Evaluation Sn(const Params& params, const FluidState& fs)
     { return 1 - Sw<FluidState, Evaluation>(params, fs); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params &/*params*/, const Evaluation& /*pc*/)
+    static Evaluation twoPhaseSatSn(const Params& /*params*/, const Evaluation& /*pc*/)
     { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::twoPhaseSatSn()"); }
 
     /*!
@@ -451,7 +451,7 @@ public:
      *        the medium.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fs)
+    static Evaluation krw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -462,7 +462,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
         // for the effective permeability we only use Land's law and
         // the relative permeability of the main drainage curve.
@@ -475,7 +475,7 @@ public:
      *        of the params.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fs)
+    static Evaluation krn(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -486,7 +486,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     {
         // for the effective permeability we only use Land's law and
         // the relative permeability of the main drainage curve.
@@ -498,7 +498,7 @@ public:
      * \brief Convert an absolute wetting saturation to an apparent one.
      */
     template <class Evaluation>
-    static Evaluation absoluteToApparentSw_(const Params &params, const Evaluation& Sw)
+    static Evaluation absoluteToApparentSw_(const Params& params, const Evaluation& Sw)
     {
         return effectiveToApparentSw_(params, absoluteToEffectiveSw_(params, Sw));
     }
@@ -514,7 +514,7 @@ private:
      * \return          Effective saturation of the wetting phase.
      */
     template <class Evaluation>
-    static Evaluation absoluteToEffectiveSw_(const Params &params, const Evaluation& Sw)
+    static Evaluation absoluteToEffectiveSw_(const Params& params, const Evaluation& Sw)
     { return (Sw - params.SwrPc())/(1 - params.SwrPc()); }
 
     /*!
@@ -527,13 +527,13 @@ private:
      * \return          Absolute saturation of the non-wetting phase.
      */
     template <class Evaluation>
-    static Evaluation effectiveToAbsoluteSw_(const Params &params, const Evaluation& Swe)
+    static Evaluation effectiveToAbsoluteSw_(const Params& params, const Evaluation& Swe)
     { return Swe*(1 - params.SwrPc()) + params.SwrPc(); }
 
     // return the effctive residual non-wetting saturation, given an
     // effective wetting saturation
     template <class Evaluation>
-    static Evaluation computeCurrentSnr_(const Params &params, const Evaluation& Sw)
+    static Evaluation computeCurrentSnr_(const Params& params, const Evaluation& Sw)
     {
         // regularize
         if (Sw > 1 - params.Snr())
@@ -558,7 +558,7 @@ private:
     // returns the trapped effective non-wetting saturation for a
     // given wetting phase saturation
     template <class Evaluation>
-    static Evaluation trappedEffectiveSn_(const Params &params, const Evaluation& Sw)
+    static Evaluation trappedEffectiveSn_(const Params& params, const Evaluation& Sw)
     {
         const Evaluation& Swe = absoluteToEffectiveSw_(params, Sw);
         Scalar SwePisc = absoluteToEffectiveSw_(params, params.pisc()->Sw());
@@ -570,7 +570,7 @@ private:
     // returns the apparent saturation of the wetting phase depending
     // on the effective saturation
     template <class Evaluation>
-    static Evaluation effectiveToApparentSw_(const Params &params, const Evaluation& Swe)
+    static Evaluation effectiveToApparentSw_(const Params& params, const Evaluation& Swe)
     {
         if (params.pisc() == NULL ||
             Swe <= absoluteToEffectiveSw_(params, params.pisc()->Sw()))
@@ -589,7 +589,7 @@ private:
 
     // Returns the effective saturation to a given apparent one
     template <class Evaluation>
-    static Evaluation apparentToEffectiveSw_(const Params &params, const Evaluation& Swapp)
+    static Evaluation apparentToEffectiveSw_(const Params& params, const Evaluation& Swapp)
     {
         Scalar SwePisc = absoluteToEffectiveSw_(params, params.pisc()->Sw());
         if (params.pisc() == NULL || Swapp <= SwePisc) {
@@ -608,7 +608,7 @@ private:
 
     // find the loop on which the an effective
     // saturation has to be
-    static ScanningCurve *findScanningCurve_(const Params &params, Scalar Sw)
+    static ScanningCurve* findScanningCurve_(const Params& params, Scalar Sw)
     {
         if (params.pisc() == NULL || Sw <= params.pisc()->Sw()) {
             // we don't have a PISC yet, or the effective
@@ -627,7 +627,7 @@ private:
             return params.pisc();
         }
 
-        ScanningCurve *curve = params.csc()->next();
+        ScanningCurve* curve = params.csc()->next();
         while (true) {
             assert(curve != params.mdc()->prev());
             if (curve->isValidAt_Sw(Sw)) {

--- a/opm/material/fluidmatrixinteractions/ParkerLenhardParams.hpp
+++ b/opm/material/fluidmatrixinteractions/ParkerLenhardParams.hpp
@@ -61,7 +61,7 @@ public:
 #endif
     }
 
-    ParkerLenhardParams(const ParkerLenhardParams &p)
+    ParkerLenhardParams(const ParkerLenhardParams& p)
     {
         currentSnr_ = 0;
         SwrPc_ = p.SwrPc_;
@@ -91,28 +91,28 @@ public:
      * \brief Returns the parameters of the main imbibition curve (which uses
      *        the van Genuchten capillary pressure model).
      */
-    const VanGenuchtenParams &micParams() const
+    const VanGenuchtenParams& micParams() const
     { assertFinalized_(); return *micParams_; }
 
     /*!
      * \brief Sets the parameters of the main imbibition curve (which uses
      *        the van Genuchten capillary pressure model).
      */
-    void setMicParams(const VanGenuchtenParams *val)
+    void setMicParams(const VanGenuchtenParams* val)
     { micParams_ = val; }
 
     /*!
      * \brief Returns the parameters of the main drainage curve (which uses
      *        the van Genuchten capillary pressure model).
      */
-    const VanGenuchtenParams &mdcParams() const
+    const VanGenuchtenParams& mdcParams() const
     { assertFinalized_(); return *mdcParams_; }
 
     /*!
      * \brief Sets the parameters of the main drainage curve (which uses
      *        the van Genuchten capillary pressure model).
      */
-    void setMdcParams(const VanGenuchtenParams *val)
+    void setMdcParams(const VanGenuchtenParams* val)
     { mdcParams_ = val; }
 
     /*!
@@ -167,37 +167,37 @@ public:
     /*!
      * \brief Returns the main drainage curve
      */
-    ScanningCurve *mdc() const
+    ScanningCurve* mdc() const
     { assertFinalized_(); return mdc_; }
 
     /*!
      * \brief Set the main drainage curve.
      */
-    void setMdc(ScanningCurve *val)
+    void setMdc(ScanningCurve* val)
     { mdc_ = val; }
 
     /*!
      * \brief Returns the primary imbibition scanning curve
      */
-    ScanningCurve *pisc() const
+    ScanningCurve* pisc() const
     { assertFinalized_(); return pisc_; }
 
     /*!
      * \brief Set the primary imbibition scanning curve.
      */
-    void setPisc(ScanningCurve *val)
+    void setPisc(ScanningCurve* val)
     { pisc_ = val; }
 
     /*!
      * \brief Returns the current scanning curve
      */
-    ScanningCurve *csc() const
+    ScanningCurve* csc() const
     { assertFinalized_(); return csc_; }
 
     /*!
      * \brief Set the current scanning curve.
      */
-    void setCsc(ScanningCurve *val)
+    void setCsc(ScanningCurve* val)
     { csc_ = val; }
 
 private:
@@ -211,15 +211,15 @@ private:
     { }
 #endif
 
-    const VanGenuchtenParams *micParams_;
-    const VanGenuchtenParams *mdcParams_;
+    const VanGenuchtenParams* micParams_;
+    const VanGenuchtenParams* mdcParams_;
     Scalar SwrPc_;
     Scalar SwrKr_;
     Scalar Snr_;
     Scalar currentSnr_;
-    mutable ScanningCurve *mdc_;
-    mutable ScanningCurve *pisc_;
-    mutable ScanningCurve *csc_;
+    mutable ScanningCurve* mdc_;
+    mutable ScanningCurve* pisc_;
+    mutable ScanningCurve* csc_;
 };
 } // namespace Opm
 

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -97,7 +97,7 @@ public:
      * \brief The capillary pressure-saturation curve.
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container &values, const Params &params, const FluidState &fs)
+    static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -117,7 +117,7 @@ public:
      * \brief The relative permeabilities
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container &values, const Params &params, const FluidState &fs)
+    static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -129,7 +129,7 @@ public:
      * \brief The capillary pressure-saturation curve
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fs)
+    static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         const auto& Sw =
@@ -142,11 +142,11 @@ public:
      * \brief The saturation-capillary pressure curve
      */
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     { return eval_(params.SwPcwnSamples(), params.pcnwSamples(), Sw); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnwInv(const Params &params, const Evaluation& pcnw)
+    static Evaluation twoPhaseSatPcnwInv(const Params& params, const Evaluation& pcnw)
     { return eval_(params.pcnwSamples(), params.SwPcwnSamples(), pcnw); }
 
     /*!
@@ -165,11 +165,11 @@ public:
      *        the phase pressures.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fs)
+    static Evaluation Sn(const Params& params, const FluidState& fs)
     { return 1 - Sw<FluidState, Scalar>(params, fs); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params &params, const Evaluation& pC)
+    static Evaluation twoPhaseSatSn(const Params& params, const Evaluation& pC)
     { return 1 - twoPhaseSatSw(params, pC); }
 
     /*!
@@ -177,7 +177,7 @@ public:
      *        porous medium
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fs)
+    static Evaluation krw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         const auto& Sw =
@@ -187,11 +187,11 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     { return eval_(params.SwKrwSamples(), params.krwSamples(), Sw); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrwInv(const Params &params, const Evaluation& krw)
+    static Evaluation twoPhaseSatKrwInv(const Params& params, const Evaluation& krw)
     { return eval_(params.krwSamples(), params.SwKrwSamples(), krw); }
 
     /*!
@@ -199,7 +199,7 @@ public:
      *        of the porous medium
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fs)
+    static Evaluation krn(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         const auto& Sw =
@@ -209,17 +209,17 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     { return eval_(params.SwKrnSamples(), params.krnSamples(), Sw); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrnInv(const Params &params, const Evaluation& krn)
+    static Evaluation twoPhaseSatKrnInv(const Params& params, const Evaluation& krn)
     { return eval_(params.krnSamples(), params.SwKrnSamples(), krn); }
 
 private:
     template <class Evaluation>
-    static Evaluation eval_(const ValueVector &xValues,
-                            const ValueVector &yValues,
+    static Evaluation eval_(const ValueVector& xValues,
+                            const ValueVector& yValues,
                             const Evaluation& x)
     {
         if (xValues.front() < xValues.back())
@@ -228,8 +228,8 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation evalAscending_(const ValueVector &xValues,
-                                     const ValueVector &yValues,
+    static Evaluation evalAscending_(const ValueVector& xValues,
+                                     const ValueVector& yValues,
                                      const Evaluation& x)
     {
         typedef MathToolbox<Evaluation> Toolbox;
@@ -253,8 +253,8 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation evalDescending_(const ValueVector &xValues,
-                                      const ValueVector &yValues,
+    static Evaluation evalDescending_(const ValueVector& xValues,
+                                      const ValueVector& yValues,
                                       const Evaluation& x)
     {
         typedef MathToolbox<Evaluation> Toolbox;
@@ -278,8 +278,8 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation evalDeriv_(const ValueVector &xValues,
-                                 const ValueVector &yValues,
+    static Evaluation evalDeriv_(const ValueVector& xValues,
+                                 const ValueVector& yValues,
                                  const Evaluation& x)
     {
         typedef MathToolbox<Evaluation> Toolbox;
@@ -300,7 +300,7 @@ private:
         return Toolbox::createConstant((y1 - y0)/(x1 - x0));
     }
 
-    static size_t findSegmentIndex_(const ValueVector &xValues, Scalar x)
+    static size_t findSegmentIndex_(const ValueVector& xValues, Scalar x)
     {
         assert(xValues.size() > 1); // we need at least two sampling points!
         size_t n = xValues.size() - 1;
@@ -322,7 +322,7 @@ private:
         return lowIdx;
     }
 
-    static size_t findSegmentIndexDescending_(const ValueVector &xValues, Scalar x)
+    static size_t findSegmentIndexDescending_(const ValueVector& xValues, Scalar x)
     {
         assert(xValues.size() > 1); // we need at least two sampling points!
         size_t n = xValues.size() - 1;

--- a/opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp
@@ -116,7 +116,7 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container &values, const Params &params, const FluidState &fs)
+    static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -129,7 +129,7 @@ public:
      *        their pressure differences.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &values, const Params &params, const FluidState &fs)
+    static void saturations(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -148,7 +148,7 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container &values, const Params &params, const FluidState &fs)
+    static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -171,7 +171,7 @@ public:
      * \sa BrooksCorey::pcnw
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fs)
+    static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -180,7 +180,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         const Scalar Sthres = params.pcnwLowSw();
 
@@ -207,7 +207,7 @@ public:
      * This is the inverse of the pcnw() method.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fs)
+    static Evaluation Sw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -218,7 +218,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &params, const Evaluation& pcnw)
+    static Evaluation twoPhaseSatSw(const Params& params, const Evaluation& pcnw)
     {
         const Scalar Sthres = params.pcnwLowSw();
 
@@ -257,11 +257,11 @@ public:
      *        the phase pressures.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fs)
+    static Evaluation Sn(const Params& params, const FluidState& fs)
     { return 1 - Sw<FluidState, Evaluation>(params, fs); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params &params, const Evaluation& pcnw)
+    static Evaluation twoPhaseSatSn(const Params& params, const Evaluation& pcnw)
     { return 1 - twoPhaseSatSw(params, pcnw); }
 
     /*!
@@ -279,7 +279,7 @@ public:
      * \sa BrooksCorey::krw
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fs)
+    static Evaluation krw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -288,7 +288,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -301,7 +301,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrwInv(const Params &params, const Evaluation& krw)
+    static Evaluation twoPhaseSatKrwInv(const Params& params, const Evaluation& krw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -328,7 +328,7 @@ public:
      * \sa BrooksCorey::krn
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fs)
+    static Evaluation krn(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -338,7 +338,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -351,7 +351,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrnInv(const Params &params, const Evaluation& krn)
+    static Evaluation twoPhaseSatKrnInv(const Params& params, const Evaluation& krn)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 

--- a/opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp
@@ -113,7 +113,7 @@ public:
      *        most generic way.
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container &values, const Params &params, const FluidState &fs)
+    static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -126,7 +126,7 @@ public:
      *        their pressure differences.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &values, const Params &params, const FluidState &fs)
+    static void saturations(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -139,7 +139,7 @@ public:
      *        dependening on the phase saturations.
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container &values, const Params &params, const FluidState &fs)
+    static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -160,7 +160,7 @@ public:
      * \copydetails VanGenuchten::pC()
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fs)
+    static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -169,7 +169,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         // retrieve the low and the high threshold saturations for the
         // unregularized capillary pressure curve from the parameters
@@ -191,7 +191,7 @@ public:
 
             if (Sw < 1.0) {
                 // use spline between threshold Sw and 1.0
-                const Spline<Scalar> &sp = params.pcnwHighSpline();
+                const Spline<Scalar>& sp = params.pcnwHighSpline();
 
                 return sp.eval(Sw);
             }
@@ -221,7 +221,7 @@ public:
      *
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fs)
+    static Evaluation Sw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -232,7 +232,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &params, const Evaluation& pC)
+    static Evaluation twoPhaseSatSw(const Params& params, const Evaluation& pC)
     {
         // retrieve the low and the high threshold saturations for the
         // unregularized capillary pressure curve from the parameters
@@ -273,11 +273,11 @@ public:
      *        the phase pressures.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fs)
+    static Evaluation Sn(const Params& params, const FluidState& fs)
     { return 1 - Sw<FluidState, Evaluation>(params, fs); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params &params, const Evaluation& pc)
+    static Evaluation twoPhaseSatSn(const Params& params, const Evaluation& pc)
     { return 1 - twoPhaseSatSw(params, pc); }
 
     /*!
@@ -295,7 +295,7 @@ public:
         \copydetails VanGenuchten::krw()
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fs)
+    static Evaluation krw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -304,7 +304,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -332,7 +332,7 @@ public:
      *
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fs)
+    static Evaluation krn(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -342,7 +342,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 

--- a/opm/material/fluidmatrixinteractions/RegularizedVanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedVanGenuchtenParams.hpp
@@ -137,7 +137,7 @@ public:
      * \brief Return the spline curve which ought to be used between
      *        the upper threshold saturation and 1.
      */
-    const Spline<Scalar> &pcnwHighSpline() const
+    const Spline<Scalar>& pcnwHighSpline() const
     { assertFinalized_(); return pcnwHighSpline_; }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
@@ -92,7 +92,7 @@ public:
      * \brief The capillary pressure-saturation curve.
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container &values, const Params &params, const FluidState &fluidState)
+    static void capillaryPressures(Container& values, const Params& params, const FluidState& fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -105,14 +105,14 @@ public:
      *        pressure differences.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &/*values*/, const Params &/*params*/, const FluidState &/*fluidState*/)
+    static void saturations(Container& /*values*/, const Params& /*params*/, const FluidState& /*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: saturations()"); }
 
     /*!
      * \brief The relative permeabilities
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container &values, const Params &params, const FluidState &fluidState)
+    static void relativePermeabilities(Container& values, const Params& params, const FluidState& fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -124,7 +124,7 @@ public:
      * \brief The capillary pressure-saturation curve
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fluidState)
+    static Evaluation pcnw(const Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -138,7 +138,7 @@ public:
      * \brief The saturation-capillary pressure curve
      */
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         // this assumes that the capillary pressure is monotonically decreasing
         const auto& pcnwSpline = params.pcnwSpline();
@@ -151,7 +151,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnwInv(const Params &params, const Evaluation& pcnw)
+    static Evaluation twoPhaseSatPcnwInv(const Params& params, const Evaluation& pcnw)
     {
         static const Evaluation nil(0.0);
 
@@ -171,11 +171,11 @@ public:
      * \brief The saturation-capillary pressure curve
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &/*params*/, const FluidState &/*fluidState*/)
+    static Evaluation Sw(const Params& /*params*/, const FluidState& /*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: Sw()"); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &/*params*/, const Evaluation& /*pC*/)
+    static Evaluation twoPhaseSatSw(const Params& /*params*/, const Evaluation& /*pC*/)
     { OPM_THROW(std::logic_error, "Not implemented: twoPhaseSatSw()"); }
 
     /*!
@@ -183,11 +183,11 @@ public:
      *        the phase pressures.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fluidState)
+    static Evaluation Sn(const Params& params, const FluidState& fluidState)
     { return 1 - Sw<FluidState, Evaluation>(params, fluidState); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params &params, const Evaluation& pC)
+    static Evaluation twoPhaseSatSn(const Params& params, const Evaluation& pC)
     { return 1 - twoPhaseSatSw(params, pC); }
 
     /*!
@@ -195,7 +195,7 @@ public:
      *        porous medium
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fluidState)
+    static Evaluation krw(const Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -206,7 +206,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
         const auto& krwSpline = params.krwSpline();
         if (Sw <= krwSpline.xAt(0))
@@ -218,7 +218,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrwInv(const Params &params, const Evaluation& krw)
+    static Evaluation twoPhaseSatKrwInv(const Params& params, const Evaluation& krw)
     {
         static const Evaluation nil(0.0);
 
@@ -236,7 +236,7 @@ public:
      *        of the porous medium
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fluidState)
+    static Evaluation krn(const Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -247,7 +247,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrn(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     {
         const auto& krnSpline = params.krnSpline();
         if (Sw <= krnSpline.xAt(0))
@@ -259,7 +259,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrnInv(const Params &params, const Evaluation& krn)
+    static Evaluation twoPhaseSatKrnInv(const Params& params, const Evaluation& krn)
     {
         static const Evaluation nil(0.0);
 

--- a/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
@@ -99,9 +99,9 @@ public:
      * \param state The fluid state
      */
     template <class ContainerT, class FluidState>
-    static void capillaryPressures(ContainerT &values,
-                                   const Params &params,
-                                   const FluidState &fluidState)
+    static void capillaryPressures(ContainerT& values,
+                                   const Params& params,
+                                   const FluidState& fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -120,7 +120,7 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcgn(const Params &params, const FluidState &fluidState)
+    static Evaluation pcgn(const Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -176,7 +176,7 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fluidState)
+    static Evaluation pcnw(const Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -225,39 +225,39 @@ public:
      *
      */
     template <class ContainerT, class FluidState>
-    static void saturations(ContainerT &/*values*/,
-                            const Params &/*params*/,
-                            const FluidState &/*fluidState*/)
+    static void saturations(ContainerT& /*values*/,
+                            const Params& /*params*/,
+                            const FluidState& /*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: inverse capillary pressures"); }
 
     /*!
      * \brief The saturation of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sg(const Params &/*params*/, const FluidState &/*fluidState*/)
+    static Evaluation Sg(const Params& /*params*/, const FluidState& /*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: Sg()"); }
 
     /*!
      * \brief The saturation of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &/*params*/, const FluidState &/*fluidState*/)
+    static Evaluation Sn(const Params& /*params*/, const FluidState& /*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: Sn()"); }
 
     /*!
      * \brief The saturation of the wetting (i.e., water) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &/*params*/, const FluidState &/*fluidState*/)
+    static Evaluation Sw(const Params& /*params*/, const FluidState& /*fluidState*/)
     { OPM_THROW(std::logic_error, "Not implemented: Sw()"); }
 
     /*!
      * \brief The relative permeability of all phases.
      */
     template <class ContainerT, class FluidState>
-    static void relativePermeabilities(ContainerT &values,
-                                       const Params &params,
-                                       const FluidState &fluidState)
+    static void relativePermeabilities(ContainerT& values,
+                                       const Params& params,
+                                       const FluidState& fluidState)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -275,7 +275,7 @@ public:
      * MOJDEH  DELSHAD and GARY A. POPE, Transport in Porous Media 4 (1989), 59-83.)
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fluidState)
+    static Evaluation krw(const Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -306,7 +306,7 @@ public:
      * 66 (2003), 261-285
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fluidState)
+    static Evaluation krn(const Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;
@@ -354,7 +354,7 @@ public:
      * G. A. Pope, Transport in Porous Media 4 (1989), 59-83.)
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krg(const Params &params, const FluidState &fluidState)
+    static Evaluation krg(const Params& params, const FluidState& fluidState)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef MathToolbox<Evaluation> Toolbox;

--- a/opm/material/fluidmatrixinteractions/VanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/VanGenuchten.hpp
@@ -111,7 +111,7 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container &values, const Params &params, const FluidState &fs)
+    static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -124,7 +124,7 @@ public:
      *        their pressure differences.
      */
     template <class Container, class FluidState>
-    static void saturations(Container &values, const Params &params, const FluidState &fs)
+    static void saturations(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -143,7 +143,7 @@ public:
      *           ought to be calculated
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container &values, const Params &params, const FluidState &fs)
+    static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
     {
         typedef typename std::remove_reference<decltype(values[0])>::type Evaluation;
 
@@ -166,7 +166,7 @@ public:
      *           ought to be calculated
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params &params, const FluidState &fs)
+    static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -193,7 +193,7 @@ public:
      * \param Sw The effective wetting phase saturation
      */
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -213,7 +213,7 @@ public:
      * \param fs The fluid state containing valid phase pressures
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params &params, const FluidState &fs)
+    static Evaluation Sw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -224,7 +224,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params &params, const Evaluation& pC)
+    static Evaluation twoPhaseSatSw(const Params& params, const Evaluation& pC)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -238,11 +238,11 @@ public:
      *        the phase pressures.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params &params, const FluidState &fs)
+    static Evaluation Sn(const Params& params, const FluidState& fs)
     { return 1 - Sw<FluidState, Evaluation>(params, fs); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params &params, const Evaluation& pC)
+    static Evaluation twoPhaseSatSn(const Params& params, const Evaluation& pC)
     { return 1 - twoPhaseSatSw(params, pC); }
 
     /*!
@@ -256,7 +256,7 @@ public:
      *           ought to be calculated
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params &params, const FluidState &fs)
+    static Evaluation krw(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -267,7 +267,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrw(const Params &params, const Evaluation& Sw)
+    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
@@ -287,7 +287,7 @@ public:
      *           ought to be calculated
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params &params, const FluidState &fs)
+    static Evaluation krn(const Params& params, const FluidState& fs)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -298,7 +298,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrn(const Params &params, Evaluation Sw)
+    static Evaluation twoPhaseSatKrn(const Params& params, Evaluation Sw)
     {
         typedef MathToolbox<Evaluation> Toolbox;
 

--- a/opm/material/fluidstates/FluidStateCompositionModules.hpp
+++ b/opm/material/fluidstates/FluidStateCompositionModules.hpp
@@ -164,7 +164,7 @@ public:
     }
 
 protected:
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
     Scalar moleFraction_[numPhases][numComponents];
@@ -246,7 +246,7 @@ public:
     { }
 
 protected:
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 };
 

--- a/opm/material/fluidstates/FluidStateDensityModules.hpp
+++ b/opm/material/fluidstates/FluidStateDensityModules.hpp
@@ -103,7 +103,7 @@ public:
     }
 
 protected:
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
     Scalar density_[numPhases];

--- a/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
+++ b/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
@@ -96,7 +96,7 @@ public:
     }
 
 protected:
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
     Scalar enthalpy_[numPhases];

--- a/opm/material/fluidstates/FluidStateFugacityModules.hpp
+++ b/opm/material/fluidstates/FluidStateFugacityModules.hpp
@@ -100,7 +100,7 @@ public:
     }
 
 protected:
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
     Scalar fugacityCoefficient_[numPhases][numComponents];
@@ -167,7 +167,7 @@ public:
     }
 
 protected:
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
     Scalar fugacityCoefficient_[numPhases];

--- a/opm/material/fluidstates/PressureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/PressureOverlayFluidState.hpp
@@ -55,7 +55,7 @@ public:
      * so it initially behaves exactly like the underlying fluid
      * state.
      */
-    PressureOverlayFluidState(const FluidState &fs)
+    PressureOverlayFluidState(const FluidState& fs)
         : fs_(&fs)
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
@@ -63,14 +63,14 @@ public:
     }
 
     // copy constructor
-    PressureOverlayFluidState(const PressureOverlayFluidState &fs)
+    PressureOverlayFluidState(const PressureOverlayFluidState& fs)
         : fs_(fs.fs_)
         , pressure_(fs.pressure_)
     {
     }
 
     // assignment operator
-    PressureOverlayFluidState &operator=(const PressureOverlayFluidState &fs)
+    PressureOverlayFluidState& operator=(const PressureOverlayFluidState& fs)
     {
         fs_ = fs.fs_;
         pressure_ = fs.pressure_;
@@ -229,7 +229,7 @@ public:
     }
 
 protected:
-    const FluidState *fs_;
+    const FluidState* fs_;
     std::array<Scalar, numPhases> pressure_;
 };
 

--- a/opm/material/fluidstates/SaturationOverlayFluidState.hpp
+++ b/opm/material/fluidstates/SaturationOverlayFluidState.hpp
@@ -55,7 +55,7 @@ public:
      * argument, so it initially behaves exactly like the underlying
      * fluid state.
      */
-    SaturationOverlayFluidState(const FluidState &fs)
+    SaturationOverlayFluidState(const FluidState& fs)
         : fs_(&fs)
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
@@ -63,13 +63,13 @@ public:
     }
 
     // copy constructor
-    SaturationOverlayFluidState(const SaturationOverlayFluidState &fs)
+    SaturationOverlayFluidState(const SaturationOverlayFluidState& fs)
         : fs_(fs.fs_)
         , saturation_(fs.saturation_)
     {}
 
     // assignment operator
-    SaturationOverlayFluidState &operator=(const SaturationOverlayFluidState &fs)
+    SaturationOverlayFluidState& operator=(const SaturationOverlayFluidState& fs)
     {
         fs_ = fs.fs_;
         saturation_ = fs.saturation_;
@@ -228,7 +228,7 @@ public:
     }
 
 protected:
-    const FluidState *fs_;
+    const FluidState* fs_;
     std::array<Scalar, numPhases> saturation_;
 };
 

--- a/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
@@ -55,24 +55,24 @@ public:
      * like the underlying fluid state, provided that the underlying
      * fluid state is in thermal equilibrium.
      */
-    TemperatureOverlayFluidState(const FluidState &fs)
+    TemperatureOverlayFluidState(const FluidState& fs)
         : fs_(&fs)
     {
         temperature_ = fs.temperature(/*phaseIdx=*/0);
     }
 
-    TemperatureOverlayFluidState(Scalar T, const FluidState &fs)
+    TemperatureOverlayFluidState(Scalar T, const FluidState& fs)
         : temperature_(T), fs_(&fs)
     { }
 
     // copy constructor
-    TemperatureOverlayFluidState(const TemperatureOverlayFluidState &fs)
+    TemperatureOverlayFluidState(const TemperatureOverlayFluidState& fs)
         : fs_(fs.fs_)
         , temperature_(fs.temperature_)
     {}
 
     // assignment operator
-    TemperatureOverlayFluidState &operator=(const TemperatureOverlayFluidState &fs)
+    TemperatureOverlayFluidState& operator=(const TemperatureOverlayFluidState& fs)
     {
         fs_ = fs.fs_;
         temperature_ = fs.temperature_;
@@ -230,7 +230,7 @@ public:
     }
 
 protected:
-    const FluidState *fs_;
+    const FluidState* fs_;
     Scalar temperature_;
 };
 

--- a/opm/material/fluidsystems/BaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/BaseFluidSystem.hpp
@@ -71,7 +71,7 @@ public:
      *
      * \copydoc Doxygen::phaseIdxParam
      */
-    static char *phaseName(unsigned /*phaseIdx*/)
+    static char* phaseName(unsigned /*phaseIdx*/)
     {
         OPM_THROW(std::runtime_error,
                   "Not implemented: The fluid system '" << Dune::className<Implementation>() << "' does not provide a phaseName() method!");
@@ -140,7 +140,7 @@ public:
      *
      * \copydoc Doxygen::compIdxParam
      */
-    static const char *componentName(unsigned /*compIdx*/)
+    static const char* componentName(unsigned /*compIdx*/)
     {
         OPM_THROW(std::runtime_error,
                   "Not implemented: The fluid system '" << Dune::className<Implementation>() << "' does not provide a componentName() method!");

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -363,9 +363,9 @@ public:
     static const Scalar surfaceTemperature;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(unsigned phaseIdx)
+    static const char* phaseName(unsigned phaseIdx)
     {
-        static const char *name[] = { "water", "oil", "gas" };
+        static const char* name[] = { "water", "oil", "gas" };
 
         assert(0 <= phaseIdx && phaseIdx < numPhases + 1);
         return name[phaseIdx];
@@ -420,9 +420,9 @@ public:
     { return static_cast<unsigned>(phaseToSoluteCompIdx_[phaseIdx]); }
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(unsigned compIdx)
+    static const char* componentName(unsigned compIdx)
     {
-        static const char *name[] = { "Oil", "Water", "Gas" };
+        static const char* name[] = { "Oil", "Water", "Gas" };
 
         assert(0 <= compIdx && compIdx < numComponents);
         return name[compIdx];
@@ -491,15 +491,15 @@ public:
      ****************************************/
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache<ParamCacheEval> &paramCache,
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& paramCache,
                            unsigned phaseIdx)
     { return density<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &paramCache,
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& paramCache,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
@@ -511,8 +511,8 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache<ParamCacheEval> &paramCache,
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& paramCache,
                              unsigned phaseIdx)
     { return viscosity<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
 
@@ -523,7 +523,7 @@ public:
      ****************************************/
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    static LhsEval density(const FluidState &fluidState,
+    static LhsEval density(const FluidState& fluidState,
                            unsigned phaseIdx,
                            unsigned regionIdx)
     {
@@ -580,7 +580,7 @@ public:
      * maximum. For the water phase, there's no difference to the density() method.
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    static LhsEval saturatedDensity(const FluidState &fluidState,
+    static LhsEval saturatedDensity(const FluidState& fluidState,
                                     unsigned phaseIdx,
                                     unsigned regionIdx)
     {
@@ -735,7 +735,7 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
                                        unsigned phaseIdx,
                                        unsigned compIdx,
                                        unsigned regionIdx)
@@ -863,7 +863,7 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    static LhsEval viscosity(const FluidState &fluidState,
+    static LhsEval viscosity(const FluidState& fluidState,
                              unsigned phaseIdx,
                              unsigned regionIdx)
     {

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -63,7 +63,7 @@ LhsEval getRs_(typename std::enable_if<!HasMember_Rs<FluidState>::value, const F
 
 template <class FluidSystem, class LhsEval, class FluidState>
 auto getRs_(typename std::enable_if<HasMember_Rs<FluidState>::value, const FluidState&>::type fluidState,
-            OPM_UNUSED unsigned regionIdx)
+            unsigned regionIdx OPM_UNUSED)
     -> decltype(Opm::MathToolbox<typename FluidState::Scalar>
                 ::template decay<LhsEval>(fluidState.Rs()))
 {
@@ -85,7 +85,7 @@ LhsEval getRv_(typename std::enable_if<!HasMember_Rv<FluidState>::value, const F
 
 template <class FluidSystem, class LhsEval, class FluidState>
 auto getRv_(typename std::enable_if<HasMember_Rv<FluidState>::value, const FluidState&>::type fluidState,
-            OPM_UNUSED unsigned regionIdx)
+            unsigned regionIdx OPM_UNUSED)
     -> decltype(Opm::MathToolbox<typename FluidState::Scalar>
                 ::template decay<LhsEval>(fluidState.Rv()))
 {

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -127,7 +127,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::isIdealMixture
      */
-    static bool isIdealMixture(OPM_OPTIM_UNUSED unsigned phaseIdx)
+    static bool isIdealMixture(unsigned phaseIdx OPM_OPTIM_UNUSED)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -137,7 +137,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::isCompressible
      */
-    static bool isCompressible(OPM_OPTIM_UNUSED unsigned phaseIdx)
+    static bool isCompressible(unsigned phaseIdx OPM_OPTIM_UNUSED)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -91,9 +91,9 @@ public:
     /*!
      * \copydoc BaseFluidSystem::phaseName
      */
-    static const char *phaseName(unsigned phaseIdx)
+    static const char* phaseName(unsigned phaseIdx)
     {
-        static const char *name[] = {
+        static const char* name[] = {
             "liquid",
             "gas"
         };
@@ -163,9 +163,9 @@ public:
     /*!
      * \copydoc BaseFluidSystem::componentName
      */
-    static const char *componentName(unsigned compIdx)
+    static const char* componentName(unsigned compIdx)
     {
-        static const char *name[] = {
+        static const char* name[] = {
             Brine::name(),
             CO2::name(),
         };
@@ -230,8 +230,8 @@ public:
      * \copydoc BaseFluidSystem::density
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& /*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -284,8 +284,8 @@ public:
      * \copydoc BaseFluidSystem::viscosity
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -313,8 +313,8 @@ public:
      * \copydoc BaseFluidSystem::fugacityCoefficient
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
@@ -370,8 +370,8 @@ public:
      * \copydoc BaseFluidSystem::diffusionCoefficient
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval diffusionCoefficient(const FluidState& fluidState,
+                                        const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                         unsigned phaseIdx,
                                         unsigned /*compIdx*/)
     {
@@ -390,8 +390,8 @@ public:
      * \copydoc BaseFluidSystem::enthalpy
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval enthalpy(const FluidState& fluidState,
+                            const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -427,8 +427,8 @@ public:
      * \copydoc BaseFluidSystem::thermalConductivity
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval thermalConductivity(const FluidState &/*fluidState*/,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval thermalConductivity(const FluidState& /*fluidState*/,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx)
     {
         typedef MathToolbox<LhsEval> LhsToolbox;
@@ -454,8 +454,8 @@ public:
      * \tparam FluidState the fluid state class
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval heatCapacity(const FluidState& fluidState,
+                                const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                 unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/GasPhase.hpp
+++ b/opm/material/fluidsystems/GasPhase.hpp
@@ -45,7 +45,7 @@ public:
     /*!
      * \brief A human readable name for the component.
      */
-    static const char *name()
+    static const char* name()
     { return Component::name(); }
 
     /*!

--- a/opm/material/fluidsystems/H2OAirFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirFluidSystem.hpp
@@ -85,7 +85,7 @@ public:
     static const int gasPhaseIdx = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(unsigned phaseIdx)
+    static const char* phaseName(unsigned phaseIdx)
     {
         switch (phaseIdx) {
         case liquidPhaseIdx: return "liquid";
@@ -145,7 +145,7 @@ public:
     static const int AirIdx = 1;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(unsigned compIdx)
+    static const char* componentName(unsigned compIdx)
     {
         switch (compIdx)
         {
@@ -255,14 +255,14 @@ public:
 
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& /*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
         typedef Opm::MathToolbox<LhsEval> LhsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         const auto& T = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         LhsEval p;
@@ -321,14 +321,14 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<LhsEval> LhsToolbox;
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         const auto& T = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const auto& p = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));
@@ -390,15 +390,15 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
-        assert(0 <= compIdx  && compIdx < numComponents);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
+        assert(0 <= compIdx && compIdx < numComponents);
 
         const auto& T = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const auto& p = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));
@@ -416,8 +416,8 @@ public:
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval binaryDiffusionCoefficient(const FluidState &fluidState,
-                                              const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval binaryDiffusionCoefficient(const FluidState& fluidState,
+                                              const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                               unsigned phaseIdx,
                                               unsigned /*compIdx*/)
     {
@@ -435,8 +435,8 @@ public:
 
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval enthalpy(const FluidState& fluidState,
+                            const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -469,13 +469,13 @@ public:
 
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval thermalConductivity(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         const LhsEval& temperature =
             FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));

--- a/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
@@ -162,7 +162,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(unsigned phaseIdx)
+    static const char* phaseName(unsigned phaseIdx)
     {
         switch (phaseIdx) {
         case waterPhaseIdx: return "water";
@@ -173,7 +173,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(unsigned compIdx)
+    static const char* componentName(unsigned compIdx)
     {
         switch (compIdx) {
         case H2OIdx: return H2O::name();
@@ -199,8 +199,8 @@ public:
 
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& /*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -246,8 +246,8 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -310,8 +310,8 @@ public:
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval diffusionCoefficient(const FluidState &/*fluidState*/,
-                                        const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval diffusionCoefficient(const FluidState& /*fluidState*/,
+                                        const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                         unsigned /*phaseIdx*/,
                                         unsigned /*compIdx*/)
     {
@@ -371,15 +371,15 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
-        assert(0 <= compIdx  && compIdx < numComponents);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
+        assert(0 <= compIdx && compIdx < numComponents);
 
         const LhsEval& T = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const LhsEval& p = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));
@@ -420,8 +420,8 @@ public:
 
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval enthalpy(const FluidState& fluidState,
+                            const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -449,13 +449,13 @@ public:
 
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval thermalConductivity(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         if (phaseIdx == waterPhaseIdx){ // water phase
             const LhsEval& T = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));

--- a/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
@@ -127,7 +127,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(unsigned phaseIdx)
+    static const char* phaseName(unsigned phaseIdx)
     {
         switch (phaseIdx) {
         case waterPhaseIdx: return "water";
@@ -138,7 +138,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(unsigned compIdx)
+    static const char* componentName(unsigned compIdx)
     {
         switch (compIdx) {
         case H2OIdx: return H2O::name();
@@ -166,8 +166,8 @@ public:
 
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& /*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -209,8 +209,8 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -273,8 +273,8 @@ public:
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval diffusionCoefficient(const FluidState& fluidState,
+                                        const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                         unsigned phaseIdx,
                                         unsigned compIdx)
     {
@@ -327,15 +327,15 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
-        assert(0 <= compIdx  && compIdx < numComponents);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
+        assert(0 <= compIdx && compIdx < numComponents);
 
         const auto& T = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const auto& p = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));
@@ -372,8 +372,8 @@ public:
 
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval enthalpy(const FluidState& fluidState,
+                            const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/H2ON2FluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2FluidSystem.hpp
@@ -83,9 +83,9 @@ public:
     static const int gasPhaseIdx = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(unsigned phaseIdx)
+    static const char* phaseName(unsigned phaseIdx)
     {
-        static const char *name[] = {
+        static const char* name[] = {
             "liquid",
             "gas"
         };
@@ -154,9 +154,9 @@ public:
     typedef SimpleN2 N2;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(unsigned compIdx)
+    static const char* componentName(unsigned compIdx)
     {
-        static const char *name[] = {
+        static const char* name[] = {
             H2O::name(),
             N2::name()
         };
@@ -266,11 +266,11 @@ public:
      * University of Stuttgart, 2008
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& /*paramCache*/,
                            unsigned phaseIdx)
     {
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         typedef Opm::MathToolbox<LhsEval> LhsToolbox;
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -323,11 +323,11 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         typedef Opm::MathToolbox<LhsEval> LhsToolbox;
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -384,13 +384,13 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
-        assert(0 <= compIdx  && compIdx < numComponents);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
+        assert(0 <= compIdx && compIdx < numComponents);
 
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -413,8 +413,8 @@ public:
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval diffusionCoefficient(const FluidState& fluidState,
+                                        const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                         unsigned phaseIdx,
                                         unsigned /*compIdx*/)
 
@@ -435,8 +435,8 @@ public:
 
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval enthalpy(const FluidState& fluidState,
+                            const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -469,11 +469,11 @@ public:
 
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval thermalConductivity(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx)
     {
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -504,8 +504,8 @@ public:
 
     //! \copydoc BaseFluidSystem::heatCapacity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval heatCapacity(const FluidState& fluidState,
+                                const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                 unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -142,9 +142,9 @@ public:
     typedef SimpleN2 N2;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(unsigned compIdx)
+    static const char* componentName(unsigned compIdx)
     {
-        static const char *name[] = {
+        static const char* name[] = {
             H2O::name(),
             N2::name()
         };
@@ -251,13 +251,13 @@ public:
 
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& /*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         const auto& T = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const auto& p = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));
@@ -288,8 +288,8 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -305,15 +305,15 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
         assert(phaseIdx == liquidPhaseIdx);
-        assert(0 <= compIdx  && compIdx < numComponents);
+        assert(0 <= compIdx && compIdx < numComponents);
 
         const auto& T = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const auto& p = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));
@@ -325,8 +325,8 @@ public:
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval diffusionCoefficient(const FluidState &fluidState,
-                                        const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval diffusionCoefficient(const FluidState& fluidState,
+                                        const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                         unsigned phaseIdx,
                                         unsigned /*compIdx*/)
 
@@ -343,8 +343,8 @@ public:
 
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval enthalpy(const FluidState& fluidState,
+                            const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -362,8 +362,8 @@ public:
 
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval thermalConductivity(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        const unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -381,8 +381,8 @@ public:
 
     //! \copydoc BaseFluidSystem::heatCapacity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval heatCapacity(const FluidState& fluidState,
+                                const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                 unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -82,7 +82,7 @@ public:
     static const int liquidPhaseIdx = 0;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(OPM_OPTIM_UNUSED unsigned phaseIdx)
+    static const char* phaseName(unsigned phaseIdx OPM_OPTIM_UNUSED)
     {
         assert(phaseIdx == liquidPhaseIdx);
 

--- a/opm/material/fluidsystems/LiquidPhase.hpp
+++ b/opm/material/fluidsystems/LiquidPhase.hpp
@@ -41,7 +41,7 @@ public:
     typedef ComponentT Component;
 
     //! \copydoc GasPhase::name
-    static const char *name()
+    static const char* name()
     { return Component::name(); }
 
     //! \copydoc GasPhase::isLiquid

--- a/opm/material/fluidsystems/ParameterCacheBase.hpp
+++ b/opm/material/fluidsystems/ParameterCacheBase.hpp
@@ -72,7 +72,7 @@ public:
      * \param exceptQuantities The quantities of the fluid state that have not changed since the last update.
      */
     template <class FluidState>
-    void updateAll(const FluidState &fluidState, int /*exceptQuantities*/ = None)
+    void updateAll(const FluidState& fluidState, int /*exceptQuantities*/ = None)
     {
         for (unsigned phaseIdx = 0; phaseIdx < FluidState::numPhases; ++phaseIdx)
             asImp_().updatePhase(fluidState, phaseIdx);
@@ -88,7 +88,7 @@ public:
      * \param fluidState The representation of the thermodynamic system of interest.
      */
     template <class FluidState>
-    void updateAllPressures(const FluidState &fluidState)
+    void updateAllPressures(const FluidState& fluidState)
     { asImp_().updateAll(fluidState, Temperature | Composition); }
 
     /*!
@@ -101,7 +101,7 @@ public:
      * \param fluidState The representation of the thermodynamic system of interest.
      */
     template <class FluidState>
-    void updateAllTemperatures(const FluidState &fluidState)
+    void updateAllTemperatures(const FluidState& fluidState)
     {
         for (unsigned phaseIdx = 0; phaseIdx < FluidState::numPhases; ++phaseIdx)
             asImp_().updatePhase(fluidState, phaseIdx);
@@ -131,7 +131,7 @@ public:
      * \param phaseIdx The index of the fluid phase of interest.
      */
     template <class FluidState>
-    void updateTemperature(const FluidState &fluidState, unsigned phaseIdx)
+    void updateTemperature(const FluidState& fluidState, unsigned phaseIdx)
     {
         asImp_().updatePhase(fluidState, phaseIdx);
     }
@@ -148,7 +148,7 @@ public:
      * \param phaseIdx The index of the fluid phase of interest.
      */
     template <class FluidState>
-    void updatePressure(const FluidState &fluidState, unsigned phaseIdx)
+    void updatePressure(const FluidState& fluidState, unsigned phaseIdx)
     {
         asImp_().updatePhase(fluidState, phaseIdx);
     }
@@ -165,7 +165,7 @@ public:
      * \param phaseIdx The index of the fluid phase of interest.
      */
     template <class FluidState>
-    void updateComposition(const FluidState &fluidState, unsigned phaseIdx)
+    void updateComposition(const FluidState& fluidState, unsigned phaseIdx)
     {
         asImp_().updatePhase(fluidState, phaseIdx, /*except=*/Temperature | Pressure);
     }
@@ -184,7 +184,7 @@ public:
      * \param compIdx The component index of the component for which the mole fraction was modified in the fluid phase of interest.
      */
     template <class FluidState>
-    void updateSingleMoleFraction(const FluidState &fluidState,
+    void updateSingleMoleFraction(const FluidState& fluidState,
                                   unsigned phaseIdx,
                                   unsigned /*compIdx*/)
     {
@@ -192,7 +192,7 @@ public:
     }
 
 private:
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
 };
 

--- a/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
@@ -75,7 +75,7 @@ public:
     static const int numPhases = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(OPM_OPTIM_UNUSED unsigned phaseIdx)
+    static const char* phaseName(unsigned phaseIdx OPM_OPTIM_UNUSED)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -125,7 +125,7 @@ public:
     static const int numComponents = 1;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(OPM_OPTIM_UNUSED unsigned compIdx)
+    static const char* componentName(unsigned compIdx OPM_OPTIM_UNUSED)
     {
         assert(0 <= compIdx && compIdx < numComponents);
 

--- a/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
@@ -186,8 +186,8 @@ public:
 
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& /*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -201,8 +201,8 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -216,13 +216,13 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval fugacityCoefficient(const FluidState &/*fluidState*/,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval fugacityCoefficient(const FluidState& /*fluidState*/,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
-        assert(0 <= compIdx  && compIdx < numComponents);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
+        assert(0 <= compIdx && compIdx < numComponents);
 
         if (phaseIdx == compIdx)
             // TODO (?): calculate the real fugacity coefficient of
@@ -235,8 +235,8 @@ public:
 
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval enthalpy(const FluidState& fluidState,
+                            const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -250,8 +250,8 @@ public:
 
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval thermalConductivity(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
@@ -265,8 +265,8 @@ public:
 
     //! \copydoc BaseFluidSystem::heatCapacity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval heatCapacity(const FluidState& fluidState,
+                                const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                 unsigned phaseIdx)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;

--- a/opm/material/fluidsystems/Spe5FluidSystem.hpp
+++ b/opm/material/fluidsystems/Spe5FluidSystem.hpp
@@ -86,9 +86,9 @@ public:
     typedef Opm::H2O<Scalar> H2O;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(unsigned phaseIdx)
+    static const char* phaseName(unsigned phaseIdx)
     {
-        static const char *name[] = {
+        static const char* name[] = {
             "gas",
             "water",
             "oil",
@@ -148,9 +148,9 @@ public:
     static const int C20Idx = 6; //!< Index of the C20 component
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(unsigned compIdx)
+    static const char* componentName(unsigned compIdx)
     {
-        static const char *name[] = {
+        static const char* name[] = {
             H2O::name(),
             "C1",
             "C3",
@@ -359,22 +359,22 @@ public:
 
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache<ParamCacheEval> &paramCache,
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& paramCache,
                            unsigned phaseIdx)
     {
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         return fluidState.averageMolarMass(phaseIdx)/paramCache.molarVolume(phaseIdx);
     }
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval viscosity(const FluidState &/*fluidState*/,
-                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval viscosity(const FluidState& /*fluidState*/,
+                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
-        assert(0 <= phaseIdx  && phaseIdx <= numPhases);
+        assert(0 <= phaseIdx && phaseIdx <= numPhases);
 
         if (phaseIdx == gasPhaseIdx) {
             // given by SPE-5 in table on page 64. we use a constant
@@ -394,13 +394,13 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval fugacityCoefficient(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &paramCache,
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& paramCache,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
-        assert(0 <= phaseIdx  && phaseIdx <= numPhases);
-        assert(0 <= compIdx  && compIdx <= numComponents);
+        assert(0 <= phaseIdx && phaseIdx <= numPhases);
+        assert(0 <= compIdx && compIdx <= numComponents);
 
         if (phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx)
             return PengRobinsonMixture::computeFugacityCoefficient(fluidState,

--- a/opm/material/fluidsystems/Spe5ParameterCache.hpp
+++ b/opm/material/fluidsystems/Spe5ParameterCache.hpp
@@ -72,7 +72,7 @@ public:
 
     //! \copydoc ParameterCacheBase::updatePhase
     template <class FluidState>
-    void updatePhase(const FluidState &fluidState,
+    void updatePhase(const FluidState& fluidState,
                      unsigned phaseIdx,
                      int exceptQuantities = ParentType::None)
     {
@@ -89,7 +89,7 @@ public:
 
     //! \copydoc ParameterCacheBase::updateSingleMoleFraction
     template <class FluidState>
-    void updateSingleMoleFraction(const FluidState &fluidState,
+    void updateSingleMoleFraction(const FluidState& fluidState,
                                   unsigned phaseIdx,
                                   unsigned compIdx)
     {
@@ -192,14 +192,14 @@ public:
      * \brief Returns the Peng-Robinson mixture parameters for the oil
      *        phase.
      */
-    const OilPhaseParams &oilPhaseParams() const
+    const OilPhaseParams& oilPhaseParams() const
     { return oilPhaseParams_; }
 
     /*!
      * \brief Returns the Peng-Robinson mixture parameters for the gas
      *        phase.
      */
-    const GasPhaseParams &gasPhaseParams() const
+    const GasPhaseParams& gasPhaseParams() const
     { return gasPhaseParams_; }
 
     /*!
@@ -211,7 +211,7 @@ public:
      * \param exceptQuantities The quantities of the fluid state that have not changed since the last update.
      */
     template <class FluidState>
-    void updateEosParams(const FluidState &fluidState,
+    void updateEosParams(const FluidState& fluidState,
                          unsigned phaseIdx,
                          int exceptQuantities = ParentType::None)
     {
@@ -239,7 +239,7 @@ protected:
      * This usually means the parameters for the pure components.
      */
     template <class FluidState>
-    void updatePure_(const FluidState &fluidState, unsigned phaseIdx)
+    void updatePure_(const FluidState& fluidState, unsigned phaseIdx)
     {
         Scalar T = fluidState.temperature(phaseIdx);
         Scalar p = fluidState.pressure(phaseIdx);
@@ -260,7 +260,7 @@ protected:
      * Here, the mixing rule kicks in.
      */
     template <class FluidState>
-    void updateMix_(const FluidState &fluidState, unsigned phaseIdx)
+    void updateMix_(const FluidState& fluidState, unsigned phaseIdx)
     {
         Valgrind::CheckDefined(fluidState.averageMolarMass(phaseIdx));
         switch (phaseIdx)
@@ -277,7 +277,7 @@ protected:
     }
 
     template <class FluidState>
-    void updateMolarVolume_(const FluidState &fluidState,
+    void updateMolarVolume_(const FluidState& fluidState,
                             unsigned phaseIdx)
     {
         VmUpToDate_[phaseIdx] = true;

--- a/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
+++ b/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
@@ -82,11 +82,11 @@ public:
     static const int nonWettingPhaseIdx = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char *phaseName(unsigned phaseIdx)
+    static const char* phaseName(unsigned phaseIdx)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        static const char *name[] = {
+        static const char* name[] = {
             "wetting",
             "nonwetting"
         };
@@ -148,7 +148,7 @@ public:
     static const int nonWettingCompIdx = 1;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char *componentName(unsigned compIdx)
+    static const char* componentName(unsigned compIdx)
     {
         assert(0 <= compIdx && compIdx < numComponents);
 
@@ -222,13 +222,13 @@ public:
 
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval density(const FluidState &fluidState,
-                           const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& /*paramCache*/,
                            unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         const auto& temperature = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const auto& pressure = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));
@@ -239,13 +239,13 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval viscosity(const FluidState &fluidState,
-                             const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         const auto& temperature = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const auto& pressure = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));
@@ -256,15 +256,15 @@ public:
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval fugacityCoefficient(const FluidState &/*fluidState*/,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval fugacityCoefficient(const FluidState& /*fluidState*/,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx,
                                        unsigned compIdx)
     {
         typedef MathToolbox<LhsEval> LhsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
-        assert(0 <= compIdx  && compIdx < numComponents);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
+        assert(0 <= compIdx && compIdx < numComponents);
 
         if (phaseIdx == compIdx)
             // TODO (?): calculate the real fugacity coefficient of
@@ -277,13 +277,13 @@ public:
 
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval enthalpy(const FluidState &fluidState,
-                            const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval enthalpy(const FluidState& fluidState,
+                            const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         const auto& temperature = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const auto& pressure = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));
@@ -294,13 +294,13 @@ public:
 
     //! \copydoc BaseFluidSystem::thermalConductivity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval thermalConductivity(const FluidState &fluidState,
-                                       const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval thermalConductivity(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                        unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         const auto& temperature = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const auto& pressure = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));
@@ -311,13 +311,13 @@ public:
 
     //! \copydoc BaseFluidSystem::heatCapacity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    static LhsEval heatCapacity(const FluidState &fluidState,
-                                const ParameterCache<ParamCacheEval> &/*paramCache*/,
+    static LhsEval heatCapacity(const FluidState& fluidState,
+                                const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                 unsigned phaseIdx)
     {
         typedef MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        assert(0 <= phaseIdx  && phaseIdx < numPhases);
+        assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         const auto& temperature = FsToolbox::template decay<LhsEval>(fluidState.temperature(phaseIdx));
         const auto& pressure = FsToolbox::template decay<LhsEval>(fluidState.pressure(phaseIdx));

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -148,7 +148,7 @@ public:
      *
      * \param samplePoints A container of \f$(p_g, B_g)\f$ values
      */
-    void setGasFormationVolumeFactor(unsigned regionIdx, const SamplingPoints &samplePoints)
+    void setGasFormationVolumeFactor(unsigned regionIdx, const SamplingPoints& samplePoints)
     {
         SamplingPoints tmp(samplePoints);
         auto it = tmp.begin();

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -42,17 +42,17 @@ namespace Opm {
 #define OPM_GAS_PVT_MULTIPLEXER_CALL(codeToCall)                        \
     switch (gasPvtApproach_) {                                          \
     case DryGasPvt: {                                                   \
-        auto &pvtImpl = getRealPvt<DryGasPvt>();                        \
+        auto& pvtImpl = getRealPvt<DryGasPvt>();                        \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
     case WetGasPvt: {                                                   \
-        auto &pvtImpl = getRealPvt<WetGasPvt>();                        \
+        auto& pvtImpl = getRealPvt<WetGasPvt>();                        \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
     case ThermalGasPvt: {                                               \
-        auto &pvtImpl = getRealPvt<ThermalGasPvt>();                    \
+        auto& pvtImpl = getRealPvt<ThermalGasPvt>();                    \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
@@ -290,7 +290,7 @@ public:
 
 private:
     GasPvtApproach gasPvtApproach_;
-    void *realGasPvt_;
+    void* realGasPvt_;
 };
 
 #undef OPM_GAS_PVT_MULTIPLEXER_CALL

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -147,7 +147,7 @@ public:
             return isothermalPvt_->viscosity(regionIdx, temperature, pressure, Rv);
 
         // compute the viscosity deviation due to temperature
-        const auto &muGasvisct = gasvisctCurves_[regionIdx].eval(temperature);
+        const auto& muGasvisct = gasvisctCurves_[regionIdx].eval(temperature);
         return muGasvisct;
     }
 
@@ -163,7 +163,7 @@ public:
             return isothermalPvt_->saturatedViscosity(regionIdx, temperature, pressure);
 
         // compute the viscosity deviation due to temperature
-        const auto &muGasvisct = gasvisctCurves_[regionIdx].eval(temperature);
+        const auto& muGasvisct = gasvisctCurves_[regionIdx].eval(temperature);
         return muGasvisct;
     }
 
@@ -250,7 +250,7 @@ public:
     { return isothermalPvt_->saturationPressure(regionIdx, temperature, pressure); }
 
 private:
-    IsothermalPvt *isothermalPvt_;
+    IsothermalPvt* isothermalPvt_;
 
     // The PVT properties needed for temperature dependence of the viscosity. We need
     // to store one value per PVT region.

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -265,7 +265,7 @@ public:
      *
      * \param samplePoints A container of (x,y) values.
      */
-    void setSaturatedOilGasDissolutionFactor(unsigned regionIdx, const SamplingPoints &samplePoints)
+    void setSaturatedOilGasDissolutionFactor(unsigned regionIdx, const SamplingPoints& samplePoints)
     { saturatedGasDissolutionFactorTable_[regionIdx].setContainerOfTuples(samplePoints); }
 
     /*!
@@ -277,7 +277,7 @@ public:
      * only depends on pressure) while the dependence on the gas mass fraction is
      * guesstimated.
      */
-    void setSaturatedOilFormationVolumeFactor(unsigned regionIdx, const SamplingPoints &samplePoints)
+    void setSaturatedOilFormationVolumeFactor(unsigned regionIdx, const SamplingPoints& samplePoints)
     {
         Scalar T = 273.15 + 15.56; // [K]
         auto& invOilB = inverseOilBTable_[regionIdx];
@@ -331,7 +331,7 @@ public:
      * requires the viscosity of gas-saturated oil (which only depends on pressure) while
      * there is assumed to be no dependence on the gas mass fraction...
      */
-    void setSaturatedOilViscosity(unsigned regionIdx, const SamplingPoints &samplePoints)
+    void setSaturatedOilViscosity(unsigned regionIdx, const SamplingPoints& samplePoints)
     {
         Scalar T = 273.15 + 15.56; // [K]
 

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -36,22 +36,22 @@ namespace Opm {
 #define OPM_OIL_PVT_MULTIPLEXER_CALL(codeToCall)                        \
     switch (approach_) {                                                \
     case ConstantCompressibilityOilPvt: {                               \
-        auto &pvtImpl = getRealPvt<ConstantCompressibilityOilPvt>();    \
+        auto& pvtImpl = getRealPvt<ConstantCompressibilityOilPvt>();    \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
     case DeadOilPvt: {                                                  \
-        auto &pvtImpl = getRealPvt<DeadOilPvt>();                       \
+        auto& pvtImpl = getRealPvt<DeadOilPvt>();                       \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
     case LiveOilPvt: {                                                  \
-        auto &pvtImpl = getRealPvt<LiveOilPvt>();                       \
+        auto& pvtImpl = getRealPvt<LiveOilPvt>();                       \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
     case ThermalOilPvt: {                                               \
-        auto &pvtImpl = getRealPvt<ThermalOilPvt>();                    \
+        auto& pvtImpl = getRealPvt<ThermalOilPvt>();                    \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -177,7 +177,7 @@ public:
             return isothermalMu;
 
         // compute the viscosity deviation due to temperature
-        const auto &muOilvisct = oilvisctCurves_[regionIdx].eval(temperature);
+        const auto& muOilvisct = oilvisctCurves_[regionIdx].eval(temperature);
         return muOilvisct/viscRef_[regionIdx]*isothermalMu;
     }
 
@@ -194,7 +194,7 @@ public:
             return isothermalMu;
 
         // compute the viscosity deviation due to temperature
-        const auto &muOilvisct = oilvisctCurves_[regionIdx].eval(temperature);
+        const auto& muOilvisct = oilvisctCurves_[regionIdx].eval(temperature);
         return muOilvisct/viscRef_[regionIdx]*isothermalMu;
     }
 
@@ -286,7 +286,7 @@ public:
     { return isothermalPvt_->saturationPressure(regionIdx, temperature, pressure); }
 
 private:
-    IsothermalPvt *isothermalPvt_;
+    IsothermalPvt* isothermalPvt_;
 
     // The PVT properties needed for temperature dependence of the viscosity. We need
     // to store one value per PVT region.

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -33,12 +33,12 @@
 #define OPM_WATER_PVT_MULTIPLEXER_CALL(codeToCall)                      \
     switch (approach_) {                                                \
     case ConstantCompressibilityWaterPvt: {                             \
-        auto &pvtImpl = getRealPvt<ConstantCompressibilityWaterPvt>();  \
+        auto& pvtImpl = getRealPvt<ConstantCompressibilityWaterPvt>();  \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
     case ThermalWaterPvt: {                                             \
-        auto &pvtImpl = getRealPvt<ThermalWaterPvt>();                  \
+        auto& pvtImpl = getRealPvt<ThermalWaterPvt>();                  \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
@@ -191,7 +191,7 @@ public:
 
 private:
     WaterPvtApproach approach_;
-    void *realWaterPvt_;
+    void* realWaterPvt_;
 };
 
 #undef OPM_WATER_PVT_MULTIPLEXER_CALL

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -198,7 +198,7 @@ public:
     }
 
 private:
-    IsothermalPvt *isothermalPvt_;
+    IsothermalPvt* isothermalPvt_;
 
     // The PVT properties needed for temperature dependence. We need to store one
     // value per PVT region.

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -268,7 +268,7 @@ public:
      *
      * \param samplePoints A container of (x,y) values.
      */
-    void setSaturatedGasOilVaporizationFactor(unsigned regionIdx, const SamplingPoints &samplePoints)
+    void setSaturatedGasOilVaporizationFactor(unsigned regionIdx, const SamplingPoints& samplePoints)
     { saturatedOilVaporizationFactorTable_[regionIdx].setContainerOfTuples(samplePoints); }
 
     /*!
@@ -280,11 +280,11 @@ public:
      * only depends on pressure) while the dependence on the oil mass fraction is
      * guesstimated...
      */
-    void setSaturatedGasFormationVolumeFactor(unsigned regionIdx, const SamplingPoints &samplePoints)
+    void setSaturatedGasFormationVolumeFactor(unsigned regionIdx, const SamplingPoints& samplePoints)
     {
         auto& invGasB = inverseGasB_[regionIdx];
 
-        auto &RvTable = saturatedOilVaporizationFactorTable_[regionIdx];
+        auto& RvTable = saturatedOilVaporizationFactorTable_[regionIdx];
 
         Scalar T = 273.15 + 15.56; // [K]
 
@@ -359,7 +359,7 @@ public:
      * requires the viscosity of oil-saturated gas (which only depends on pressure) while
      * there is assumed to be no dependence on the gas mass fraction...
      */
-    void setSaturatedGasViscosity(unsigned regionIdx, const SamplingPoints &samplePoints  )
+    void setSaturatedGasViscosity(unsigned regionIdx, const SamplingPoints& samplePoints  )
     {
         auto& oilVaporizationFac = saturatedOilVaporizationFactorTable_[regionIdx];
 

--- a/opm/material/heatconduction/DummyHeatConductionLaw.hpp
+++ b/opm/material/heatconduction/DummyHeatConductionLaw.hpp
@@ -54,8 +54,8 @@ public:
      * If this method is called an exception is thrown at run time.
      */
     template <class FluidState, class Evaluation = Scalar>
-    static Scalar heatConductivity(const Params& OPM_UNUSED params,
-                                   const FluidState& OPM_UNUSED fluidState)
+    static Scalar heatConductivity(const Params& params OPM_UNUSED,
+                                   const FluidState& fluidState OPM_UNUSED)
     {
         OPM_THROW(std::logic_error,
                    "No heat conduction law specified!");

--- a/opm/material/heatconduction/FluidConduction.hpp
+++ b/opm/material/heatconduction/FluidConduction.hpp
@@ -54,7 +54,7 @@ public:
      *        medium.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation heatConductivity(const Params& OPM_UNUSED params,
+    static Evaluation heatConductivity(const Params& params OPM_UNUSED,
                                        const FluidState& fluidState)
     {
         typename FluidSystem::template ParameterCache<Evaluation> paramCache;

--- a/opm/material/heatconduction/FluidConductionParams.hpp
+++ b/opm/material/heatconduction/FluidConductionParams.hpp
@@ -35,7 +35,7 @@ template <class ScalarT>
 class FluidHeatConductionParams
 {
     // do not copy!
-    FluidHeatConductionParams(const FluidHeatConductionParams &)
+    FluidHeatConductionParams(const FluidHeatConductionParams&)
     {}
 
 public:

--- a/opm/material/heatconduction/Somerton.hpp
+++ b/opm/material/heatconduction/Somerton.hpp
@@ -87,8 +87,8 @@ public:
      * phase \f$\alpha\f$.
      */
     template <class FluidState, class Evaluation = Scalar>
-    static Evaluation heatConductivity(const Params &params,
-                                       const FluidState &fluidState)
+    static Evaluation heatConductivity(const Params& params,
+                                       const FluidState& fluidState)
     {
         typedef Opm::MathToolbox<Evaluation> Toolbox;
 

--- a/opm/material/heatconduction/SomertonParams.hpp
+++ b/opm/material/heatconduction/SomertonParams.hpp
@@ -39,7 +39,7 @@ template <unsigned numPhases, class ScalarT>
 class SomertonParams
 {
     // do not copy!
-    SomertonParams(const SomertonParams &)
+    SomertonParams(const SomertonParams&)
     {}
 
 public:

--- a/tests/checkComponent.hpp
+++ b/tests/checkComponent.hpp
@@ -48,23 +48,23 @@ void checkComponent()
     typedef typename Component::Scalar Scalar;
 
     // make sure the necessary constants are exported
-    OPM_UNUSED bool isTabulated = Component::isTabulated;
+    bool isTabulated OPM_UNUSED = Component::isTabulated;
 
     // test for the gas-phase functions
     Evaluation T=0, p=0;
     while (0) {
-        { OPM_UNUSED bool b = Component::gasIsCompressible(); }
-        { OPM_UNUSED bool b = Component::gasIsIdeal(); }
-        { OPM_UNUSED bool b = Component::liquidIsCompressible(); }
-        { OPM_UNUSED std::string s = Component::name(); }
-        { OPM_UNUSED Scalar M = Component::molarMass(); }
-        { OPM_UNUSED Scalar Tc = Component::criticalTemperature(); }
-        { OPM_UNUSED Scalar pc = Component::criticalPressure(); }
-        { OPM_UNUSED Scalar Tt = Component::tripleTemperature(); }
-        { OPM_UNUSED Scalar pt = Component::triplePressure(); }
-        { OPM_UNUSED Evaluation pv = Component::vaporPressure(T); }
-        { OPM_UNUSED Evaluation rho = Component::gasDensity(T, p); }
-        { OPM_UNUSED Evaluation rho = Component::liquidDensity(T, p); }
+        { bool b OPM_UNUSED = Component::gasIsCompressible(); }
+        { bool b OPM_UNUSED = Component::gasIsIdeal(); }
+        { bool b OPM_UNUSED = Component::liquidIsCompressible(); }
+        { std::string s OPM_UNUSED = Component::name(); }
+        { Scalar M OPM_UNUSED = Component::molarMass(); }
+        { Scalar Tc OPM_UNUSED = Component::criticalTemperature(); }
+        { Scalar pc OPM_UNUSED = Component::criticalPressure(); }
+        { Scalar Tt OPM_UNUSED = Component::tripleTemperature(); }
+        { Scalar pt OPM_UNUSED = Component::triplePressure(); }
+        { Evaluation pv OPM_UNUSED = Component::vaporPressure(T); }
+        { Evaluation rho OPM_UNUSED = Component::gasDensity(T, p); }
+        { Evaluation rho OPM_UNUSED = Component::liquidDensity(T, p); }
     }
     std::cout << "----------------------------------\n";
 }

--- a/tests/test_2dtables.cpp
+++ b/tests/test_2dtables.cpp
@@ -57,7 +57,7 @@ static Scalar testFn3(Scalar x, Scalar y)
 
 template <class Fn>
 std::shared_ptr<Opm::UniformTabulated2DFunction<Scalar> >
-createUniformTabulatedFunction(Fn &f)
+createUniformTabulatedFunction(Fn& f)
 {
     Scalar xMin = -2.0;
     Scalar xMax = 3.0;
@@ -83,7 +83,7 @@ createUniformTabulatedFunction(Fn &f)
 
 template <class Fn>
 std::shared_ptr<Opm::UniformXTabulated2DFunction<Scalar> >
-createUniformXTabulatedFunction(Fn &f)
+createUniformXTabulatedFunction(Fn& f)
 {
     Scalar xMin = -2.0;
     Scalar xMax = 3.0;
@@ -109,7 +109,7 @@ createUniformXTabulatedFunction(Fn &f)
 
 template <class Fn>
 std::shared_ptr<Opm::UniformXTabulated2DFunction<Scalar> >
-createUniformXTabulatedFunction2(Fn &f)
+createUniformXTabulatedFunction2(Fn& f)
 {
     Scalar xMin = -2.0;
     Scalar xMax = 3.0;
@@ -135,7 +135,7 @@ createUniformXTabulatedFunction2(Fn &f)
 }
 
 template <class Fn, class Table>
-bool compareTableWithAnalyticFn(const Table &table,
+bool compareTableWithAnalyticFn(const Table& table,
                                 Scalar xMin,
                                 Scalar xMax,
                                 unsigned numX,
@@ -144,7 +144,7 @@ bool compareTableWithAnalyticFn(const Table &table,
                                 Scalar yMax,
                                 unsigned numY,
 
-                                Fn &f,
+                                Fn& f,
                                 Scalar tolerance = 1e-8)
 {
     // make sure that the tabulated function evaluates to the same thing as the analytic
@@ -167,7 +167,7 @@ bool compareTableWithAnalyticFn(const Table &table,
 template <class UniformTablePtr, class UniformXTablePtr, class Fn>
 bool compareTables(const UniformTablePtr uTable,
                    const UniformXTablePtr uXTable,
-                   Fn &f,
+                   Fn& f,
                    Scalar tolerance = 1e-8)
 {
     // make sure the uniform and the non-uniform tables exhibit the same dimensions

--- a/tests/test_densead.cpp
+++ b/tests/test_densead.cpp
@@ -62,7 +62,7 @@ void testOperators(const Scalar tolerance)
     const Scalar x = 4.567;
     const Scalar y = 8.910;
     const Eval cEval = Eval::createConstant(c);
-    const Eval OPM_UNUSED c2Eval = c;
+    const Eval c2Eval OPM_UNUSED = c;
     const Eval xEval = Eval::createVariable(x, 0);
     const Eval yEval = Eval::createVariable(y, 1);
 
@@ -596,9 +596,13 @@ inline void testAll()
                            1e-6, 1e9);
 
     while (false) {
-        OPM_UNUSED Scalar val1(0.0), val2(1.0), resultVal;
+        Scalar val1 OPM_UNUSED = 0.0;
+        Scalar val2 OPM_UNUSED = 1.0;
+        Scalar resultVal OPM_UNUSED;
         typedef Opm::DenseAd::Evaluation<Scalar, numVars> TmpEval;
-        OPM_UNUSED TmpEval eval1(1.0), eval2(2.0), resultEval;
+        TmpEval eval1 OPM_UNUSED = 1.0;
+        TmpEval eval2 OPM_UNUSED = 2.0;
+        TmpEval resultEval OPM_UNUSED;
 
         // make sure that the convenince functions work (i.e., that everything can be
         // accessed without the MathToolbox<Scalar> detour.)

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -86,10 +86,10 @@ void testGenericApi()
         static const int numPhases = MaterialLaw::numPhases;
 
         // check for the presence of the is*Dependent values
-        OPM_UNUSED static const bool isSaturationDependent = MaterialLaw::isSaturationDependent;
-        OPM_UNUSED static const bool isPressureDependent = MaterialLaw::isPressureDependent;
-        OPM_UNUSED static const bool isTemperatureDependent = MaterialLaw::isTemperatureDependent;
-        OPM_UNUSED static const bool isCompositionDependent = MaterialLaw::isCompositionDependent;
+        static const bool OPM_UNUSED isSaturationDependent = MaterialLaw::isSaturationDependent;
+        static const bool OPM_UNUSED isPressureDependent = MaterialLaw::isPressureDependent;
+        static const bool OPM_UNUSED isTemperatureDependent = MaterialLaw::isTemperatureDependent;
+        static const bool OPM_UNUSED isCompositionDependent = MaterialLaw::isCompositionDependent;
 
         // Make sure that the Traits, Params and Scalar typedefs are
         // exported by the material law
@@ -149,8 +149,8 @@ void testTwoPhaseApi()
                       "This material law is expected to implement "
                       "the two-phase API!");
 
-        OPM_UNUSED static const int wettingPhaseIdx = MaterialLaw::wettingPhaseIdx;
-        OPM_UNUSED static const int nonWettingPhaseIdx = MaterialLaw::nonWettingPhaseIdx;
+        static const int OPM_UNUSED wettingPhaseIdx = MaterialLaw::wettingPhaseIdx;
+        static const int OPM_UNUSED nonWettingPhaseIdx = MaterialLaw::nonWettingPhaseIdx;
 
         // make sure the two-phase specific methods are present
         const FluidState fs;
@@ -192,7 +192,7 @@ void testTwoPhaseSatApi()
                       "Capillary pressure laws which implement the twophase saturation only "
                       "API cannot be dependent on the phase compositions!");
 
-        OPM_UNUSED static const int numPhases = MaterialLaw::numPhases;
+        static const int OPM_UNUSED numPhases = MaterialLaw::numPhases;
 
         // make sure the two-phase specific methods are present
         const typename MaterialLaw::Params params;
@@ -226,9 +226,9 @@ void testThreePhaseApi()
                       "The number of fluid phases for a threephase "
                       "capillary pressure law must be 3");
 
-        OPM_UNUSED static const int wettingPhaseIdx = MaterialLaw::wettingPhaseIdx;
-        OPM_UNUSED static const int nonWettingPhaseIdx = MaterialLaw::nonWettingPhaseIdx;
-        OPM_UNUSED static const int gasPhaseIdx = MaterialLaw::gasPhaseIdx;
+        static const int OPM_UNUSED wettingPhaseIdx = MaterialLaw::wettingPhaseIdx;
+        static const int OPM_UNUSED nonWettingPhaseIdx = MaterialLaw::nonWettingPhaseIdx;
+        static const int OPM_UNUSED gasPhaseIdx = MaterialLaw::gasPhaseIdx;
 
         // make sure the two-phase specific methods are present
         const FluidState fs;

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -154,9 +154,9 @@ void ensureBlackoilApi()
 
 
         // the "not considered safe to use directly" API
-        const OilPvt  &oilPvt2 OPM_UNUSED = FluidSystem::oilPvt();
-        const GasPvt  &gasPvt2 OPM_UNUSED = FluidSystem::gasPvt();
-        const WaterPvt  &waterPvt2 OPM_UNUSED = FluidSystem::waterPvt();
+        const OilPvt& oilPvt2 OPM_UNUSED = FluidSystem::oilPvt();
+        const GasPvt& gasPvt2 OPM_UNUSED = FluidSystem::gasPvt();
+        const WaterPvt& waterPvt2 OPM_UNUSED = FluidSystem::waterPvt();
     }
 }
 

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -122,12 +122,12 @@ void ensureBlackoilApi()
         FluidSystem::initEnd();
 
         // the molarMass() method has an optional argument for the PVT region
-        unsigned OPM_UNUSED numRegions = FluidSystem::numRegions();
-        Scalar OPM_UNUSED Mg = FluidSystem::molarMass(FluidSystem::gasCompIdx,
+        unsigned numRegions OPM_UNUSED = FluidSystem::numRegions();
+        Scalar Mg OPM_UNUSED = FluidSystem::molarMass(FluidSystem::gasCompIdx,
                                                       /*regionIdx=*/0);
-        bool OPM_UNUSED b1 = FluidSystem::enableDissolvedGas();
-        bool OPM_UNUSED b2 = FluidSystem::enableVaporizedOil();
-        Scalar OPM_UNUSED rhoRefOil = FluidSystem::referenceDensity(FluidSystem::oilPhaseIdx,
+        bool b1 OPM_UNUSED = FluidSystem::enableDissolvedGas();
+        bool b2 OPM_UNUSED = FluidSystem::enableVaporizedOil();
+        Scalar rhoRefOil OPM_UNUSED = FluidSystem::referenceDensity(FluidSystem::oilPhaseIdx,
                                                                     /*regionIdx=*/0);
         dummy = FluidSystem::convertXoGToRs(XoG, /*regionIdx=*/0);
         dummy = FluidSystem::convertXgOToRv(XgO, /*regionIdx=*/0);
@@ -154,9 +154,9 @@ void ensureBlackoilApi()
 
 
         // the "not considered safe to use directly" API
-        const OPM_UNUSED OilPvt &oilPvt2 = FluidSystem::oilPvt();
-        const OPM_UNUSED GasPvt &gasPvt2 = FluidSystem::gasPvt();
-        const OPM_UNUSED WaterPvt &waterPvt2 = FluidSystem::waterPvt();
+        const OilPvt  &oilPvt2 OPM_UNUSED = FluidSystem::oilPvt();
+        const GasPvt  &gasPvt2 OPM_UNUSED = FluidSystem::gasPvt();
+        const WaterPvt  &waterPvt2 OPM_UNUSED = FluidSystem::waterPvt();
     }
 }
 

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -51,7 +51,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 template <class Scalar, class FluidState>
-void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
+void checkSame(const FluidState& fsRef, const FluidState& fsFlash)
 {
     enum { numPhases = FluidState::numPhases };
     enum { numComponents = FluidState::numComponents };
@@ -95,8 +95,8 @@ void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
 }
 
 template <class Scalar, class FluidSystem, class MaterialLaw, class FluidState>
-void checkImmiscibleFlash(const FluidState &fsRef,
-                          typename MaterialLaw::Params &matParams)
+void checkImmiscibleFlash(const FluidState& fsRef,
+                          typename MaterialLaw::Params& matParams)
 {
     enum { numPhases = FluidSystem::numPhases };
     enum { numComponents = FluidSystem::numComponents };
@@ -129,8 +129,8 @@ void checkImmiscibleFlash(const FluidState &fsRef,
 
 
 template <class Scalar, class FluidSystem, class MaterialLaw, class FluidState>
-void completeReferenceFluidState(FluidState &fs,
-                                 typename MaterialLaw::Params &matParams,
+void completeReferenceFluidState(FluidState& fs,
+                                 typename MaterialLaw::Params& matParams,
                                  unsigned refPhaseIdx)
 {
     enum { numPhases = FluidSystem::numPhases };

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -50,7 +50,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 template <class Scalar, class FluidState>
-void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
+void checkSame(const FluidState& fsRef, const FluidState& fsFlash)
 {
     enum { numPhases = FluidState::numPhases };
     enum { numComponents = FluidState::numComponents };
@@ -93,8 +93,8 @@ void checkSame(const FluidState &fsRef, const FluidState &fsFlash)
 }
 
 template <class Scalar, class FluidSystem, class MaterialLaw, class FluidState>
-void checkNcpFlash(const FluidState &fsRef,
-                   typename MaterialLaw::Params &matParams)
+void checkNcpFlash(const FluidState& fsRef,
+                   typename MaterialLaw::Params& matParams)
 {
     enum { numPhases = FluidSystem::numPhases };
     enum { numComponents = FluidSystem::numComponents };
@@ -129,8 +129,8 @@ void checkNcpFlash(const FluidState &fsRef,
 
 
 template <class Scalar, class FluidSystem, class MaterialLaw, class FluidState>
-void completeReferenceFluidState(FluidState &fs,
-                                 typename MaterialLaw::Params &matParams,
+void completeReferenceFluidState(FluidState& fs,
+                                 typename MaterialLaw::Params& matParams,
                                  unsigned refPhaseIdx)
 {
     enum { numPhases = FluidSystem::numPhases };

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -41,7 +41,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 template <class FluidSystem, class FluidState>
-void createSurfaceGasFluidSystem(FluidState &gasFluidState)
+void createSurfaceGasFluidSystem(FluidState& gasFluidState)
 {
     static const int gasPhaseIdx = FluidSystem::gasPhaseIdx;
 
@@ -71,9 +71,9 @@ void createSurfaceGasFluidSystem(FluidState &gasFluidState)
 }
 
 template <class Scalar, class FluidSystem, class FluidState>
-Scalar computeSumxg(FluidState &resultFluidState,
-                    const FluidState &prestineFluidState,
-                    const FluidState &gasFluidState,
+Scalar computeSumxg(FluidState& resultFluidState,
+                    const FluidState& prestineFluidState,
+                    const FluidState& gasFluidState,
                     Scalar additionalGas)
 {
     static const int oilPhaseIdx = FluidSystem::oilPhaseIdx;
@@ -104,7 +104,7 @@ Scalar computeSumxg(FluidState &resultFluidState,
 }
 
 template <class Scalar, class FluidSystem, class FluidState>
-void makeOilSaturated(FluidState &fluidState, const FluidState &gasFluidState)
+void makeOilSaturated(FluidState& fluidState, const FluidState& gasFluidState)
 {
     static const int gasPhaseIdx = FluidSystem::gasPhaseIdx;
 
@@ -139,7 +139,7 @@ void makeOilSaturated(FluidState &fluidState, const FluidState &gasFluidState)
 }
 
 template <class FluidSystem, class FluidState>
-void guessInitial(FluidState &fluidState, unsigned phaseIdx)
+void guessInitial(FluidState& fluidState, unsigned phaseIdx)
 {
     if (phaseIdx == FluidSystem::gasPhaseIdx) {
         fluidState.setMoleFraction(phaseIdx, FluidSystem::H2OIdx, 0.0);
@@ -165,7 +165,7 @@ void guessInitial(FluidState &fluidState, unsigned phaseIdx)
 }
 
 template <class Scalar, class FluidSystem, class FluidState>
-Scalar bringOilToSurface(FluidState &surfaceFluidState, Scalar alpha, const FluidState &reservoirFluidState, bool guessInitial)
+Scalar bringOilToSurface(FluidState& surfaceFluidState, Scalar alpha, const FluidState& reservoirFluidState, bool guessInitial)
 {
     enum {
         numPhases = FluidSystem::numPhases,
@@ -258,7 +258,7 @@ Scalar bringOilToSurface(FluidState &surfaceFluidState, Scalar alpha, const Flui
 
 template <class RawTable>
 void printResult(const RawTable& rawTable,
-                 const std::string &fieldName,
+                 const std::string& fieldName,
                  size_t firstIdx,
                  size_t secondIdx,
                  double hiresThres)

--- a/tests/test_spline.cpp
+++ b/tests/test_spline.cpp
@@ -47,9 +47,9 @@ gnuplot> plot "spline.csv" using 1:2 w l ti "Curve", \
 #include <array>
 
 template <class Spline>
-void testCommon(const Spline &sp,
-                const double *x,
-                const double *y)
+void testCommon(const Spline& sp,
+                const double* x,
+                const double* y)
 {
     static double eps = 1e-10;
     static double epsFD = 1e-7;
@@ -111,9 +111,9 @@ void testCommon(const Spline &sp,
 }
 
 template <class Spline>
-void testFull(const Spline &sp,
-              const double *x,
-              const double *y,
+void testFull(const Spline& sp,
+              const double* x,
+              const double* y,
               double m0,
               double m1)
 {
@@ -135,9 +135,9 @@ void testFull(const Spline &sp,
 }
 
 template <class Spline>
-void testNatural(const Spline &sp,
-                 const double *x,
-                 const double *y)
+void testNatural(const Spline& sp,
+                 const double* x,
+                 const double* y)
 {
     // test the common properties of splines
     testCommon(sp, x, y);
@@ -159,9 +159,9 @@ void testNatural(const Spline &sp,
 }
 
 template <class Spline>
-void testMonotonic(const Spline &sp,
-                   const double *x,
-                   const double *y)
+void testMonotonic(const Spline& sp,
+                   const double* x,
+                   const double* y)
 {
     // test the common properties of splines
     testCommon(sp, x, y);
@@ -270,8 +270,8 @@ void plot()
     double y_[] = { 10, 0, 10, 0, 10 };
     double m1 = 10;
     double m2 = -10;
-    FV &xs = *reinterpret_cast<FV*>(x_);
-    FV &ys = *reinterpret_cast<FV*>(y_);
+    FV& xs = *reinterpret_cast<FV*>(x_);
+    FV& ys = *reinterpret_cast<FV*>(y_);
     Opm::Spline<double> spFull(xs, ys, m1, m2);
     Opm::Spline<double> spNatural(xs, ys);
     Opm::Spline<double> spPeriodic(xs, ys, /*type=*/Opm::Spline<double>::Periodic);
@@ -303,7 +303,7 @@ int main(int argc, char **argv)
         testAll();
         plot();
     }
-    catch (const std::exception &e) {
+    catch (const std::exception& e) {
         std::cout << "Caught OPM exception: " << e.what() << "\n";
     }
 

--- a/tests/test_tabulation.cpp
+++ b/tests/test_tabulation.cpp
@@ -42,7 +42,7 @@ extern bool success;
 bool success;
 
 template <class Scalar>
-void isSame(const char *str, Scalar v, Scalar vRef, Scalar tol=1e-3)
+void isSame(const char* str, Scalar v, Scalar vRef, Scalar tol=1e-3)
 {
     if (std::abs( (v - vRef)/vRef ) > tol) {
         std::cout << "error for \"" << str << "\": "  << (v - vRef)/vRef*100 << "% difference (tolerance: "  << tol*100 << "%)\n";


### PR DESCRIPTION
this PR places the OPM_UNUSED macros behind the variable corresponding name because some compilers seem to be picky about this and changes pointer and reference indicators (i.e., '&' and '*') to be seem as part of the type, not part of the object.

the patch is very large, but it is quite trivial.