### PR TITLE
[Discussion] handle a few NaN situation when evaluating saturationPressure()

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -548,6 +548,14 @@ public:
 
         // use the tabulated saturation pressure function to get a pretty good initial value
         Evaluation pSat = saturationPressure_[regionIdx].eval(Rv, /*extrapolate=*/true);
+
+        if ( Opm::MathToolbox<Evaluation>::isnan(pSat) ) {
+            std::stringstream errlog;
+            errlog << "Find initial gas saturation pressure with NaN value for X_g^O = " << Rv;
+            OpmLog::problem("wetgas NaN initial saturationpressure", errlog.str());
+            OPM_THROW_NOLOG(NumericalProblem, errlog.str());
+        }
+
         const Evaluation& eps = pSat*1e-11;
 
         // Newton method to do the remaining work. If the initial
@@ -558,6 +566,14 @@ public:
             const Evaluation& fPrime = ((saturatedOilVaporizationFactor(regionIdx, temperature, pSat + eps) - Rv) - f)/eps;
 
             const Evaluation& delta = f/fPrime;
+
+            if ( Opm::MathToolbox<Evaluation>::isnan(delta) ) {
+                 std::stringstream errlog;
+                 errlog << "Obtain delta with NaN value for X_g^O = " << Rv << " in the " << i << "th iteration during finding saturation pressure iteratively";
+                 OpmLog::problem("wetgas NaN delta value", errlog.str());
+                 OPM_THROW_NOLOG(NumericalProblem, errlog.str());
+            }
+
             pSat -= delta;
 
             if (std::abs(Toolbox::scalarValue(delta)) < std::abs(Toolbox::scalarValue(pSat)) * 1e-10)


### PR DESCRIPTION
With model 2 (or with some other models with testing branch), when outputting the bubble/dew-point pressure, the evaluation of saturation pressure easily encounters assert failure. The reason is that some NaN values are generated during the calculation. 

This PR tries to catch the NaN values generated during the process and avoids to halt the whole simulation due to assert failures without investigate deeper causes. 

Feel free to close it if it is really not the way the thing should be done.   I am really not very familiar with this part and the output module.

Please suggest if it is still workable. 
 