### PR TITLE
Adapt to unit changes in opm-parser for JFUNC

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -145,38 +145,6 @@ public:
     { enableLeverettScaling_ = yesno; }
 
     /*!
-     * \brief Specify the conversion factor between deck and SI pressure units
-     *
-     * i.e. for METRIC decks this should be set to 10^5, for FIELD decks to 6894.7573,
-     * and so on. This factor is required to be set if Leverett pressure scaling is
-     * enabled because the ECL Leverett function implementation "misuses" the pressure
-     * column of the underlying tables (SWOF, SGOF, SWFN, etc.) for the (dimensionless)
-     * J-Function. Since opm-parser automatically applies the conversion factor for deck
-     * to SI pressure values to the column, opm-material needs this value in order to
-     * restore the value of the J-function from the "pressure" value.
-     *
-     * Note that this is a BIG *FAT* *_HACK_*
-     */
-    void setDeckPressureConversionFactor(double pToSiFactor)
-    { pToSiFactor_ = pToSiFactor; }
-
-    /*!
-     * \brief Returns the conversion factor between deck and SI pressure units
-     *
-     * i.e. for METRIC decks this should be set to 10^5, for FIELD decks to 6894.7573,
-     * and so on. This factor is required to be set if Leverett pressure scaling is
-     * enabled because the ECL Leverett function implementation "misuses" the pressure
-     * column of the underlying tables (SWOF, SGOF, SWFN, etc.) for the (dimensionless)
-     * J-Function. Since opm-parser automatically applies the conversion factor for deck
-     * to SI pressure values to the column, opm-material needs this value in order to
-     * restore the value of the J-function from the "pressure" value.
-     *
-     * Note that this is a BIG *FAT* *_HACK_*
-     */
-    double deckPressureConversionFactor() const
-    { return pToSiFactor_; }
-
-    /*!
      * \brief Returns whether the Leverett capillary pressure scaling is enabled.
      *
      * If this returns true, Leverett capillary pressure scaling will be used instead of
@@ -232,9 +200,6 @@ public:
         }
         else
             enableThreePointKrSatScaling_ = false;
-
-        // determine the conversion factor for deck pressures to Pascals
-        pToSiFactor_ = deck.getActiveUnitSystem().getDimension("Pressure").getSIScaling();
 
         auto& props = eclState.get3DProperties();
         // check if we are supposed to scale the Y axis of the capillary pressure
@@ -295,9 +260,6 @@ public:
 #endif
 
 private:
-    // conversion factor for deck pressure units to SI quantities
-    double pToSiFactor_;
-
     // enable scaling of the input saturations (i.e., rescale the x-Axis)
     bool enableSatScaling_;
 

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -372,9 +372,7 @@ struct EclEpsScalingPointsInfo
             if (jfuncFlag == Opm::JFunc::Flag::WATER || jfuncFlag == Opm::JFunc::Flag::BOTH) {
                 // note that we use the surface tension in terms of [dyn/cm]
                 Scalar gamma =
-                    jfunc.owSurfaceTension()
-                    * (/*dyn/N=*/1e5 * /*m/cm=*/1e-2);
-
+                    jfunc.owSurfaceTension();
                 pcowLeverettFactor = commonFactor*gamma*Uconst;
             }
 
@@ -382,9 +380,7 @@ struct EclEpsScalingPointsInfo
             if (jfuncFlag == Opm::JFunc::Flag::GAS || jfuncFlag == Opm::JFunc::Flag::BOTH) {
                 // note that we use the surface tension in terms of [dyn/cm]
                 Scalar gamma =
-                    jfunc.goSurfaceTension()
-                    * (/*dyn/N=*/1e5 * /*m/cm=*/1e-2);
-
+                    jfunc.goSurfaceTension();
                 pcgoLeverettFactor = commonFactor*gamma*Uconst;
             }
         }

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -469,14 +469,8 @@ private:
     static Evaluation unscaledToScaledPcnw_(const Params& params, const Evaluation& unscaledPcnw)
     {
         if (params.config().enableLeverettScaling()) {
-            // HACK: we need to divide the "unscaled capillary pressure" by the
-            // conversion factor for deck to SI pressures because this quantity is
-            // actually *not* a pressure but the (dimensionless) value of the
-            // J-function. Since opm-parser currently always treads this column as a
-            // pressure, it multiplies it with the conversion factor and we have to
-            // revert this here.
             Scalar alpha = params.scaledPoints().leverettFactor();
-            return unscaledPcnw*(alpha/params.config().deckPressureConversionFactor());
+            return unscaledPcnw*alpha;
         }
         else if (params.config().enablePcScaling()) {
             Scalar alpha = params.scaledPoints().maxPcnw()/params.unscaledPoints().maxPcnw();
@@ -490,11 +484,8 @@ private:
     static Evaluation scaledToUnscaledPcnw_(const Params& params, const Evaluation& scaledPcnw)
     {
         if (params.config().enableLeverettScaling()) {
-            // HACK: we need to multiply the "scaled capillary pressure" by the conversion
-            // factor for deck to SI pressures because this quantity is actually *not* a
-            // pressure but the (dimensionless) value of the J-function.
             Scalar alpha = params.scaledPoints().leverettFactor();
-            return scaledPcnw*(params.config().deckPressureConversionFactor()/alpha);
+            return scaledPcnw/alpha;
         }
         else if (params.config().enablePcScaling()) {
             Scalar alpha = params.unscaledPoints().maxPcnw()/params.scaledPoints().maxPcnw();


### PR DESCRIPTION
The ECL Leverett function implementation "misuses" the pressure column
of the underlying tables (SWOF, SGOF, SWFN, etc.) for the
(dimensionless) J-Function. The correct conversion factor is now
applied in the parser and no conversions is needed no the opm-material
side.

Fixes issue #199

