### PR TITLE
fixed: build with MPI

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ override_dh_auto_build:
 
 # consider using -DUSE_VERSIONED_DIR=ON if backporting
 override_dh_auto_configure:
-	dh_auto_configure --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRIP_DEBUGGING_SYMBOLS=ON -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-material1 -DUSE_RUNPATH=OFF -DWITH_NATIVE=OFF
+	dh_auto_configure --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRIP_DEBUGGING_SYMBOLS=ON -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-material1 -DUSE_RUNPATH=OFF -DWITH_NATIVE=OFF -DUSE_MPI=1
 
 override_dh_auto_install:
 	dh_auto_install -- install-html


### PR DESCRIPTION
opm-material exports MPI related settings in its config file,
this does not really make sense, but enable in packaging for now.