### PR TITLE
add mpi to debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: build-essential, debhelper (>= 9), libboost-filesystem-dev,
                libdune-common-dev, libdune-istl-dev, cmake, bc,
                libecl-dev, git, zlib1g-dev, libtool, doxygen,
                texlive-latex-extra, texlive-latex-recommended, ghostscript,
-               libopm-parser-dev, libboost-iostreams-dev
+               libopm-parser-dev, libboost-iostreams-dev, mpi-default-dev
 Standards-Version: 3.9.2
 Section: libs
 Homepage: http://opm-project.org


### PR DESCRIPTION
reorganizations in the build system made this rear its head. we get HAVE_MPI in the config file for opm-material, and it will be off, which is inconsistent with other modules.