### PR TITLE
FluidStateCompositionModules: fix some compiler warning

### DIFF
--- a/opm/material/fluidstates/FluidStateCompositionModules.hpp
+++ b/opm/material/fluidstates/FluidStateCompositionModules.hpp
@@ -54,6 +54,10 @@ class FluidStateExplicitCompositionModule
 public:
     FluidStateExplicitCompositionModule()
     {
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+            for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+                moleFraction_[phaseIdx][compIdx] = 0.0;
+
         Valgrind::SetDefined(moleFraction_);
         Valgrind::SetUndefined(averageMolarMass_);
         Valgrind::SetUndefined(sumMoleFractions_);


### PR DESCRIPTION
that warning was correct, but bogus: while this data was indeed used without initialization, using the mass composition of a phase before fully specifying the molar composition is incorrect and would have trigger a valgrind complaint. (valgrind will still complain after that patch.)

this patch should not affect performance because fluid states are usually only created at initialization.