### PR TITLE
N2: make the heat capacity consistent with the enthalpy again

### DIFF
--- a/opm/material/components/N2.hpp
+++ b/opm/material/components/N2.hpp
@@ -238,9 +238,9 @@ public:
             1/molarMass()* // conversion from [J/(mol K)] to [J/(kg K)]
 
             cpVapA + temperature*
-            (2.0*cpVapB + temperature*
-             (3.0*cpVapC + temperature*
-              (4.0*cpVapD)));
+            (cpVapB + temperature*
+             (cpVapC + temperature*
+              (cpVapD)));
     }
     /*!
      * \brief The dynamic viscosity \f$\mathrm{[Pa*s]}\f$ of \f$N_2\f$ at a given pressure and temperature.


### PR DESCRIPTION
I missed the fact that in the enthalpy() function, the polynomial coefficients are divided, i.e., this component defines a polynomial for the heat capacity and integrates it for the enthalpy. (i.e., not the other way around.)