### PR TITLE
limit the reduction due to VAPPARS to a factor of 1000

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -496,7 +496,7 @@ public:
         if (vapPar2_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
             static const Scalar sqrtEps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
             const Evaluation& So = Opm::max(oilSaturation, sqrtEps);
-            tmp *= Opm::pow(So/maxOilSaturation, vapPar2_);
+            tmp *= Opm::max(1e-3, Opm::pow(So/maxOilSaturation, vapPar2_));
         }
 
         return tmp;

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -494,8 +494,8 @@ public:
         // keyword)
         maxOilSaturation = std::min(maxOilSaturation, Scalar(1.0));
         if (vapPar2_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
-            static const Scalar sqrtEps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
-            const Evaluation& So = Opm::max(oilSaturation, sqrtEps);
+            static const Scalar eps = 0.001;
+            const Evaluation& So = Opm::max(oilSaturation, eps);
             tmp *= Opm::max(1e-3, Opm::pow(So/maxOilSaturation, vapPar2_));
         }
 

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -520,7 +520,7 @@ public:
         if (vapPar1_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
             static const Scalar sqrtEps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
             const Evaluation& So = Opm::max(oilSaturation, sqrtEps);
-            tmp *= Opm::pow(So/maxOilSaturation, vapPar1_);
+            tmp *= Opm::max(1e-3, Opm::pow(So/maxOilSaturation, vapPar1_));
         }
 
         return tmp;

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -518,8 +518,8 @@ public:
         // keyword)
         maxOilSaturation = std::min(maxOilSaturation, Scalar(1.0));
         if (vapPar1_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
-            static const Scalar sqrtEps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
-            const Evaluation& So = Opm::max(oilSaturation, sqrtEps);
+            static const Scalar eps = 0.001;
+            const Evaluation& So = Opm::max(oilSaturation, eps);
             tmp *= Opm::max(1e-3, Opm::pow(So/maxOilSaturation, vapPar1_));
         }
 


### PR DESCRIPTION
a factor of 100 should be enough physically and the numerical stability is quite a bit better. This applies in particular, because the whole concept of VAPPARS is a staggeringly ugly hack from the outset.