### PR TITLE
fix heatCapacity() and enthaply() of some components

### DIFF
--- a/opm/material/components/Air.hpp
+++ b/opm/material/components/Air.hpp
@@ -31,6 +31,7 @@
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/IdealGas.hpp>
 
+#include <opm/common/Unused.hpp>
 #include <opm/common/Exceptions.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
@@ -181,7 +182,7 @@ public:
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
-        return 1005*(temperature - 273.15);
+        return 1005.0*temperature;
     }
 
     /*!
@@ -201,7 +202,7 @@ public:
     {
         return
             gasEnthalpy(temperature, pressure)
-            - (IdealGas::R*temperature/molarMass()); // <- specific volume of an ideal gas
+            - (IdealGas::R*temperature/molarMass()); // <- pressure times specific volume of an ideal gas
     }
 
     /*!
@@ -246,29 +247,9 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasHeatCapacity(const Evaluation& temperature,
-                                      const Evaluation& /*pressure*/)
+                                      const Evaluation& pressure OPM_UNUSED)
     {
-        // scale temperature by reference temp of 100K
-        Evaluation phi = temperature/100;
-
-        Evaluation c_p =
-            0.661738E+01
-            -0.105885E+01 * phi
-            +0.201650E+00 * Opm::pow(phi,2.)
-            -0.196930E-01 * Opm::pow(phi,3.)
-            +0.106460E-02 * Opm::pow(phi,4.)
-            -0.303284E-04 * Opm::pow(phi,5.)
-            +0.355861E-06 * Opm::pow(phi,6.);
-        c_p +=
-            -0.549169E+01 * Opm::pow(phi,-1.)
-            +0.585171E+01* Opm::pow(phi,-2.)
-            -0.372865E+01* Opm::pow(phi,-3.)
-            +0.133981E+01* Opm::pow(phi,-4.)
-            -0.233758E+00* Opm::pow(phi,-5.)
-            +0.125718E-01* Opm::pow(phi,-6.);
-        c_p *= IdealGas::R / (molarMass() * 1000); // in J/mol/K * mol / kg / 1000 = kJ/kg/K
-
-        return  c_p;
+        return 1005.0;
     }
 };
 

--- a/opm/material/components/Dnapl.hpp
+++ b/opm/material/components/Dnapl.hpp
@@ -32,6 +32,8 @@
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
+#include <opm/common/Unused.hpp>
+
 namespace Opm {
 /*!
  * \ingroup Components
@@ -139,6 +141,20 @@ public:
     static Evaluation liquidEnthalpy(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         return 120.0/molarMass() * temperature; // [J/kg]
+    }
+
+    /*!
+     * \brief Specific isobaric heat capacity \f$[J/(kg K)]\f$ of pure
+     *        liquid TCE.
+     *
+     * \param temperature temperature of component in \f$\mathrm{[K]}\f$
+     * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
+     */
+    template <class Evaluation>
+    static Evaluation liquidHeatCapacity(const Evaluation& temperature OPM_UNUSED,
+                                         const Evaluation& pressure OPM_UNUSED)
+    {
+        return 120.0/molarMass();
     }
 
     /*!

--- a/opm/material/components/Lnapl.hpp
+++ b/opm/material/components/Lnapl.hpp
@@ -29,6 +29,8 @@
 
 #include "Component.hpp"
 
+#include <opm/common/Unused.hpp>
+
 namespace Opm {
 /*!
  * \ingroup Components
@@ -42,10 +44,16 @@ class LNAPL : public Component<Scalar, LNAPL<Scalar> >
 {
 public:
     /*!
-     * \brief A human readable name for the LNAPL.
+     * \brief A human readable name for the iso-octane.
      */
     static const char* name()
     { return "LNAPL"; }
+
+    /*!
+     * \brief The molar mass in \f$\mathrm{[kg/mol]}\f$ of iso-octane.
+     */
+    static Scalar molarMass()
+    { return 0.11423; }
 
     /*!
      * \brief Returns true iff the liquid phase is assumed to be compressible
@@ -61,7 +69,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidDensity(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
-    { return 890; }
+    { return 692.0; }
 
     /*!
      * \brief Rough estimate of the viscosity of oil in \f$\mathrm{[Pa*s]}\f$.
@@ -71,7 +79,51 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidViscosity(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
-    { return 8e-3; }
+    { return 0.005; }
+
+    /*!
+     * \brief The enthalpy of iso-octane at a given pressure and temperature \f$\mathrm{[J/kg]}\f$.
+     *
+     * We simply use the value of iso-octane here.
+     *
+     * \param temperature temperature of component in \f$\mathrm{[K]}\f$
+     * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
+     */
+    template <class Evaluation>
+    static Evaluation liquidEnthalpy(const Evaluation& temperature,
+                                     const Evaluation& pressure OPM_UNUSED)
+    {
+        return 240.0/molarMass() * temperature; // [J/kg]
+    }
+
+    /*!
+     * \brief Specific isobaric heat capacity \f$[J/(kg K)]\f$ of liquid iso-octane.
+     *
+     * We simply use the value of iso-octane here.
+     *
+     * \param temperature temperature of component in \f$\mathrm{[K]}\f$
+     * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
+     */
+    template <class Evaluation>
+    static Evaluation liquidHeatCapacity(const Evaluation& temperature OPM_UNUSED,
+                                         const Evaluation& pressure OPM_UNUSED)
+    {
+        return 240.0/molarMass();
+    }
+
+    /*!
+     * \brief Specific heat conductivity of liquid TCE \f$\mathrm{[W/(m K)]}\f$.
+     *
+     * \todo The value returned here is a guess which does not necessarily correspond to reality in any way!
+     *
+     * \param temperature temperature of component in \f$\mathrm{[K]}\f$
+     * \param pressure pressure of component in \f$\mathrm{[Pa]}\f$
+     */
+    template <class Evaluation>
+    static Evaluation liquidThermalConductivity(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
+    {
+        return 0.3; // TODO: guess
+    }
 };
 
 } // namespace Opm

--- a/opm/material/components/N2.hpp
+++ b/opm/material/components/N2.hpp
@@ -27,10 +27,12 @@
 #ifndef OPM_N2_HPP
 #define OPM_N2_HPP
 
+#include "Component.hpp"
+
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
-#include "Component.hpp"
+#include <opm/common/Unused.hpp>
 
 #include <cmath>
 
@@ -174,7 +176,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& temperature,
-                                  const Evaluation& /*pressure*/)
+                                  const Evaluation& pressure OPM_UNUSED)
     {
         // method of Joback
         const Scalar cpVapA = 31.15;
@@ -190,14 +192,6 @@ public:
                          (cpVapB/2 + temperature*
                           (cpVapC/3 + temperature*
                            (cpVapD/4))));
-
-//#warning NIST DATA STUPID INTERPOLATION
-//        Scalar T2 = 300.;
-//        Scalar T1 = 285.;
-//        Scalar h2 = 311200.;
-//        Scalar h1 = 295580.;
-//        Scalar h = h1+ (h2-h1) / (T2-T1) * (T-T1);
-//        return h ;
     }
 
     /*!
@@ -232,7 +226,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasHeatCapacity(const Evaluation& temperature,
-                                      const Evaluation& /*pressure*/)
+                                      const Evaluation& pressure OPM_UNUSED)
     {
         // method of Joback
         const Scalar cpVapA = 31.15;
@@ -244,11 +238,10 @@ public:
             1/molarMass()* // conversion from [J/(mol K)] to [J/(kg K)]
 
             cpVapA + temperature*
-            (cpVapB + temperature*
-             (cpVapC + temperature*
-              (cpVapD)));
+            (2.0*cpVapB + temperature*
+             (3.0*cpVapC + temperature*
+              (4.0*cpVapD)));
     }
-
     /*!
      * \brief The dynamic viscosity \f$\mathrm{[Pa*s]}\f$ of \f$N_2\f$ at a given pressure and temperature.
      *

--- a/opm/material/components/SimpleCO2.hpp
+++ b/opm/material/components/SimpleCO2.hpp
@@ -105,16 +105,32 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& temperature,
-                                  const Evaluation& /*pressure*/)
-    { return 571.3e3 + (temperature - 298.15)*0.85e3; }
+                                  const Evaluation& pressure OPM_UNUSED)
+    { return 350.0e3 + temperature*0.85e3; }
+
+    /*!
+     * \copydoc Component::gasHeatCapacity
+     */
+    template <class Evaluation>
+    static Evaluation gasHeatCapacity(const Evaluation& temperature OPM_UNUSED,
+                                      const Evaluation& pressure OPM_UNUSED)
+    { return 0.85e3; }
 
     /*!
      * \copydoc Component::liquidEnthalpy
      */
     template <class Evaluation>
     static Evaluation liquidEnthalpy(const Evaluation& temperature,
-                                     const Evaluation& /*pressure*/)
-    { return (temperature - 298.15)*5e3; }
+                                     const Evaluation& pressure OPM_UNUSED)
+    { return temperature*2e3; }
+
+    /*!
+     * \copydoc Component::liquidHeatCapacity
+     */
+    template <class Evaluation>
+    static Evaluation liquidHeatCapacity(const Evaluation& temperature OPM_UNUSED,
+                                         const Evaluation& pressure OPM_UNUSED)
+    { return 2e3; /* TODO: UNKNOWN! */ }
 
     /*!
      * \copydoc Component::gasInternalEnergy

--- a/opm/material/components/SimpleH2O.hpp
+++ b/opm/material/components/SimpleH2O.hpp
@@ -27,10 +27,12 @@
 #ifndef OPM_SIMPLE_H2O_HPP
 #define OPM_SIMPLE_H2O_HPP
 
+#include "Component.hpp"
+
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
-#include "Component.hpp"
+#include <opm/common/Unused.hpp>
 
 #include <cmath>
 
@@ -161,7 +163,16 @@ public:
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& temperature,
                                   const Evaluation& /*pressure*/)
-    { return 1976*(temperature - 293.15) + 2.45e6; }
+    { return 1.976e3*temperature + 40.65e3/molarMass(); }
+
+
+    /*!
+     * \copydoc Component::gasHeatCapacity
+     */
+    template <class Evaluation>
+    static Evaluation gasHeatCapacity(const Evaluation& temperature OPM_UNUSED,
+                                      const Evaluation& pressure OPM_UNUSED)
+    { return 1.976e3; }
 
     /*!
      * \brief Specific enthalpy of liquid water \f$\mathrm{[J/kg]}\f$.
@@ -172,7 +183,15 @@ public:
     template <class Evaluation>
     static Evaluation liquidEnthalpy(const Evaluation& temperature,
                                      const Evaluation& /*pressure*/)
-    { return 4180*(temperature - 293.15); }
+    { return 4180*temperature; }
+
+    /*!
+     * \copydoc Component::liquidHeatCapacity
+     */
+    template <class Evaluation>
+    static Evaluation liquidHeatCapacity(const Evaluation& temperature,
+                                         const Evaluation& pressure OPM_UNUSED)
+    { return 4.184e3; }
 
     /*!
      * \brief Specific internal energy of steam \f$\mathrm{[J/kg]}\f$.


### PR DESCRIPTION
I looked at all components: For the ones that use simple enthalpy relations, heatCapacity() and enthalpy() should now be consistent. (Here "simple" means "an approach that I understood without reading literature for several hours".)