### PR TITLE
[WIP] Move assertFinalized_ to base class to avoid code duplication.

### DIFF
--- a/opm/material/common/AssertFinalized.hpp
+++ b/opm/material/common/AssertFinalized.hpp
@@ -1,0 +1,77 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::AssertFinalized
+ */
+#ifndef OPM_MATERIAL_ASSERT_FINALIZED_HPP
+#define OPM_MATERIAL_ASSERT_FINALIZED_HPP
+
+#include <type_traits>
+#include <cassert>
+#include <memory>
+
+namespace Opm {
+
+/*!
+ * \brief Default implementation for asserting finalization of parameter objects.
+ *
+ */
+class AssertFinalized
+{
+#if OPM_CHECK_PARAM_FINALIZED
+    bool finalized_;
+#endif
+
+protected:
+    /*!
+     * \brief The default constructor.
+     */
+    AssertFinalized()
+#if OPM_CHECK_PARAM_FINALIZED
+        : finalized_( false )
+#endif
+    {
+    }
+
+    void assertFinalized_() const
+    {
+#if OPM_CHECK_PARAM_FINALIZED
+        assert(finalized_);
+#endif
+    }
+
+public:
+    /*!
+     * \brief Mark the object as finalized.
+     */
+    void finalize()
+    {
+#if OPM_CHECK_PARAM_FINALIZED
+        finalized_ = true;
+#endif
+    }
+};
+
+} // namespace Opm
+#endif

--- a/opm/material/common/EnsureFinalized.hpp
+++ b/opm/material/common/EnsureFinalized.hpp
@@ -22,14 +22,15 @@
 */
 /*!
  * \file
- * \copydoc Opm::AssertFinalized
+ * \copydoc Opm::EnsureFinalized
  */
-#ifndef OPM_MATERIAL_ASSERT_FINALIZED_HPP
-#define OPM_MATERIAL_ASSERT_FINALIZED_HPP
+#ifndef OPM_MATERIAL_ENSURE_FINALIZED_HPP
+#define OPM_MATERIAL_ENSURE_FINALIZED_HPP
 
-#include <type_traits>
 #include <cassert>
-#include <memory>
+#include <opm/common/ErrorMacros.hpp>
+
+#define OPM_CHECK_PARAM_FINALIZED 1
 
 namespace Opm {
 
@@ -37,7 +38,7 @@ namespace Opm {
  * \brief Default implementation for asserting finalization of parameter objects.
  *
  */
-class AssertFinalized
+class EnsureFinalized
 {
 #if OPM_CHECK_PARAM_FINALIZED
     bool finalized_;
@@ -47,17 +48,20 @@ protected:
     /*!
      * \brief The default constructor.
      */
-    AssertFinalized()
+    EnsureFinalized()
 #if OPM_CHECK_PARAM_FINALIZED
         : finalized_( false )
 #endif
     {
     }
 
-    void assertFinalized_() const
+    void check() const
     {
 #if OPM_CHECK_PARAM_FINALIZED
-        assert(finalized_);
+        if( ! finalized_ )
+        {
+            OPM_THROW(std::runtime_error,"Parameter class has not been finalized before usage!");
+        }
 #endif
     }
 

--- a/opm/material/common/EnsureFinalized.hpp
+++ b/opm/material/common/EnsureFinalized.hpp
@@ -30,7 +30,12 @@
 #include <cassert>
 #include <opm/common/ErrorMacros.hpp>
 
+// TODO: move this variable to config.h
 #define OPM_CHECK_PARAM_FINALIZED 1
+
+#if ! defined(NDEBUG) && OPM_CHECK_PARAM_FINALIZED
+#define USE_OPM_CHECK_PARAM_FINALIZED 1
+#endif
 
 namespace Opm {
 
@@ -40,7 +45,7 @@ namespace Opm {
  */
 class EnsureFinalized
 {
-#if OPM_CHECK_PARAM_FINALIZED
+#if USE_OPM_CHECK_PARAM_FINALIZED
     bool finalized_;
 #endif
 
@@ -49,7 +54,7 @@ protected:
      * \brief The default constructor.
      */
     EnsureFinalized()
-#if OPM_CHECK_PARAM_FINALIZED
+#if USE_OPM_CHECK_PARAM_FINALIZED
         : finalized_( false )
 #endif
     {
@@ -57,7 +62,7 @@ protected:
 
     void check() const
     {
-#if OPM_CHECK_PARAM_FINALIZED
+#if USE_OPM_CHECK_PARAM_FINALIZED
         if( ! finalized_ )
         {
             OPM_THROW(std::runtime_error,"Parameter class has not been finalized before usage!");
@@ -71,11 +76,13 @@ public:
      */
     void finalize()
     {
-#if OPM_CHECK_PARAM_FINALIZED
+#if USE_OPM_CHECK_PARAM_FINALIZED
         finalized_ = true;
 #endif
     }
 };
+
+#undef USE_OPM_CHECK_PARAM_FINALIZED
 
 } // namespace Opm
 #endif

--- a/opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
+++ b/opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
@@ -28,7 +28,7 @@
 #define OPM_BROOKS_COREY_PARAMS_HPP
 
 #include <opm/common/Valgrind.hpp>
-#include <opm/material/common/AssertFinalized.hpp>
+#include <opm/material/common/EnsureFinalized.hpp>
 
 #include <cassert>
 
@@ -43,13 +43,11 @@ namespace Opm {
  *\see BrooksCorey
  */
 template <class TraitsT>
-class BrooksCoreyParams : public AssertFinalized
+class BrooksCoreyParams : public EnsureFinalized
 {
     typedef typename TraitsT::Scalar Scalar;
-protected:
-    using AssertFinalized :: assertFinalized_;
 public:
-    using AssertFinalized :: finalize;
+    using EnsureFinalized :: finalize;
 
     typedef TraitsT Traits;
 
@@ -68,7 +66,7 @@ public:
      * \brief Returns the entry pressure [Pa]
      */
     Scalar entryPressure() const
-    { assertFinalized_(); return entryPressure_; }
+    { EnsureFinalized::check(); return entryPressure_; }
 
     /*!
      * \brief Set the entry pressure [Pa]
@@ -81,7 +79,7 @@ public:
      * \brief Returns the lambda shape parameter
      */
     Scalar lambda() const
-    { assertFinalized_(); return lambda_; }
+    { EnsureFinalized::check(); return lambda_; }
 
     /*!
      * \brief Set the lambda shape parameter

--- a/opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
+++ b/opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
@@ -28,6 +28,7 @@
 #define OPM_BROOKS_COREY_PARAMS_HPP
 
 #include <opm/common/Valgrind.hpp>
+#include <opm/material/common/AssertFinalized.hpp>
 
 #include <cassert>
 
@@ -42,36 +43,25 @@ namespace Opm {
  *\see BrooksCorey
  */
 template <class TraitsT>
-class BrooksCoreyParams
+class BrooksCoreyParams : public AssertFinalized
 {
     typedef typename TraitsT::Scalar Scalar;
-
+protected:
+    using AssertFinalized :: assertFinalized_;
 public:
+    using AssertFinalized :: finalize;
+
     typedef TraitsT Traits;
 
     BrooksCoreyParams()
     {
         Valgrind::SetUndefined(*this);
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     BrooksCoreyParams(Scalar ePressure, Scalar shapeParam)
         : entryPressure_(ePressure), lambda_(shapeParam)
     {
         finalize();
-    }
-
-    /*!
-     * \brief Calculate all dependent quantities once the independent
-     *        quantities of the parameter object have been set.
-     */
-    void finalize()
-    {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     /*!
@@ -100,16 +90,6 @@ public:
     { lambda_ = v; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     Scalar entryPressure_;
     Scalar lambda_;
 };

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
@@ -31,7 +31,7 @@
 #include <cassert>
 #include <memory>
 
-#include <opm/material/common/AssertFinalized.hpp>
+#include <opm/material/common/EnsureFinalized.hpp>
 
 namespace Opm {
 
@@ -44,14 +44,12 @@ namespace Opm {
  * the twophase capillary pressure laws.
  */
 template<class Traits, class GasOilParamsT, class OilWaterParamsT>
-class EclDefaultMaterialParams : public AssertFinalized
+class EclDefaultMaterialParams : public EnsureFinalized
 {
     typedef typename Traits::Scalar Scalar;
     enum { numPhases = 3 };
-protected:
-    using AssertFinalized :: assertFinalized_;
 public:
-    using AssertFinalized :: finalize;
+    using EnsureFinalized :: finalize;
 
     typedef GasOilParamsT GasOilParams;
     typedef OilWaterParamsT OilWaterParams;
@@ -67,13 +65,13 @@ public:
      * \brief The parameter object for the gas-oil twophase law.
      */
     const GasOilParams& gasOilParams() const
-    { assertFinalized_(); return *gasOilParams_; }
+    { EnsureFinalized::check(); return *gasOilParams_; }
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
     GasOilParams& gasOilParams()
-    { assertFinalized_(); return *gasOilParams_; }
+    { EnsureFinalized::check(); return *gasOilParams_; }
 
     /*!
      * \brief Set the parameter object for the gas-oil twophase law.
@@ -85,13 +83,13 @@ public:
      * \brief The parameter object for the oil-water twophase law.
      */
     const OilWaterParams& oilWaterParams() const
-    { assertFinalized_(); return *oilWaterParams_; }
+    { EnsureFinalized::check(); return *oilWaterParams_; }
 
     /*!
      * \brief The parameter object for the oil-water twophase law.
      */
     OilWaterParams& oilWaterParams()
-    { assertFinalized_(); return *oilWaterParams_; }
+    { EnsureFinalized::check(); return *oilWaterParams_; }
 
     /*!
      * \brief Set the parameter object for the oil-water twophase law.
@@ -117,7 +115,7 @@ public:
      * \brief Return the saturation of "connate" water.
      */
     Scalar Swl() const
-    { assertFinalized_(); return Swl_; }
+    { EnsureFinalized::check(); return Swl_; }
 
     /*!
      * \brief Specify whether inconsistent saturations should be used to update the

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
@@ -31,6 +31,8 @@
 #include <cassert>
 #include <memory>
 
+#include <opm/material/common/AssertFinalized.hpp>
+
 namespace Opm {
 
 /*!
@@ -42,11 +44,15 @@ namespace Opm {
  * the twophase capillary pressure laws.
  */
 template<class Traits, class GasOilParamsT, class OilWaterParamsT>
-class EclDefaultMaterialParams
+class EclDefaultMaterialParams : public AssertFinalized
 {
     typedef typename Traits::Scalar Scalar;
     enum { numPhases = 3 };
+protected:
+    using AssertFinalized :: assertFinalized_;
 public:
+    using AssertFinalized :: finalize;
+
     typedef GasOilParamsT GasOilParams;
     typedef OilWaterParamsT OilWaterParams;
 
@@ -55,19 +61,6 @@ public:
      */
     EclDefaultMaterialParams()
     {
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
-    }
-
-    /*!
-     * \brief Finish the initialization of the parameter object.
-     */
-    void finalize()
-    {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     /*!
@@ -139,16 +132,6 @@ public:
     { return true; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;
 

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
@@ -40,6 +40,8 @@
 #include <cassert>
 #include <algorithm>
 
+#include <opm/material/common/EnsureFinalized.hpp>
+
 namespace Opm {
 /*!
  * \ingroup FluidMatrixInteractions
@@ -48,7 +50,7 @@ namespace Opm {
  *        which implements ECL endpoint scaleing .
  */
 template <class EffLawT>
-class EclEpsTwoPhaseLawParams
+class EclEpsTwoPhaseLawParams : public EnsureFinalized
 {
     typedef typename EffLawT::Params EffLawParams;
     typedef typename EffLawParams::Traits::Scalar Scalar;
@@ -59,9 +61,6 @@ public:
 
     EclEpsTwoPhaseLawParams()
     {
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     /*!
@@ -76,9 +75,8 @@ public:
             assert(unscaledPoints_);
         }
         assert(effectiveLawParams_);
-
-        finalized_ = true;
 #endif
+        EnsureFinalized :: finalize();
     }
 
     /*!
@@ -136,17 +134,6 @@ public:
     { return *effectiveLawParams_; }
 
 private:
-
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     std::shared_ptr<EffLawParams> effectiveLawParams_;
 
     std::shared_ptr<EclEpsConfig> config_;

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -40,6 +40,8 @@
 #include <cassert>
 #include <algorithm>
 
+#include <opm/material/common/EnsureFinalized.hpp>
+
 namespace Opm {
 /*!
  * \ingroup FluidMatrixInteractions
@@ -48,7 +50,7 @@ namespace Opm {
  *        implements the ECL relative permeability and capillary pressure hysteresis
  */
 template <class EffLawT>
-class EclHysteresisTwoPhaseLawParams
+class EclHysteresisTwoPhaseLawParams : public EnsureFinalized
 {
     typedef typename EffLawT::Params EffLawParams;
     typedef typename EffLawParams::Traits::Scalar Scalar;
@@ -64,10 +66,6 @@ public:
 
         deltaSwImbKrn_ = 0.0;
         // deltaSwImbKrw_ = 0.0;
-
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     /*!
@@ -82,9 +80,7 @@ public:
             updateDynamicParams_();
         }
 
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
+        EnsureFinalized :: finalize();
     }
 
     /*!
@@ -275,17 +271,6 @@ public:
     }
 
 private:
-
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     void updateDynamicParams_()
     {
         // HACK: Eclipse seems to disable the wetting-phase relperm even though this is

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -36,6 +36,8 @@
 #include <cassert>
 #include <memory>
 
+#include <opm/material/common/EnsureFinalized.hpp>
+
 namespace Opm {
 
 enum EclMultiplexerApproach {
@@ -53,7 +55,7 @@ enum EclMultiplexerApproach {
  * provides some methods to convert to it.
  */
 template<class Traits, class GasOilMaterialLawT, class OilWaterMaterialLawT>
-class EclMultiplexerMaterialParams : public Traits
+class EclMultiplexerMaterialParams : public Traits, public EnsureFinalized
 {
     typedef typename Traits::Scalar Scalar;
     enum { numPhases = 3 };
@@ -69,25 +71,19 @@ class EclMultiplexerMaterialParams : public Traits
     typedef typename TwoPhaseMaterial::Params TwoPhaseParams;
 
 public:
+    using EnsureFinalized :: finalize;
+
     /*!
      * \brief The multiplexer constructor.
      */
     EclMultiplexerMaterialParams()
     {
         realParams_ = 0;
-
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     EclMultiplexerMaterialParams(const EclMultiplexerMaterialParams& /*other*/)
     {
         realParams_ = 0;
-
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     ~EclMultiplexerMaterialParams()
@@ -109,16 +105,6 @@ public:
             delete static_cast<TwoPhaseParams*>(realParams_);
             break;
         }
-    }
-
-    /*!
-     * \brief Finish the initialization of the parameter object.
-     */
-    void finalize()
-    {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     void setApproach(EclMultiplexerApproach newApproach)
@@ -217,16 +203,6 @@ public:
     }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     EclMultiplexerApproach approach_;
     void* realParams_;
 };

--- a/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
@@ -42,7 +42,7 @@ namespace Opm {
  * the twophase capillary pressure laws.
  */
 template<class Traits, class GasOilLawT, class OilWaterLawT>
-class EclStone1MaterialParams
+class EclStone1MaterialParams : public EnsureFinalized
 {
     typedef typename Traits::Scalar Scalar;
     enum { numPhases = 3 };
@@ -56,9 +56,6 @@ public:
      */
     EclStone1MaterialParams()
     {
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     /*!
@@ -68,22 +65,20 @@ public:
     {
         krocw_ = OilWaterLawT::twoPhaseSatKrn(*oilWaterParams_, Swl_);
 
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
+        EnsureFinalized :: finalize();
     }
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
     const GasOilParams& gasOilParams() const
-    { assertFinalized_(); return *gasOilParams_; }
+    { EnsureFinalized::check(); return *gasOilParams_; }
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
     GasOilParams& gasOilParams()
-    { assertFinalized_(); return *gasOilParams_; }
+    { EnsureFinalized::check(); return *gasOilParams_; }
 
     /*!
      * \brief Set the parameter object for the gas-oil twophase law.
@@ -95,13 +90,13 @@ public:
      * \brief The parameter object for the oil-water twophase law.
      */
     const OilWaterParams& oilWaterParams() const
-    { assertFinalized_(); return *oilWaterParams_; }
+    { EnsureFinalized::check(); return *oilWaterParams_; }
 
     /*!
      * \brief The parameter object for the oil-water twophase law.
      */
     OilWaterParams& oilWaterParams()
-    { assertFinalized_(); return *oilWaterParams_; }
+    { EnsureFinalized::check(); return *oilWaterParams_; }
 
     /*!
      * \brief Set the parameter object for the oil-water twophase law.
@@ -127,14 +122,14 @@ public:
      * \brief Return the saturation of "connate" water.
      */
     Scalar Swl() const
-    { assertFinalized_(); return Swl_; }
+    { EnsureFinalized::check(); return Swl_; }
 
     /*!
      * \brief Return the oil relperm for the oil-water system at the connate water
      *        saturation.
      */
     Scalar krocw() const
-    { assertFinalized_(); return krocw_; }
+    { EnsureFinalized::check(); return krocw_; }
 
     /*!
      * \brief Set the exponent of the extended Stone 1 model.
@@ -146,19 +141,9 @@ public:
      * \brief Return the exponent of the extended Stone 1 model.
      */
     Scalar eta() const
-    { assertFinalized_(); return eta_; }
+    { EnsureFinalized::check(); return eta_; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;
 

--- a/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
@@ -42,11 +42,13 @@ namespace Opm {
  * the twophase capillary pressure laws.
  */
 template<class Traits, class GasOilParamsT, class OilWaterParamsT>
-class EclStone2MaterialParams
+class EclStone2MaterialParams : public EnsureFinalized
 {
     typedef typename Traits::Scalar Scalar;
     enum { numPhases = 3 };
 public:
+    using EnsureFinalized :: finalize;
+
     typedef GasOilParamsT GasOilParams;
     typedef OilWaterParamsT OilWaterParams;
 
@@ -55,32 +57,19 @@ public:
      */
     EclStone2MaterialParams()
     {
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
-    }
-
-    /*!
-     * \brief Finish the initialization of the parameter object.
-     */
-    void finalize()
-    {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
     const GasOilParams& gasOilParams() const
-    { assertFinalized_(); return *gasOilParams_; }
+    { EnsureFinalized::check(); return *gasOilParams_; }
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
     GasOilParams& gasOilParams()
-    { assertFinalized_(); return *gasOilParams_; }
+    { EnsureFinalized::check(); return *gasOilParams_; }
 
     /*!
      * \brief Set the parameter object for the gas-oil twophase law.
@@ -92,13 +81,13 @@ public:
      * \brief The parameter object for the oil-water twophase law.
      */
     const OilWaterParams& oilWaterParams() const
-    { assertFinalized_(); return *oilWaterParams_; }
+    { EnsureFinalized::check(); return *oilWaterParams_; }
 
     /*!
      * \brief The parameter object for the oil-water twophase law.
      */
     OilWaterParams& oilWaterParams()
-    { assertFinalized_(); return *oilWaterParams_; }
+    { EnsureFinalized::check(); return *oilWaterParams_; }
 
     /*!
      * \brief Set the parameter object for the oil-water twophase law.
@@ -124,19 +113,9 @@ public:
      * \brief Return the saturation of "connate" water.
      */
     Scalar Swl() const
-    { assertFinalized_(); return Swl_; }
+    { EnsureFinalized::check(); return Swl_; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;
 

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
@@ -31,6 +31,8 @@
 #include <cassert>
 #include <memory>
 
+#include <opm/material/common/EnsureFinalized.hpp>
+
 namespace Opm {
 enum EclTwoPhaseApproach {
     EclTwoPhaseGasOil,
@@ -46,11 +48,14 @@ enum EclTwoPhaseApproach {
  * the twophase capillary pressure laws.
  */
 template<class Traits, class GasOilParamsT, class OilWaterParamsT>
-class EclTwoPhaseMaterialParams
+class EclTwoPhaseMaterialParams : public EnsureFinalized
 {
     typedef typename Traits::Scalar Scalar;
     enum { numPhases = 3 };
 public:
+    using EnsureFinalized :: finalize;
+
+
     typedef GasOilParamsT GasOilParams;
     typedef OilWaterParamsT OilWaterParams;
 
@@ -59,19 +64,6 @@ public:
      */
     EclTwoPhaseMaterialParams()
     {
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
-    }
-
-    /*!
-     * \brief Finish the initialization of the parameter object.
-     */
-    void finalize()
-    {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     void setApproach(EclTwoPhaseApproach newApproach)
@@ -84,13 +76,13 @@ public:
      * \brief The parameter object for the gas-oil twophase law.
      */
     const GasOilParams& gasOilParams() const
-    { assertFinalized_(); return *gasOilParams_; }
+    { EnsureFinalized::check(); return *gasOilParams_; }
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
     GasOilParams& gasOilParams()
-    { assertFinalized_(); return *gasOilParams_; }
+    { EnsureFinalized::check(); return *gasOilParams_; }
 
     /*!
      * \brief Set the parameter object for the gas-oil twophase law.
@@ -102,13 +94,13 @@ public:
      * \brief The parameter object for the oil-water twophase law.
      */
     const OilWaterParams& oilWaterParams() const
-    { assertFinalized_(); return *oilWaterParams_; }
+    { EnsureFinalized::check(); return *oilWaterParams_; }
 
     /*!
      * \brief The parameter object for the oil-water twophase law.
      */
     OilWaterParams& oilWaterParams()
-    { assertFinalized_(); return *oilWaterParams_; }
+    { EnsureFinalized::check(); return *oilWaterParams_; }
 
     /*!
      * \brief Set the parameter object for the oil-water twophase law.
@@ -117,16 +109,6 @@ public:
     { oilWaterParams_ = val; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     EclTwoPhaseApproach approach_;
 
     std::shared_ptr<GasOilParams> gasOilParams_;

--- a/opm/material/fluidmatrixinteractions/EffToAbsLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EffToAbsLawParams.hpp
@@ -29,6 +29,8 @@
 
 #include <cassert>
 
+#include <opm/material/common/EnsureFinalized.hpp>
+
 namespace Opm {
 /*!
  * \ingroup FluidMatrixInteractions
@@ -52,10 +54,6 @@ public:
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             residualSaturation_[phaseIdx] = 0.0;
-
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     /*!
@@ -69,23 +67,19 @@ public:
             sumResidualSaturations_ += residualSaturation_[phaseIdx];
 
         EffLawParams::finalize();
-
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     /*!
      * \brief Return the residual saturation of a phase.
      */
     Scalar residualSaturation(unsigned phaseIdx) const
-    { assertFinalized_(); return residualSaturation_[phaseIdx]; }
+    { EnsureFinalized::check(); return residualSaturation_[phaseIdx]; }
 
     /*!
      * \brief Return the sum of the residual saturations.
      */
     Scalar sumResidualSaturations() const
-    { assertFinalized_(); return sumResidualSaturations_; }
+    { EnsureFinalized::check(); return sumResidualSaturations_; }
 
     /*!
      * \brief Set the residual saturation of a phase.
@@ -94,15 +88,6 @@ public:
     { residualSaturation_[phaseIdx] = value; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
 
     Scalar residualSaturation_[numPhases];
     Scalar sumResidualSaturations_;

--- a/opm/material/fluidmatrixinteractions/LinearMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/LinearMaterialParams.hpp
@@ -29,6 +29,8 @@
 
 #include <cassert>
 
+#include <opm/material/common/EnsureFinalized.hpp>
+
 namespace Opm {
 
 /*!
@@ -36,13 +38,15 @@ namespace Opm {
  *        material material.
  */
 template<class TraitsT>
-class LinearMaterialParams
+class LinearMaterialParams : public EnsureFinalized
 {
     enum { numPhases = TraitsT::numPhases };
 
     typedef typename TraitsT::Scalar Scalar;
 
 public:
+    using EnsureFinalized :: finalize;
+
     typedef TraitsT Traits;
 
     /*!
@@ -56,21 +60,6 @@ public:
             setPcMinSat(phaseIdx, 0.0);
             setPcMaxSat(phaseIdx, 0.0);
         }
-
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
-    }
-
-    /*!
-     * \brief Calculate all dependent quantities once the independent
-     *        quantities of the parameter object have been set.
-     */
-    void finalize()
-    {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     /*!
@@ -79,7 +68,7 @@ public:
      * This means \f$p_{c\alpha}\f$ at \f$S_\alpha=0\f$.
      */
     Scalar pcMinSat(unsigned phaseIdx) const
-    { assertFinalized_();return pcMinSat_[phaseIdx]; }
+    { EnsureFinalized::check();return pcMinSat_[phaseIdx]; }
 
     /*!
      * \brief Set the relative phase pressure at the minimum saturation of a phase.
@@ -95,7 +84,7 @@ public:
      * This means \f$p_{c\alpha}\f$ at \f$S_\alpha=1\f$.
      */
     Scalar pcMaxSat(unsigned phaseIdx) const
-    { assertFinalized_(); return pcMaxSat_[phaseIdx]; }
+    { EnsureFinalized::check(); return pcMaxSat_[phaseIdx]; }
 
     /*!
      * \brief Set the relative phase pressure at the maximum saturation of a phase.
@@ -106,16 +95,6 @@ public:
     { pcMaxSat_[phaseIdx] = val; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     Scalar pcMaxSat_[numPhases];
     Scalar pcMinSat_[numPhases];
 };

--- a/opm/material/fluidmatrixinteractions/ParkerLenhardParams.hpp
+++ b/opm/material/fluidmatrixinteractions/ParkerLenhardParams.hpp
@@ -28,6 +28,7 @@
 #define OPM_PARKER_LENHARD_PARAMS_HPP
 
 #include <opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp>
+#include <opm/material/common/EnsureFinalized.hpp>
 
 #include <cassert>
 
@@ -42,9 +43,11 @@ class PLScanningCurve;
  *        model.
  */
 template <class TraitsT>
-class ParkerLenhardParams
+class ParkerLenhardParams : public EnsureFinalized
 {
 public:
+    using EnsureFinalized :: finalize;
+
     typedef typename TraitsT::Scalar Scalar;
     typedef Opm::RegularizedVanGenuchten<TraitsT> VanGenuchten;
     typedef typename VanGenuchten::Params VanGenuchtenParams;
@@ -55,44 +58,26 @@ public:
         currentSnr_ = 0;
         mdc_ = new ScanningCurve(/*Swr=*/0);
         pisc_ = csc_ = NULL;
-
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     ParkerLenhardParams(const ParkerLenhardParams& p)
+        : EnsureFinalized( p )
     {
         currentSnr_ = 0;
         SwrPc_ = p.SwrPc_;
         mdc_ = new ScanningCurve(SwrPc_);
         pisc_ = csc_ = NULL;
-
-#ifndef NDEBUG
-        finalized_ = p.finalized_;
-#endif
     }
 
     ~ParkerLenhardParams()
     { delete mdc_; }
 
     /*!
-     * \brief Calculate all dependent quantities once the independent
-     *        quantities of the parameter object have been set.
-     */
-    void finalize()
-    {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
-    }
-
-    /*!
      * \brief Returns the parameters of the main imbibition curve (which uses
      *        the van Genuchten capillary pressure model).
      */
     const VanGenuchtenParams& micParams() const
-    { assertFinalized_(); return *micParams_; }
+    { EnsureFinalized::check(); return *micParams_; }
 
     /*!
      * \brief Sets the parameters of the main imbibition curve (which uses
@@ -106,7 +91,7 @@ public:
      *        the van Genuchten capillary pressure model).
      */
     const VanGenuchtenParams& mdcParams() const
-    { assertFinalized_(); return *mdcParams_; }
+    { EnsureFinalized::check(); return *mdcParams_; }
 
     /*!
      * \brief Sets the parameters of the main drainage curve (which uses
@@ -119,7 +104,7 @@ public:
      * \brief Returns non-wetting phase residual saturation.
      */
     Scalar Snr() const
-    { assertFinalized_(); return Snr_; }
+    { EnsureFinalized::check(); return Snr_; }
 
     /*!
      * \brief Set the  non-wetting phase residual saturation.
@@ -131,13 +116,13 @@ public:
      * \brief Returns wetting phase residual saturation for the capillary pressure curve.
      */
     Scalar SwrPc() const
-    { assertFinalized_(); return SwrPc_; }
+    { EnsureFinalized::check(); return SwrPc_; }
 
     /*!
      * \brief Returns wetting phase residual saturation for the residual saturation curves.
      */
     Scalar SwrKr() const
-    { assertFinalized_(); return SwrKr_; }
+    { EnsureFinalized::check(); return SwrKr_; }
 
     /*!
      * \brief Set the wetting phase residual saturation for the
@@ -156,7 +141,7 @@ public:
      * \brief Returns the current effective residual saturation.
      */
     Scalar currentSnr() const
-    { assertFinalized_(); return currentSnr_; }
+    { EnsureFinalized::check(); return currentSnr_; }
 
     /*!
      * \brief Set the current effective residual saturation.
@@ -168,7 +153,7 @@ public:
      * \brief Returns the main drainage curve
      */
     ScanningCurve* mdc() const
-    { assertFinalized_(); return mdc_; }
+    { EnsureFinalized::check(); return mdc_; }
 
     /*!
      * \brief Set the main drainage curve.
@@ -180,7 +165,7 @@ public:
      * \brief Returns the primary imbibition scanning curve
      */
     ScanningCurve* pisc() const
-    { assertFinalized_(); return pisc_; }
+    { EnsureFinalized::check(); return pisc_; }
 
     /*!
      * \brief Set the primary imbibition scanning curve.
@@ -192,7 +177,7 @@ public:
      * \brief Returns the current scanning curve
      */
     ScanningCurve* csc() const
-    { assertFinalized_(); return csc_; }
+    { EnsureFinalized::check(); return csc_; }
 
     /*!
      * \brief Set the current scanning curve.
@@ -201,16 +186,6 @@ public:
     { csc_ = val; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     const VanGenuchtenParams* micParams_;
     const VanGenuchtenParams* mdcParams_;
     Scalar SwrPc_;

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -31,6 +31,8 @@
 #include <cassert>
 #include <cstddef>
 
+#include <opm/material/common/EnsureFinalized.hpp>
+
 namespace Opm {
 /*!
  * \ingroup FluidMatrixInteractions
@@ -39,7 +41,7 @@ namespace Opm {
  *        uses a table and piecewise constant interpolation.
  */
 template<class TraitsT>
-class PiecewiseLinearTwoPhaseMaterialParams
+class PiecewiseLinearTwoPhaseMaterialParams : public EnsureFinalized
 {
     typedef typename TraitsT::Scalar Scalar;
 
@@ -50,9 +52,6 @@ public:
 
     PiecewiseLinearTwoPhaseMaterialParams()
     {
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     /*!
@@ -61,9 +60,7 @@ public:
      */
     void finalize()
     {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
+        EnsureFinalized :: finalize ();
 
         // revert the order of the sampling points if they were given
         // in reverse direction.
@@ -83,19 +80,19 @@ public:
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
     const ValueVector& SwKrwSamples() const
-    { assertFinalized_(); return SwKrwSamples_; }
+    { EnsureFinalized::check(); return SwKrwSamples_; }
 
     /*!
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
     const ValueVector& SwKrnSamples() const
-    { assertFinalized_(); return SwKrnSamples_; }
+    { EnsureFinalized::check(); return SwKrnSamples_; }
 
     /*!
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
     const ValueVector& SwPcwnSamples() const
-    { assertFinalized_(); return SwPcwnSamples_; }
+    { EnsureFinalized::check(); return SwPcwnSamples_; }
 
     /*!
      * \brief Return the sampling points for the capillary pressure curve.
@@ -103,7 +100,7 @@ public:
      * This curve is assumed to depend on the wetting phase saturation
      */
     const ValueVector& pcnwSamples() const
-    { assertFinalized_(); return pcwnSamples_; }
+    { EnsureFinalized::check(); return pcwnSamples_; }
 
     /*!
      * \brief Set the sampling points for the capillary pressure curve.
@@ -130,7 +127,7 @@ public:
      * This curve is assumed to depend on the wetting phase saturation
      */
     const ValueVector& krwSamples() const
-    { assertFinalized_(); return krwSamples_; }
+    { EnsureFinalized::check(); return krwSamples_; }
 
     /*!
      * \brief Set the sampling points for the relative permeability
@@ -158,7 +155,7 @@ public:
      * This curve is assumed to depend on the wetting phase saturation
      */
     const ValueVector& krnSamples() const
-    { assertFinalized_(); return krnSamples_; }
+    { EnsureFinalized::check(); return krnSamples_; }
 
     /*!
      * \brief Set the sampling points for the relative permeability
@@ -180,16 +177,6 @@ public:
     }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     void swapOrder_(ValueVector& swValues, ValueVector& values) const
     {
         if (swValues.front() > values.back()) {

--- a/opm/material/fluidmatrixinteractions/RegularizedBrooksCoreyParams.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedBrooksCoreyParams.hpp
@@ -34,6 +34,8 @@
 
 #include <cassert>
 
+#include <opm/material/common/EnsureFinalized.hpp>
+
 namespace Opm {
 /*!
  * \ingroup FluidMatrixInteractions
@@ -55,9 +57,6 @@ public:
         : BrooksCoreyParams()
         , pcnwLowSw_(0.01)
     {
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     RegularizedBrooksCoreyParams(Scalar entryPressure, Scalar lambda)
@@ -77,10 +76,6 @@ public:
         pcnwSlopeLow_ = dPcnw_dSw_(pcnwLowSw_);
         pcnwHigh_ = BrooksCorey::twoPhaseSatPcnw(*this, 1.0);
         pcnwSlopeHigh_ = dPcnw_dSw_(1.0);
-
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     /*!
@@ -88,14 +83,14 @@ public:
      *        capillary pressure is regularized.
      */
     Scalar pcnwLowSw() const
-    { assertFinalized_(); return pcnwLowSw_; }
+    { EnsureFinalized::check(); return pcnwLowSw_; }
 
     /*!
      * \brief Return the capillary pressure at the low threshold
      *        saturation of the wetting phase.
      */
     Scalar pcnwLow() const
-    { assertFinalized_(); return pcnwLow_; }
+    { EnsureFinalized::check(); return pcnwLow_; }
 
     /*!
      * \brief Return the slope capillary pressure curve if Sw is
@@ -104,7 +99,7 @@ public:
      * For this case, we extrapolate the curve using a straight line.
      */
     Scalar pcnwSlopeLow() const
-    { assertFinalized_(); return pcnwSlopeLow_; }
+    { EnsureFinalized::check(); return pcnwSlopeLow_; }
 
     /*!
      * \brief Set the threshold saturation below which the capillary
@@ -121,7 +116,7 @@ public:
      *        saturation of the wetting phase.
      */
     Scalar pcnwHigh() const
-    { assertFinalized_(); return pcnwHigh_; }
+    { EnsureFinalized::check(); return pcnwHigh_; }
 
     /*!
      * \brief Return the slope capillary pressure curve if Sw is
@@ -130,19 +125,9 @@ public:
      * For this case, we extrapolate the curve using a straight line.
      */
     Scalar pcnwSlopeHigh() const
-    { assertFinalized_(); return pcnwSlopeHigh_; }
+    { EnsureFinalized::check(); return pcnwSlopeHigh_; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     Scalar dPcnw_dSw_(Scalar Sw) const
     {
         // use finite differences to calculate the derivative w.r.t. Sw of the

--- a/opm/material/fluidmatrixinteractions/RegularizedVanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedVanGenuchtenParams.hpp
@@ -50,6 +50,8 @@ class RegularizedVanGenuchtenParams : public VanGenuchtenParams<TraitsT>
     typedef Opm::VanGenuchten<TraitsT> VanGenuchten;
 
 public:
+    using Parent :: finalize;
+
     typedef TraitsT Traits;
 
     RegularizedVanGenuchtenParams()
@@ -83,10 +85,6 @@ public:
         pcnwHighSpline_.set(pcnwHighSw_, 1.0, // x0, x1
                             pcnwHigh_, 0, // y0, y1
                             mThreshold, pcnwSlopeHigh_); // m0, m1
-
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     /*!
@@ -94,14 +92,14 @@ public:
      *        capillary pressure is regularized.
      */
     Scalar pcnwLowSw() const
-    { assertFinalized_(); return pcnwLowSw_; }
+    { EnsureFinalized::check(); return pcnwLowSw_; }
 
     /*!
      * \brief Return the capillary pressure at the low threshold
      *        saturation of the wetting phase.
      */
     Scalar pcnwLow() const
-    { assertFinalized_(); return pcnwLow_; }
+    { EnsureFinalized::check(); return pcnwLow_; }
 
     /*!
      * \brief Return the slope capillary pressure curve if Sw is
@@ -110,7 +108,7 @@ public:
      * For this case, we extrapolate the curve using a straight line.
      */
     Scalar pcnwSlopeLow() const
-    { assertFinalized_(); return pcnwSlopeLow_; }
+    { EnsureFinalized::check(); return pcnwSlopeLow_; }
 
     /*!
      * \brief Set the threshold saturation below which the capillary
@@ -124,21 +122,21 @@ public:
      *        capillary pressure is regularized.
      */
     Scalar pcnwHighSw() const
-    { assertFinalized_(); return pcnwHighSw_; }
+    { EnsureFinalized::check(); return pcnwHighSw_; }
 
     /*!
      * \brief Return the capillary pressure at the high threshold
      *        saturation of the wetting phase.
      */
     Scalar pcnwHigh() const
-    { assertFinalized_(); return pcnwHigh_; }
+    { EnsureFinalized::check(); return pcnwHigh_; }
 
     /*!
      * \brief Return the spline curve which ought to be used between
      *        the upper threshold saturation and 1.
      */
     const Spline<Scalar>& pcnwHighSpline() const
-    { assertFinalized_(); return pcnwHighSpline_; }
+    { EnsureFinalized::check(); return pcnwHighSpline_; }
 
     /*!
      * \brief Return the slope capillary pressure curve if Sw is
@@ -147,7 +145,7 @@ public:
      * For this case, we extrapolate the curve using a straight line.
      */
     Scalar pcnwSlopeHigh() const
-    { assertFinalized_(); return pcnwSlopeHigh_; }
+    { EnsureFinalized::check(); return pcnwSlopeHigh_; }
 
     /*!
      * \brief Set the threshold saturation below which the capillary
@@ -157,16 +155,6 @@ public:
     { pcnwHighSw_ = value; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     Scalar dPcnw_dSw_(Scalar Sw) const
     {
         // use finite differences to calculate the derivative w.r.t. Sw of the

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterialParams.hpp
@@ -28,7 +28,7 @@
 #define OPM_SPLINE_TWO_PHASE_MATERIAL_PARAMS_HPP
 
 #include <opm/material/common/Spline.hpp>
-#include <opm/material/common/AssertFinalized.hpp>
+#include <opm/material/common/EnsureFinalized.hpp>
 
 #include <vector>
 #include <cassert>
@@ -41,13 +41,11 @@ namespace Opm {
  *        uses a table and spline-based interpolation.
  */
 template<class TraitsT>
-class SplineTwoPhaseMaterialParams : public AssertFinalized
+class SplineTwoPhaseMaterialParams : public EnsureFinalized
 {
     typedef typename TraitsT::Scalar Scalar;
-protected:
-    using AssertFinalized :: assertFinalized_;
 public:
-    using AssertFinalized :: finalize;
+    using EnsureFinalized :: finalize;
 
 public:
     typedef std::vector<Scalar> SamplePoints;
@@ -66,7 +64,7 @@ public:
      * This curve is assumed to depend on the wetting phase saturation
      */
     const Spline& pcnwSpline() const
-    { assertFinalized_(); return pcwnSpline_; }
+    { EnsureFinalized::check(); return pcwnSpline_; }
 
     /*!
      * \brief Set the sampling points for the capillary pressure curve.
@@ -88,7 +86,7 @@ public:
      * This curve is assumed to depend on the wetting phase saturation
      */
     const Spline& krwSpline() const
-    { assertFinalized_(); return krwSpline_; }
+    { EnsureFinalized::check(); return krwSpline_; }
 
     /*!
      * \brief Set the sampling points for the relative permeability
@@ -111,7 +109,7 @@ public:
      * This curve is assumed to depend on the wetting phase saturation
      */
     const Spline& krnSpline() const
-    { assertFinalized_(); return krnSpline_; }
+    { EnsureFinalized::check(); return krnSpline_; }
 
     /*!
      * \brief Set the sampling points for the relative permeability

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterialParams.hpp
@@ -28,6 +28,7 @@
 #define OPM_SPLINE_TWO_PHASE_MATERIAL_PARAMS_HPP
 
 #include <opm/material/common/Spline.hpp>
+#include <opm/material/common/AssertFinalized.hpp>
 
 #include <vector>
 #include <cassert>
@@ -40,9 +41,13 @@ namespace Opm {
  *        uses a table and spline-based interpolation.
  */
 template<class TraitsT>
-class SplineTwoPhaseMaterialParams
+class SplineTwoPhaseMaterialParams : public AssertFinalized
 {
     typedef typename TraitsT::Scalar Scalar;
+protected:
+    using AssertFinalized :: assertFinalized_;
+public:
+    using AssertFinalized :: finalize;
 
 public:
     typedef std::vector<Scalar> SamplePoints;
@@ -53,20 +58,6 @@ public:
 
     SplineTwoPhaseMaterialParams()
     {
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
-    }
-
-    /*!
-     * \brief Calculate all dependent quantities once the independent
-     *        quantities of the parameter object have been set.
-     */
-    void finalize()
-    {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     /*!
@@ -137,16 +128,6 @@ public:
     }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     Spline SwSpline_;
     Spline pcwnSpline_;
     Spline krwSpline_;

--- a/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchtenParams.hpp
@@ -36,6 +36,8 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
 
+#include <opm/material/common/EnsureFinalized.hpp>
+
 #include <cassert>
 
 namespace Opm {
@@ -50,9 +52,11 @@ namespace Opm {
  * model-specific.
  */
 template<class TraitsT>
-class ThreePhaseParkerVanGenuchtenParams
+class ThreePhaseParkerVanGenuchtenParams : public EnsureFinalized
 {
 public:
+    using EnsureFinalized :: finalize;
+
     typedef TraitsT Traits;
     typedef typename Traits::Scalar Scalar;
 
@@ -60,20 +64,6 @@ public:
     {
         betaNW_ = 1.0;
         betaGN_ = 1.0;
-
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
-    }
-
-    /*!
-     * \brief Finish the initialization of the parameter object.
-     */
-    void finalize()
-    {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
     }
 
     /*!
@@ -81,7 +71,7 @@ public:
      *        curve.
      */
     Scalar vgAlpha() const
-    { assertFinalized_(); return vgAlpha_; }
+    { EnsureFinalized::check(); return vgAlpha_; }
 
     /*!
      * \brief Set the \f$\alpha\f$ shape parameter of van Genuchten's
@@ -95,7 +85,7 @@ public:
      *        curve.
      */
     Scalar vgM() const
-    { assertFinalized_(); return vgM_; }
+    { EnsureFinalized::check(); return vgM_; }
 
     /*!
      * \brief Set the \f$m\f$ shape parameter of van Genuchten's
@@ -111,7 +101,7 @@ public:
      *        curve.
      */
     Scalar vgN() const
-    { assertFinalized_(); return vgN_; }
+    { EnsureFinalized::check(); return vgN_; }
 
     /*!
      * \brief Set the \f$n\f$ shape parameter of van Genuchten's
@@ -126,7 +116,7 @@ public:
      * \brief Return the residual wetting saturation.
      */
     Scalar Swr() const
-    { assertFinalized_(); return Swr_; }
+    { EnsureFinalized::check(); return Swr_; }
 
     /*!
      * \brief Set the residual wetting saturation.
@@ -138,7 +128,7 @@ public:
      * \brief Return the residual non-wetting saturation.
      */
     Scalar Snr() const
-    { assertFinalized_(); return Snr_; }
+    { EnsureFinalized::check(); return Snr_; }
 
     /*!
      * \brief Set the residual non-wetting saturation.
@@ -150,7 +140,7 @@ public:
      * \brief Return the residual gas saturation.
      */
     Scalar Sgr() const
-    { assertFinalized_(); return Sgr_; }
+    { EnsureFinalized::check(); return Sgr_; }
 
     /*!
      * \brief Set the residual gas saturation.
@@ -159,7 +149,7 @@ public:
     { Sgr_ = input; }
 
     Scalar Swrx() const
-    { assertFinalized_(); return Swrx_; }
+    { EnsureFinalized::check(); return Swrx_; }
 
     /*!
      * \brief Set the residual gas saturation.
@@ -180,10 +170,10 @@ public:
      * \brief Return the values for the beta scaling parameters of capillary pressure between the phases
      */
     Scalar betaNW() const
-    { assertFinalized_(); return betaNW_; }
+    { EnsureFinalized::check(); return betaNW_; }
 
     Scalar betaGN() const
-    { assertFinalized_(); return betaGN_; }
+    { EnsureFinalized::check(); return betaGN_; }
 
     /*!
      * \brief defines if residual n-phase saturation should be regarded in its relative permeability.
@@ -194,7 +184,7 @@ public:
      * \brief Calls if residual n-phase saturation should be regarded in its relative permeability.
      */
     bool krRegardsSnr() const
-    { assertFinalized_(); return krRegardsSnr_; }
+    { EnsureFinalized::check(); return krRegardsSnr_; }
 
     void checkDefined() const
     {
@@ -211,16 +201,6 @@ public:
     }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     Scalar vgAlpha_;
     Scalar vgM_;
     Scalar vgN_;

--- a/opm/material/fluidmatrixinteractions/VanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/VanGenuchtenParams.hpp
@@ -29,6 +29,8 @@
 
 #include <cassert>
 
+#include <opm/material/common/EnsureFinalized.hpp>
+
 namespace Opm {
 /*!
  * \ingroup FluidMatrixInteractions
@@ -41,18 +43,17 @@ namespace Opm {
  * set independently.
  */
 template<class TraitsT>
-class VanGenuchtenParams
+class VanGenuchtenParams : public EnsureFinalized
 {
     typedef typename TraitsT::Scalar Scalar;
 
 public:
+    using EnsureFinalized :: finalize;
+
     typedef TraitsT Traits;
 
     VanGenuchtenParams()
     {
-#ifndef NDEBUG
-        finalized_ = false;
-#endif
     }
 
     VanGenuchtenParams(Scalar alphaParam, Scalar nParam)
@@ -63,22 +64,11 @@ public:
     }
 
     /*!
-     * \brief Calculate all dependent quantities once the independent
-     *        quantities of the parameter object have been set.
-     */
-    void finalize()
-    {
-#ifndef NDEBUG
-        finalized_ = true;
-#endif
-    }
-
-    /*!
      * \brief Return the \f$\alpha\f$ shape parameter of van Genuchten's
      *        curve.
      */
     Scalar vgAlpha() const
-    { assertFinalized_(); return vgAlpha_; }
+    { EnsureFinalized::check(); return vgAlpha_; }
 
     /*!
      * \brief Set the \f$\alpha\f$ shape parameter of van Genuchten's
@@ -92,7 +82,7 @@ public:
      *        curve.
      */
     Scalar vgM() const
-    { assertFinalized_(); return vgM_; }
+    { EnsureFinalized::check(); return vgM_; }
 
     /*!
      * \brief Set the \f$m\f$ shape parameter of van Genuchten's
@@ -108,7 +98,7 @@ public:
      *        curve.
      */
     Scalar vgN() const
-    { assertFinalized_(); return vgN_; }
+    { EnsureFinalized::check(); return vgN_; }
 
     /*!
      * \brief Set the \f$n\f$ shape parameter of van Genuchten's
@@ -120,16 +110,6 @@ public:
     { vgN_ = n; vgM_ = 1 - 1/vgN_; }
 
 private:
-#ifndef NDEBUG
-    void assertFinalized_() const
-    { assert(finalized_); }
-
-    bool finalized_;
-#else
-    void assertFinalized_() const
-    { }
-#endif
-
     Scalar vgAlpha_;
     Scalar vgM_;
     Scalar vgN_;


### PR DESCRIPTION
This PR moves the assertFinalized check to a base class to avoid code duplication and allow for easy toggle via preproc variable. 

Before I change all remaining headers I wanted to confirm that this solution is ok for everybody. 