### PR TITLE
[cleanup] make code compile when Scalar is non POD type.

### DIFF
--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -174,7 +174,7 @@ public:
 
         Scalar x1 = xPos_[segmentIdx];
         Scalar x2 = xPos_[segmentIdx + 1];
-        return segmentIdx + (x - x1)/(x2 - x1);
+        return Scalar(segmentIdx) + (x - x1)/(x2 - x1);
     }
 
     /*!
@@ -214,7 +214,7 @@ public:
         assert(y1 <= y || (extrapolate && lowerIdx == 0));
         assert(y <= y2 || (extrapolate && lowerIdx == colSamplePoints.size() - 2));
 
-        return lowerIdx + (y - y1)/(y2 - y1);
+        return Scalar(lowerIdx) + (y - y1)/(y2 - y1);
     }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -515,7 +515,7 @@ public:
         typedef Opm::MathToolbox<Evaluation> Toolbox;
 
         const auto& RsTable = saturatedGasDissolutionFactorTable_[regionIdx];
-        static constexpr Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon()*1e6;
+        const Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon()*1e6;
 
         // use the saturation pressure function to get a pretty good initial value
         Evaluation pSat = saturationPressure_[regionIdx].eval(Rs, /*extrapolate=*/true);
@@ -569,12 +569,12 @@ private:
         // create the function representing saturation pressure depending of the mass
         // fraction in gas
         size_t n = gasDissolutionFac.numSamples();
-        Scalar delta = (gasDissolutionFac.xMax() - gasDissolutionFac.xMin())/(n + 1);
+        Scalar delta = (gasDissolutionFac.xMax() - gasDissolutionFac.xMin())/Scalar(n + 1);
 
         SamplingPoints pSatSamplePoints;
         Scalar Rs = 0;
         for (size_t i=0; i <= n; ++ i) {
-            Scalar pSat = gasDissolutionFac.xMin() + i*delta;
+            Scalar pSat = gasDissolutionFac.xMin() + Scalar(i)*delta;
             Rs = saturatedGasDissolutionFactor(regionIdx,
                                                /*temperature=*/Scalar(1e30),
                                                pSat);

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -543,7 +543,7 @@ public:
         typedef Opm::MathToolbox<Evaluation> Toolbox;
 
         const auto& RvTable = saturatedOilVaporizationFactorTable_[regionIdx];
-        static constexpr Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon()*1e6;
+        const Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon()*1e6;
 
         // use the tabulated saturation pressure function to get a pretty good initial value
         Evaluation pSat = saturationPressure_[regionIdx].eval(Rv, /*extrapolate=*/true);
@@ -597,12 +597,12 @@ private:
         // create the taublated function representing saturation pressure depending of
         // Rv
         size_t n = oilVaporizationFac.numSamples();
-        Scalar delta = (oilVaporizationFac.xMax() - oilVaporizationFac.xMin())/(n + 1);
+        Scalar delta = (oilVaporizationFac.xMax() - oilVaporizationFac.xMin())/Scalar(n + 1);
 
         SamplingPoints pSatSamplePoints;
         Scalar Rv = 0;
         for (size_t i = 0; i <= n; ++ i) {
-            Scalar pSat = oilVaporizationFac.xMin() + i*delta;
+            Scalar pSat = oilVaporizationFac.xMin() + Scalar(i)*delta;
             Rv = saturatedOilVaporizationFactor(regionIdx, /*temperature=*/Scalar(1e30), pSat);
 
             Pair val(Rv, pSat);


### PR DESCRIPTION
This PR fixes some minor casting issues when Scalar is non POD type.