### PR TITLE
disable high performance mpi transport in debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends: build-essential, debhelper (>= 9), libboost-filesystem-dev,
                libdune-common-dev, libdune-istl-dev, cmake, bc,
                libecl-dev, git, zlib1g-dev, libtool, doxygen,
                texlive-latex-extra, texlive-latex-recommended, ghostscript,
-               libopm-parser-dev, libboost-iostreams-dev, mpi-default-dev
+               libopm-parser-dev, libboost-iostreams-dev, mpi-default-dev,
+               mpi-default-bin
 Standards-Version: 3.9.2
 Section: libs
 Homepage: http://opm-project.org

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,7 @@
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
+export OMPI_MCA_plm_rsh_agent=/bin/false
 
 %:
 	dh $@ 


### PR DESCRIPTION
doesn't work inside pbuilder when building for stretch. this is already
there for the other mpi-enable modules, but was forgotten
here when MPI was turned on for the tests.