### PR TITLE
Implement blackoil energy

### DIFF
--- a/opm/material/common/quad.hpp
+++ b/opm/material/common/quad.hpp
@@ -26,14 +26,6 @@
  * \brief This file provides the infrastructure to use quad-precision
  *        floating point values in the numerical models.
  */
-#if HAVE_DUNE_COMMON
-#ifdef DUNE_CLASSNAME_HH
-#error "Due to some trickery required for the linker, this file must be included _before_ Dune's classname.hh!"
-#endif
-
-#include <dune/common/classname.hh>
-#endif // HAVE_DUNE_COMMON
-
 #if !defined OPM_COMMON_QUAD_HPP && HAVE_QUAD
 #define OPM_COMMON_QUAD_HPP
 
@@ -331,14 +323,14 @@ inline bool isinf(quad val)
 
 } // namespace std
 
-#if HAVE_DUNE_COMMON
 // specialize Dune::className for __float128 since it former does not work properly with
 // __float128 (this is mainly the fault of GCC/libstdc++)
+#include <dune/common/classname.hh>
+
 namespace Dune {
 template <>
 inline std::string className<__float128>()
 { return "quad"; }
 } // namespace Dune
-#endif // HAVE_DUNE_COMMON
 
 #endif // OPM_COMMON_QUAD_HPP

--- a/opm/material/fluidmatrixinteractions/VanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/VanGenuchtenParams.hpp
@@ -27,8 +27,6 @@
 #ifndef VAN_GENUCHTEN_PARAMS_HPP
 #define VAN_GENUCHTEN_PARAMS_HPP
 
-#include <cassert>
-
 #include <opm/material/common/EnsureFinalized.hpp>
 
 namespace Opm {

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -195,6 +195,14 @@ public:
             ++ numActivePhases_;
         }
 
+        // set the surface conditions using the STCOND keyword
+        if (deck.hasKeyword("STCOND")) {
+            auto stcondKeyword = deck.getKeyword("STCOND");
+
+            surfaceTemperature = stcondKeyword.getRecord(0).getItem("TEMPERATURE").getSIDouble(0);
+            surfacePressure = stcondKeyword.getRecord(0).getItem("PRESSURE").getSIDouble(0);
+        }
+
         // The reservoir temperature does not really belong into the table manager. TODO:
         // change this in opm-parser
         setReservoirTemperature(eclState.getTableManager().rtemp());
@@ -246,6 +254,8 @@ public:
         enableDissolvedGas_ = true;
         enableVaporizedOil_ = false;
 
+        surfaceTemperature = 273.15 + 15.56; // [K]
+        surfacePressure = 1.01325e5; // [Pa]
         numActivePhases_ = numPhases;
         std::fill(&phaseIsActive_[0], &phaseIsActive_[numPhases], true);
 
@@ -356,10 +366,10 @@ public:
     static const unsigned gasPhaseIdx = 2;
 
     //! The pressure at the surface
-    static const Scalar surfacePressure;
+    static Scalar surfacePressure;
 
     //! The temperature at the surface
-    static const Scalar surfaceTemperature;
+    static Scalar surfaceTemperature;
 
     //! \copydoc BaseFluidSystem::phaseName
     static const char* phaseName(unsigned phaseIdx)
@@ -1246,12 +1256,12 @@ template <class Scalar>
 bool BlackOil<Scalar>::phaseIsActive_[numPhases];
 
 template <class Scalar>
-const Scalar
-BlackOil<Scalar>::surfaceTemperature = 273.15 + 15.56; // [K]
+Scalar
+BlackOil<Scalar>::surfaceTemperature; // [K]
 
 template <class Scalar>
-const Scalar
-BlackOil<Scalar>::surfacePressure = 101325.0; // [Pa]
+Scalar
+BlackOil<Scalar>::surfacePressure; // [Pa]
 
 template <class Scalar>
 Scalar

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -164,6 +164,19 @@ public:
     { return oilViscosity_.size(); }
 
     /*!
+     * \brief Returns the specific enthalpy [J/kg] of oil given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation enthalpy(unsigned regionIdx OPM_UNUSED,
+                        const Evaluation& temperature OPM_UNUSED,
+                        const Evaluation& pressure OPM_UNUSED,
+                        const Evaluation& Rs OPM_UNUSED) const
+    {
+        OPM_THROW(std::runtime_error,
+                  "Requested the enthalpy of oil but the thermal option is not enabled");
+    }
+
+    /*!
      * \brief Returns the dynamic viscosity [Pa s] of gas saturated oil given a pressure
      *        and a phase composition.
      */

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -160,6 +160,18 @@ public:
     { return waterReferenceDensity_.size(); }
 
     /*!
+     * \brief Returns the specific enthalpy [J/kg] of water given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation enthalpy(unsigned regionIdx OPM_UNUSED,
+                        const Evaluation& temperature OPM_UNUSED,
+                        const Evaluation& pressure OPM_UNUSED) const
+    {
+        OPM_THROW(std::runtime_error,
+                  "Requested the enthalpy of water but the thermal option is not enabled");
+    }
+
+    /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -166,6 +166,19 @@ public:
     { return inverseOilBMu_.size(); }
 
     /*!
+     * \brief Returns the specific enthalpy [J/kg] of oil given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation enthalpy(unsigned regionIdx OPM_UNUSED,
+                        const Evaluation& temperature OPM_UNUSED,
+                        const Evaluation& pressure OPM_UNUSED,
+                        const Evaluation& Rs OPM_UNUSED) const
+    {
+        OPM_THROW(std::runtime_error,
+                  "Requested the enthalpy of oil but the thermal option is not enabled");
+    }
+
+    /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -192,6 +192,19 @@ public:
     { return gasReferenceDensity_.size(); }
 
     /*!
+     * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation enthalpy(unsigned regionIdx OPM_UNUSED,
+                        const Evaluation& temperature OPM_UNUSED,
+                        const Evaluation& pressure OPM_UNUSED,
+                        const Evaluation& Rv OPM_UNUSED) const
+    {
+        OPM_THROW(std::runtime_error,
+                  "Requested the enthalpy of gas but the thermal option is not enabled");
+    }
+
+    /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -121,9 +121,7 @@ public:
         if (!enableGas)
             return;
 
-        if (enableThermal
-            && (deck.hasKeyword("TREF")
-                || deck.hasKeyword("GASVISCT")))
+        if (enableThermal && (deck.hasKeyword("THERMAL") || deck.hasKeyword("TEMP")))
             setApproach(ThermalGasPvt);
         else if (deck.hasKeyword("PVTG"))
             setApproach(WetGasPvt);
@@ -164,6 +162,16 @@ public:
      */
     unsigned numRegions() const
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); return 1; }
+
+    /*!
+     * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation enthalpy(unsigned regionIdx,
+                        const Evaluation& temperature,
+                        const Evaluation& pressure,
+                        const Evaluation& Rv) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.enthalpy(regionIdx, temperature, pressure, Rv)); return 0; }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -58,6 +58,13 @@ class GasPvtThermal
     typedef GasPvtMultiplexer<Scalar, /*enableThermal=*/false> IsothermalPvt;
 
 public:
+    GasPvtThermal()
+    {
+        enableThermalDensity_ = false;
+        enableThermalViscosity_ = false;
+        enableEnthalpy_ = false;
+    }
+
     ~GasPvtThermal()
     { delete isothermalPvt_; }
 
@@ -79,8 +86,9 @@ public:
         //////
         const auto& tables = eclState.getTableManager();
 
-        enableThermalDensity_ = deck.hasKeyword("TREF");
+        enableThermalDensity_ = deck.hasKeyword("GASDENT");
         enableThermalViscosity_ = deck.hasKeyword("GASVISCT");
+        enableEnthalpy_ = deck.hasKeyword("SPECHEAT");
 
         unsigned numRegions = isothermalPvt_->numRegions();
         setNumRegions(numRegions);
@@ -98,11 +106,51 @@ public:
             }
         }
 
-        // quantities required for density. note that we just always use the values
-        // for the first EOS. (since EOS != PVT region.)
-        refTemp_ = 0.0;
+        // temperature dependence of gas density
         if (enableThermalDensity_) {
-            refTemp_ = deck.getKeyword("TREF").getRecord(0).getItem("TEMPERATURE").getSIDouble(0);
+            const auto& gasdentKeyword = deck.getKeyword("GASDENT");
+
+            assert(gasdentKeyword.size() == numRegions);
+            for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
+                const auto& gasdentRecord = gasdentKeyword.getRecord(regionIdx);
+
+                gasdentRefTemp_[regionIdx] = gasdentRecord.getItem("REFERENCE_TEMPERATURE").getSIDouble(0);
+                gasdentCT1_[regionIdx] = gasdentRecord.getItem("EXPANSION_COEFF_LINEAR").getSIDouble(0);
+                gasdentCT2_[regionIdx] = gasdentRecord.getItem("EXPANSION_COEFF_QUADRATIC").getSIDouble(0);
+            }
+        }
+
+        if (deck.hasKeyword("SPECHEAT")) {
+            // the specific enthalpy of gas. be aware that ecl only specifies the heat capacity
+            // (via the SPECHEAT keyword) and we need to integrate it ourselfs to get the
+            // enthalpy
+            for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
+                const auto& specHeatTable = tables.getSpecheatTables()[regionIdx];
+                const auto& temperatureColumn = specHeatTable.getColumn("TEMPERATURE");
+                const auto& cpGasColumn = specHeatTable.getColumn("CP_GAS");
+
+                std::vector<double> hSamples(temperatureColumn.size());
+
+                Scalar h = temperatureColumn[0]*cpGasColumn[0];
+                for (size_t i = 0;; ++i) {
+                    hSamples[i] = h;
+
+                    if (i >= temperatureColumn.size() - 1)
+                        break;
+
+                    // integrate to the heat capacity from the current sampling point to the next
+                    // one. this leads to a quadratic polynomial.
+                    Scalar h0 = cpGasColumn[i];
+                    Scalar h1 = cpGasColumn[i + 1];
+                    Scalar T0 = temperatureColumn[i];
+                    Scalar T1 = temperatureColumn[i + 1];
+                    Scalar m = (h1 - h0)/(T1 - T0);
+                    Scalar deltaH = 0.5*m*(T1*T1 - T0*T0) + h0*(T1 - T0);
+                    h += deltaH;
+                }
+
+                enthalpyCurves_[regionIdx].setXYContainers(temperatureColumn.vectorCopy(), hSamples);
+            }
         }
     }
 #endif // HAVE_OPM_PARSER
@@ -111,7 +159,13 @@ public:
      * \brief Set the number of PVT-regions considered by this object.
      */
     void setNumRegions(size_t numRegions)
-    { gasvisctCurves_.resize(numRegions); }
+    {
+        gasvisctCurves_.resize(numRegions);
+        enthalpyCurves_.resize(numRegions);
+        gasdentRefTemp_.resize(numRegions);
+        gasdentCT1_.resize(numRegions);
+        gasdentCT2_.resize(numRegions);
+    }
 
     /*!
      * \brief Finish initializing the thermal part of the gas phase PVT properties.
@@ -133,6 +187,25 @@ public:
      */
     bool enableThermalViscosity() const
     { return enableThermalViscosity_; }
+
+    /*!
+     * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation enthalpy(unsigned regionIdx,
+                        const Evaluation& temperature,
+                        const Evaluation& pressure OPM_UNUSED,
+                        const Evaluation& Rv OPM_UNUSED) const
+    {
+        if (!enableEnthalpy_)
+            OPM_THROW(std::runtime_error,
+                      "Requested the enthalpy of oil but it is disabled");
+
+        // compute the specific enthalpy for the specified tempature. We use linear
+        // interpolation here despite the fact that the underlying heat capacities are
+        // piecewise linear (which leads to a quadratic function)
+        return enthalpyCurves_[regionIdx].eval(temperature, /*extrapolate=*/true);
+    }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
@@ -178,14 +251,23 @@ public:
     {
         const auto& b =
             isothermalPvt_->inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rv);
+
         if (!enableThermalDensity())
             return b;
 
-        // the Eclipse TD/RM do not explicitly specify the relation of the gas
-        // density and the temperature, but equation (69.49) (for Eclipse 2011.1)
-        // implies that the temperature dependence of the gas phase is rho(T, p) =
-        // rho(tref_, p)*T/T_ref ...
-        return b*temperature/refTemp_;
+        // we use the same approach as for the for water here, but with the OPM-specific
+        // GASDENT keyword.
+        //
+        // TODO: Since gas is quite a bit more compressible than water, it might be
+        //       necessary to make GASDENT to a table keyword. If the current temperature
+        //       is relatively close to the reference temperature, the current approach
+        //       should be good enough, though.
+        Scalar TRef = gasdentRefTemp_[regionIdx];
+        Scalar cT1 = gasdentCT1_[regionIdx];
+        Scalar cT2 = gasdentCT2_[regionIdx];
+        const Evaluation& Y = temperature - TRef;
+
+        return b/(1 + (cT1 + cT2*Y)*Y);
     }
 
     /*!
@@ -198,14 +280,23 @@ public:
     {
         const auto& b =
             isothermalPvt_->saturatedInverseFormationVolumeFactor(regionIdx, temperature, pressure);
+
         if (!enableThermalDensity())
             return b;
 
-        // the Eclipse TD/RM do not explicitly specify the relation of the gas
-        // density and the temperature, but equation (69.49) (for Eclipse 2011.1)
-        // implies that the temperature dependence of the gas phase is rho(T, p) =
-        // rho(tref_, p)*T/T_ref ...
-        return b*temperature/refTemp_;
+        // we use the same approach as for the for water here, but with the OPM-specific
+        // GASDENT keyword.
+        //
+        // TODO: Since gas is quite a bit more compressible than water, it might be
+        //       necessary to make GASDENT to a table keyword. If the current temperature
+        //       is relatively close to the reference temperature, the current approach
+        //       should be good enough, though.
+        Scalar TRef = gasdentRefTemp_[regionIdx];
+        Scalar cT1 = gasdentCT1_[regionIdx];
+        Scalar cT2 = gasdentCT2_[regionIdx];
+        const Evaluation& Y = temperature - TRef;
+
+        return b/(1 + (cT1 + cT2*Y)*Y);
     }
 
     /*!
@@ -256,13 +347,16 @@ private:
     // to store one value per PVT region.
     std::vector<TabulatedOneDFunction> gasvisctCurves_;
 
-    // The PVT properties needed for temperature dependence of the density. This is
-    // specified as one value per EOS in the manual, but we unconditionally use the
-    // expansion coefficient of the first EOS...
-    Scalar refTemp_;
+    std::vector<Scalar> gasdentRefTemp_;
+    std::vector<Scalar> gasdentCT1_;
+    std::vector<Scalar> gasdentCT2_;
+
+    // piecewise linear curve representing the enthalpy of gas
+    std::vector<TabulatedOneDFunction> enthalpyCurves_;
 
     bool enableThermalDensity_;
     bool enableThermalViscosity_;
+    bool enableEnthalpy_;
 };
 
 } // namespace Opm

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -409,6 +409,19 @@ public:
     { return inverseOilBMuTable_.size(); }
 
     /*!
+     * \brief Returns the specific enthalpy [J/kg] of oil given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation enthalpy(unsigned regionIdx OPM_UNUSED,
+                        const Evaluation& temperature OPM_UNUSED,
+                        const Evaluation& pressure OPM_UNUSED,
+                        const Evaluation& Rs OPM_UNUSED) const
+    {
+        OPM_THROW(std::runtime_error,
+                  "Requested the enthalpy of oil but the thermal option is not enabled");
+    }
+
+    /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -127,9 +127,7 @@ public:
         if (!enableOil)
             return;
 
-        if (enableThermal
-            && (deck.hasKeyword("THERMEX1")
-                || deck.hasKeyword("VISCREF")))
+        if (enableThermal && (deck.hasKeyword("THERMAL") || deck.hasKeyword("TEMP")))
             setApproach(ThermalOilPvt);
         else if (deck.hasKeyword("PVCDO"))
             setApproach(ConstantCompressibilityOilPvt);
@@ -151,6 +149,16 @@ public:
      */
     unsigned numRegions() const
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); return 1; }
+
+    /*!
+     * \brief Returns the specific enthalpy [J/kg] oil given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation enthalpy(unsigned regionIdx,
+                        const Evaluation& temperature,
+                        const Evaluation& pressure,
+                        const Evaluation& Rs) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.enthalpy(regionIdx, temperature, pressure, Rs)); return 0; }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -96,9 +96,7 @@ public:
         if (!enableWater)
             return;
 
-        if (enableThermal
-            && (deck.hasKeyword("WATDENT")
-                || deck.hasKeyword("VISCREF")))
+        if (enableThermal && (deck.hasKeyword("THERMAL") || deck.hasKeyword("TEMP")))
             setApproach(ThermalWaterPvt);
         else if (deck.hasKeyword("PVTW"))
             setApproach(ConstantCompressibilityWaterPvt);
@@ -115,6 +113,15 @@ public:
      */
     unsigned numRegions() const
     { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); return 1; }
+
+    /*!
+     * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation enthalpy(unsigned regionIdx,
+                        const Evaluation& temperature,
+                        const Evaluation& pressure) const
+    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.enthalpy(regionIdx, temperature, pressure)); return 0; }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -439,6 +439,19 @@ public:
     { return gasReferenceDensity_.size(); }
 
     /*!
+     * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation enthalpy(unsigned regionIdx OPM_UNUSED,
+                        const Evaluation& temperature OPM_UNUSED,
+                        const Evaluation& pressure OPM_UNUSED,
+                        const Evaluation& Rv OPM_UNUSED) const
+    {
+        OPM_THROW(std::runtime_error,
+                  "Requested the enthalpy of gas but the thermal option is not enabled");
+    }
+
+    /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
     template <class Evaluation>

--- a/opm/material/thermal/ConstantSolidHeatCapLaw.hpp
+++ b/opm/material/thermal/ConstantSolidHeatCapLaw.hpp
@@ -1,0 +1,64 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::ConstantSolidHeatCapLaw
+ */
+#ifndef OPM_CONSTANT_SOLID_HEAT_CAP_LAW_HPP
+#define OPM_CONSTANT_SOLID_HEAT_CAP_LAW_HPP
+
+#include "ConstantSolidHeatCapLawParams.hpp"
+
+#include <opm/material/densead/Math.hpp>
+
+namespace Opm
+{
+/*!
+ * \ingroup material
+ *
+ * \brief Implements a solid energy storage law which assumes constant heat capacity.
+ */
+template <class ScalarT,
+          class ParamsT = ConstantSolidHeatCapLawParams<ScalarT> >
+class ConstantSolidHeatCapLaw
+{
+public:
+    typedef ParamsT Params;
+    typedef typename Params::Scalar Scalar;
+
+    /*!
+     * \brief Given a fluid state, compute the volumetric internal energy of the solid matrix [W/m^3].
+     */
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
+    static Evaluation solidInternalEnergy(const Params& params, const FluidState& fluidState)
+    {
+        const Evaluation& T = fluidState.temperature(/*phaseIdx=*/0);
+
+        Scalar cp = params.solidHeatCapacity();
+
+        return T*cp;
+    }
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/ConstantSolidHeatCapLawParams.hpp
+++ b/opm/material/thermal/ConstantSolidHeatCapLawParams.hpp
@@ -22,46 +22,46 @@
 */
 /*!
  * \file
- * \copydoc Opm::DummyHeatConductionLaw
+ * \copydoc Opm::ConstantSolidHeatCapLawParams
  */
-#ifndef OPM_DUMMY_HEATCONDUCTION_LAW_HPP
-#define OPM_DUMMY_HEATCONDUCTION_LAW_HPP
+#ifndef OPM_CONSTANT_SOLID_HEAT_CAP_LAW_PARAMS_HPP
+#define OPM_CONSTANT_SOLID_HEAT_CAP_LAW_PARAMS_HPP
 
-#include <opm/common/Unused.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/EnsureFinalized.hpp>
 
-namespace Opm
-{
+namespace Opm {
+
 /*!
- * \ingroup material
- *
- * \brief Implements a dummy law for heat conduction to which isothermal models
- *        can fall back to.
- *
- * If any method of this law is called, it throws std::logic_error.
+ * \brief The default implementation of a parameter object for the
+ *        solid energy storage law which assumes constant heat capacity.
  */
 template <class ScalarT>
-class DummyHeatConductionLaw
+class ConstantSolidHeatCapLawParams : public EnsureFinalized
 {
 public:
-    typedef int Params;
     typedef ScalarT Scalar;
 
+    ConstantSolidHeatCapLawParams(const ConstantSolidHeatCapLawParams&) = default;
+
+    ConstantSolidHeatCapLawParams()
+    { }
+
     /*!
-     * \brief Given a fluid state, return the effective heat conductivity [W/m^2 / (K/m)] of the porous
-     *        medium.
-     *
-     * If this method is called an exception is thrown at run time.
+     * \brief Set the specific heat capacity of the solid matrix [J/(m^3 K)].
      */
-    template <class FluidState, class Evaluation = Scalar>
-    static Scalar heatConductivity(const Params& params OPM_UNUSED,
-                                   const FluidState& fluidState OPM_UNUSED)
-    {
-        OPM_THROW(std::logic_error,
-                   "No heat conduction law specified!");
-    }
+    void setSolidHeatCapacity(Scalar value)
+    { solidHeatCapacity_ = value; }
+
+    /*!
+     * \brief Return the specific heat capacity of the solid matrix  [J/(m^3 K)].
+     */
+    Scalar solidHeatCapacity() const
+    { EnsureFinalized::check(); return solidHeatCapacity_; }
+
+private:
+    Scalar solidHeatCapacity_;
 };
+
 } // namespace Opm
 
 #endif

--- a/opm/material/thermal/EclHeatConductionLawMultiplexer.hpp
+++ b/opm/material/thermal/EclHeatConductionLawMultiplexer.hpp
@@ -1,0 +1,87 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclHeatConductionLawMultiplexer
+ */
+#ifndef OPM_ECL_HEAT_CONDUCTION_LAW_MULTIPLEXER_HPP
+#define OPM_ECL_HEAT_CONDUCTION_LAW_MULTIPLEXER_HPP
+
+#include "EclHeatConductionLawMultiplexerParams.hpp"
+
+#include "EclThconrLaw.hpp"
+#include "EclThcLaw.hpp"
+#include "NullHeatConductionLaw.hpp"
+
+#include <opm/material/densead/Math.hpp>
+
+namespace Opm
+{
+/*!
+ * \ingroup material
+ *
+ * \brief Implements the total heat conductivity and rock enthalpy relations used by ECL.
+ */
+template <class ScalarT,
+          class FluidSystem,
+          class ParamsT = EclHeatConductionLawMultiplexerParams<ScalarT>>
+class EclHeatConductionLawMultiplexer
+{
+    enum { numPhases = FluidSystem::numPhases };
+
+    typedef Opm::EclThconrLaw<ScalarT, FluidSystem, typename ParamsT::ThconrLawParams> ThconrLaw;
+    typedef Opm::EclThcLaw<ScalarT, typename ParamsT::ThcLawParams> ThcLaw;
+    typedef Opm::NullHeatConductionLaw<ScalarT> NullLaw;
+
+public:
+    typedef ParamsT Params;
+    typedef typename Params::Scalar Scalar;
+
+    /*!
+     * \brief Given a fluid state, compute the volumetric internal energy of the rock [W/m^3].
+     */
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
+    static Evaluation heatConductivity(const Params& params,
+                                       const FluidState& fluidState)
+    {
+        switch (params.heatConductionApproach()) {
+        case Params::thconrApproach:
+            // relevant ECL keywords: THCONR and THCONSF
+            return ThconrLaw::heatConductivity(params.template getRealParams<Params::thconrApproach>(), fluidState);
+
+        case Params::thcApproach:
+            // relevant ECL keywords: THCROCK, THCOIL, THCGAS and THCWATER
+            return ThcLaw::heatConductivity(params.template getRealParams<Params::thcApproach>(), fluidState);
+
+        case Params::nullApproach:
+            // relevant ECL keywords: none or none recognized
+            return NullLaw::heatConductivity(0, fluidState);
+
+        default:
+            OPM_THROW(std::logic_error, "Invalid heat conductivity approach: " << params.heatConductionApproach());
+        }
+    }
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclHeatConductionLawMultiplexerParams.hpp
+++ b/opm/material/thermal/EclHeatConductionLawMultiplexerParams.hpp
@@ -1,0 +1,158 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclHeatConductivtyLawMultiplexerParams
+ */
+#ifndef OPM_ECL_HEAT_CONDUCTION_LAW_MULTIPLEXER_PARAMS_HPP
+#define OPM_ECL_HEAT_CONDUCTION_LAW_MULTIPLEXER_PARAMS_HPP
+
+#include "EclThconrLawParams.hpp"
+#include "EclThcLawParams.hpp"
+
+#include <opm/material/common/EnsureFinalized.hpp>
+
+#include <memory>
+
+namespace Opm {
+
+/*!
+ * \brief The default implementation of a parameter object for the
+ *        ECL thermal law.
+ */
+template <class ScalarT>
+class EclHeatConductionLawMultiplexerParams : public EnsureFinalized
+{
+    typedef void* ParamPointerType;
+
+public:
+    typedef ScalarT Scalar;
+
+    enum HeatConductionApproach {
+        undefinedApproach,
+        thconrApproach, // keywords: THCONR, THCONSF
+        thcApproach, // keywords: THCROCK, THCOIL, THCGAS, THCWATER
+        nullApproach, // (no keywords)
+    };
+
+    typedef Opm::EclThconrLawParams<ScalarT> ThconrLawParams;
+    typedef Opm::EclThcLawParams<ScalarT> ThcLawParams;
+
+    EclHeatConductionLawMultiplexerParams(const EclHeatConductionLawMultiplexerParams&) = default;
+
+    EclHeatConductionLawMultiplexerParams()
+    { heatConductionApproach_ = undefinedApproach; }
+
+    ~EclHeatConductionLawMultiplexerParams()
+    { destroy_(); }
+
+    void setHeatConductionApproach(HeatConductionApproach newApproach)
+    {
+        destroy_();
+
+        heatConductionApproach_ = newApproach;
+        switch (heatConductionApproach()) {
+        case undefinedApproach:
+            OPM_THROW(std::logic_error,
+                      "Cannot set the approach for heat conduction to 'undefined'!");
+
+        case thconrApproach:
+            realParams_ = new ThconrLawParams;
+            break;
+
+        case thcApproach:
+            realParams_ = new ThcLawParams;
+            break;
+
+        case nullApproach:
+            realParams_ = nullptr;
+            break;
+        }
+    }
+
+    HeatConductionApproach heatConductionApproach() const
+    { return heatConductionApproach_; }
+
+    // get the parameter object for the THCONR case
+    template <HeatConductionApproach approachV>
+    typename std::enable_if<approachV == thconrApproach, ThconrLawParams>::type&
+    getRealParams()
+    {
+        assert(heatConductionApproach() == approachV);
+        return *static_cast<ThconrLawParams*>(realParams_);
+    }
+
+    template <HeatConductionApproach approachV>
+    typename std::enable_if<approachV == thconrApproach, const ThconrLawParams>::type&
+    getRealParams() const
+    {
+        assert(heatConductionApproach() == approachV);
+        return *static_cast<const ThconrLawParams*>(realParams_);
+    }
+
+    // get the parameter object for the THC* case
+    template <HeatConductionApproach approachV>
+    typename std::enable_if<approachV == thcApproach, ThcLawParams>::type&
+    getRealParams()
+    {
+        assert(heatConductionApproach() == approachV);
+        return *static_cast<ThcLawParams*>(realParams_);
+    }
+
+    template <HeatConductionApproach approachV>
+    typename std::enable_if<approachV == thcApproach, const ThcLawParams>::type&
+    getRealParams() const
+    {
+        assert(heatConductionApproach() == approachV);
+        return *static_cast<const ThcLawParams*>(realParams_);
+    }
+
+private:
+    void destroy_()
+    {
+        switch (heatConductionApproach()) {
+        case undefinedApproach:
+            break;
+
+        case thconrApproach:
+            delete static_cast<ThconrLawParams*>(realParams_);
+            break;
+
+        case thcApproach:
+            delete static_cast<ThcLawParams*>(realParams_);
+            break;
+
+        case nullApproach:
+            break;
+        }
+
+        heatConductionApproach_ = undefinedApproach;
+    }
+
+    HeatConductionApproach heatConductionApproach_;
+    ParamPointerType realParams_;
+};
+
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclHeatcrLaw.hpp
+++ b/opm/material/thermal/EclHeatcrLaw.hpp
@@ -1,0 +1,69 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclHeatcrLaw
+ */
+#ifndef OPM_ECL_HEATCR_LAW_HPP
+#define OPM_ECL_HEATCR_LAW_HPP
+
+#include "EclHeatcrLawParams.hpp"
+
+#include <opm/material/densead/Math.hpp>
+
+namespace Opm
+{
+/*!
+ * \ingroup material
+ *
+ * \brief Implements the volumetric interior energy relations of rock used by ECL.
+ *
+ * This class uses the approach defined via keywords HEATCR, HEATCRT and STCOND.
+ */
+template <class ScalarT,
+          class FluidSystem,
+          class ParamsT = EclHeatcrLawParams<ScalarT> >
+class EclHeatcrLaw
+{
+public:
+    typedef ParamsT Params;
+    typedef typename Params::Scalar Scalar;
+
+    /*!
+     * \brief Given a fluid state, compute the volumetric internal energy of the rock [W/m^3].
+     */
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
+    static Evaluation solidInternalEnergy(const Params& params, const FluidState& fluidState)
+    {
+        const Evaluation& T = fluidState.temperature(/*phaseIdx=*/0);
+        const Evaluation& deltaT = T - params.referenceTemperature();
+
+        Scalar C0 = params.referenceRockHeatCapacity();
+        Scalar C1 = params.dRockHeatCapacity_dT();
+
+        return deltaT*(C0 + deltaT*C1 / 2.0);
+    }
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclHeatcrLawParams.hpp
+++ b/opm/material/thermal/EclHeatcrLawParams.hpp
@@ -1,0 +1,100 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclHeatcrLawParams
+ */
+#ifndef OPM_ECL_HEATCR_LAW_PARAMS_HPP
+#define OPM_ECL_HEATCR_LAW_PARAMS_HPP
+
+#include <opm/material/common/EnsureFinalized.hpp>
+
+namespace Opm {
+
+/*!
+ * \brief The default implementation of a parameter object for the
+ *        ECL thermal law.
+ */
+template <class ScalarT>
+class EclHeatcrLawParams : public EnsureFinalized
+{
+public:
+    typedef ScalarT Scalar;
+
+    EclHeatcrLawParams(const EclHeatcrLawParams&) = default;
+
+    EclHeatcrLawParams()
+    { }
+
+    /*!
+     * \brief Set the reference temperature for the thermal law.
+     *
+     * This is a bit hacky because only one temperature is possible, but some
+     * memory is saved this way. TODO: Solve this in a better way.
+     */
+    static void setReferenceTemperature(Scalar value)
+    { referenceTemperature_ = value; }
+
+    /*!
+     * \brief Return the reference temperature for the thermal law.
+     */
+    static Scalar referenceTemperature()
+    { return referenceTemperature_; }
+
+    /*!
+     * \brief Set the specific heat capacity of rock.
+     */
+    void setReferenceRockHeatCapacity(Scalar value)
+    { referenceRockHeatCapacity_ = value; }
+
+    /*!
+     * \brief The specific heat capacity of rock.
+     */
+    Scalar referenceRockHeatCapacity() const
+    { EnsureFinalized::check(); return referenceRockHeatCapacity_; }
+
+    /*!
+     * \brief Set the derivative of the specific heat capacity of rock w.r.t. temperature.
+     */
+    void setDRockHeatCapacity_dT(Scalar value)
+    { dRockHeatCapacity_dT_ = value; }
+
+    /*!
+     * \brief The derivative of the specific heat capacity of rock w.r.t. temperature.
+     */
+    Scalar dRockHeatCapacity_dT() const
+    { EnsureFinalized::check(); return dRockHeatCapacity_dT_; }
+
+private:
+    static Scalar referenceTemperature_;
+
+    Scalar referenceRockHeatCapacity_;
+    Scalar dRockHeatCapacity_dT_;
+};
+
+template <class ScalarT>
+ScalarT EclHeatcrLawParams<ScalarT>::referenceTemperature_ = 273.15 + 15.56; // [K]
+
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclSolidHeatLawMultiplexer.hpp
+++ b/opm/material/thermal/EclSolidHeatLawMultiplexer.hpp
@@ -1,0 +1,86 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclSolidHeatLawMultiplexer
+ */
+#ifndef OPM_ECL_SOLID_HEAT_LAW_MULTIPLEXER_HPP
+#define OPM_ECL_SOLID_HEAT_LAW_MULTIPLEXER_HPP
+
+#include "EclSolidHeatLawMultiplexerParams.hpp"
+
+#include "EclHeatcrLaw.hpp"
+#include "EclSpecrockLaw.hpp"
+#include "NullSolidEnergyLaw.hpp"
+
+#include <opm/material/densead/Math.hpp>
+
+namespace Opm
+{
+/*!
+ * \ingroup material
+ *
+ * \brief Implements the total heat conductivity and rock enthalpy relations used by ECL.
+ */
+template <class ScalarT,
+          class FluidSystem,
+          class ParamsT = EclSolidHeatLawMultiplexerParams<ScalarT>>
+class EclSolidHeatLawMultiplexer
+{
+    enum { numPhases = FluidSystem::numPhases };
+
+    typedef Opm::EclHeatcrLaw<ScalarT, FluidSystem, typename ParamsT::HeatcrLawParams> HeatcrLaw;
+    typedef Opm::EclSpecrockLaw<ScalarT, typename ParamsT::SpecrockLawParams> SpecrockLaw;
+    typedef Opm::NullSolidEnergyLaw<ScalarT> NullLaw;
+
+public:
+    typedef ParamsT Params;
+    typedef typename Params::Scalar Scalar;
+
+    /*!
+     * \brief Given a fluid state, compute the volumetric internal energy of the rock [W/m^3].
+     */
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
+    static Evaluation solidInternalEnergy(const Params& params, const FluidState& fluidState)
+    {
+        switch (params.solidEnergyApproach()) {
+        case Params::heatcrApproach:
+            // relevant ECL keywords: HEATCR, HEATCRT and STCOND
+            return HeatcrLaw::solidInternalEnergy(params.template getRealParams<Params::heatcrApproach>(), fluidState);
+
+        case Params::specrockApproach:
+            // relevant ECL keyword: SPECROCK
+            return SpecrockLaw::solidInternalEnergy(params.template getRealParams<Params::specrockApproach>(), fluidState);
+
+        case Params::nullApproach:
+            // (no relevant ECL keyword)
+            return NullLaw::solidInternalEnergy(0, fluidState);
+
+        default:
+            OPM_THROW(std::logic_error, "Invalid solid energy approach: " << params.solidEnergyApproach());
+        }
+    }
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclSolidHeatLawMultiplexerParams.hpp
+++ b/opm/material/thermal/EclSolidHeatLawMultiplexerParams.hpp
@@ -1,0 +1,158 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclSolidHeatLawMultiplexerParams
+ */
+#ifndef OPM_ECL_SOLID_HEAT_LAW_MULTIPLEXER_PARAMS_HPP
+#define OPM_ECL_SOLID_HEAT_LAW_MULTIPLEXER_PARAMS_HPP
+
+#include "EclHeatcrLawParams.hpp"
+#include "EclSpecrockLawParams.hpp"
+
+#include <opm/material/common/EnsureFinalized.hpp>
+
+#include <memory>
+
+namespace Opm {
+
+/*!
+ * \brief The default implementation of a parameter object for the
+ *        ECL thermal law.
+ */
+template <class ScalarT>
+class EclSolidHeatLawMultiplexerParams : public EnsureFinalized
+{
+    typedef void* ParamPointerType;
+
+public:
+    typedef ScalarT Scalar;
+
+    enum SolidEnergyApproach {
+        undefinedApproach,
+        heatcrApproach, // keywords: HEATCR, HEATCRT, STCOND
+        specrockApproach, // keyword: SPECROCK
+        nullApproach, // (no keywords)
+    };
+
+    typedef Opm::EclHeatcrLawParams<ScalarT> HeatcrLawParams;
+    typedef Opm::EclSpecrockLawParams<ScalarT> SpecrockLawParams;
+
+    EclSolidHeatLawMultiplexerParams(const EclSolidHeatLawMultiplexerParams&) = default;
+
+    EclSolidHeatLawMultiplexerParams()
+    { solidEnergyApproach_ = undefinedApproach; }
+
+    ~EclSolidHeatLawMultiplexerParams()
+    { destroy_(); }
+
+    void setSolidEnergyApproach(SolidEnergyApproach newApproach)
+    {
+        destroy_();
+
+        solidEnergyApproach_ = newApproach;
+        switch (solidEnergyApproach()) {
+        case undefinedApproach:
+            OPM_THROW(std::logic_error,
+                      "Cannot set the approach for solid heat storage to 'undefined'!");
+
+        case heatcrApproach:
+            realParams_ = new HeatcrLawParams;
+            break;
+
+        case specrockApproach:
+            realParams_ = new SpecrockLawParams;
+            break;
+
+        case nullApproach:
+            realParams_ = nullptr;
+            break;
+        }
+    }
+
+    SolidEnergyApproach solidEnergyApproach() const
+    { return solidEnergyApproach_; }
+
+    // get the parameter object for the HEATCR case
+    template <SolidEnergyApproach approachV>
+    typename std::enable_if<approachV == heatcrApproach, HeatcrLawParams>::type&
+    getRealParams()
+    {
+        assert(solidEnergyApproach() == approachV);
+        return *static_cast<HeatcrLawParams*>(realParams_);
+    }
+
+    template <SolidEnergyApproach approachV>
+    typename std::enable_if<approachV == heatcrApproach, const HeatcrLawParams>::type&
+    getRealParams() const
+    {
+        assert(solidEnergyApproach() == approachV);
+        return *static_cast<const HeatcrLawParams*>(realParams_);
+    }
+
+    // get the parameter object for the SPECROCK case
+    template <SolidEnergyApproach approachV>
+    typename std::enable_if<approachV == specrockApproach, SpecrockLawParams>::type&
+    getRealParams()
+    {
+        assert(solidEnergyApproach() == approachV);
+        return *static_cast<SpecrockLawParams*>(realParams_);
+    }
+
+    template <SolidEnergyApproach approachV>
+    typename std::enable_if<approachV == specrockApproach, const SpecrockLawParams>::type&
+    getRealParams() const
+    {
+        assert(solidEnergyApproach() == approachV);
+        return *static_cast<const SpecrockLawParams*>(realParams_);
+    }
+
+private:
+    void destroy_()
+    {
+        switch (solidEnergyApproach()) {
+        case undefinedApproach:
+            break;
+
+        case heatcrApproach:
+            delete static_cast<HeatcrLawParams*>(realParams_);
+            break;
+
+        case specrockApproach:
+            delete static_cast<SpecrockLawParams*>(realParams_);
+            break;
+
+        case nullApproach:
+            break;
+        }
+
+        solidEnergyApproach_ = undefinedApproach;
+    }
+
+    SolidEnergyApproach solidEnergyApproach_;
+    ParamPointerType realParams_;
+};
+
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclSpecrockLaw.hpp
+++ b/opm/material/thermal/EclSpecrockLaw.hpp
@@ -1,0 +1,63 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclSpecrockLaw
+ */
+#ifndef OPM_ECL_SPECROCK_LAW_HPP
+#define OPM_ECL_SPECROCK_LAW_HPP
+
+#include "EclSpecrockLawParams.hpp"
+
+#include <opm/material/densead/Math.hpp>
+
+namespace Opm
+{
+/*!
+ * \ingroup material
+ *
+ * \brief Implements the volumetric interior energy relations of rock used by ECL.
+ *
+ * This class uses the approach defined via SPECROCK keyword.
+ */
+template <class ScalarT,
+          class ParamsT = EclSpecrockLawParams<ScalarT> >
+class EclSpecrockLaw
+{
+public:
+    typedef ParamsT Params;
+    typedef typename Params::Scalar Scalar;
+
+    /*!
+     * \brief Given a fluid state, compute the volumetric internal energy of the rock [W/m^3].
+     */
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
+    static Evaluation solidInternalEnergy(const Params& params, const FluidState& fluidState)
+    {
+        const auto& T = fluidState.temperature(/*phaseIdx=*/0);
+        return params.internalEnergyFunction().eval(T, /*extrapolate=*/true);
+    }
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclSpecrockLawParams.hpp
+++ b/opm/material/thermal/EclSpecrockLawParams.hpp
@@ -1,0 +1,104 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclSpecrockLawParams
+ */
+#ifndef OPM_ECL_SPECROCK_LAW_PARAMS_HPP
+#define OPM_ECL_SPECROCK_LAW_PARAMS_HPP
+
+#include <opm/material/common/EnsureFinalized.hpp>
+
+#include <opm/material/common/Tabulated1DFunction.hpp>
+
+namespace Opm {
+
+/*!
+ * \brief The default implementation of a parameter object for the
+ *        ECL thermal law based on SPECROCK.
+ */
+template <class ScalarT>
+class EclSpecrockLawParams : public EnsureFinalized
+{
+    typedef Tabulated1DFunction<ScalarT> InternalEnergyFunction;
+
+public:
+    typedef ScalarT Scalar;
+
+    EclSpecrockLawParams(const EclSpecrockLawParams&) = default;
+
+    EclSpecrockLawParams()
+    { }
+
+    /*!
+     * \brief Specify the volumetric internal energy of rock via heat capacities.
+     */
+    template <class Container>
+    void setHeatCapacities(const Container& temperature,
+                           const Container& heatCapacity)
+    {
+        assert(temperature.size() == heatCapacity.size());
+
+        // integrate the heat capacity to compute the internal energy
+        Scalar curU = temperature[0]*heatCapacity[0];
+        std::vector<Scalar> T(temperature.size());
+        std::vector<Scalar> u(heatCapacity.size());
+        for (unsigned i = 0; i < temperature.size(); ++ i) {
+            T[i] = temperature[i];
+            u[i] = curU;
+
+            if (i >= temperature.size() - 1)
+                break;
+
+            // integrate to the heat capacity from the current sampling point to the next
+            // one. this leads to a quadratic polynomial.
+            Scalar u0 = heatCapacity[i];
+            Scalar u1 = heatCapacity[i + 1];
+            Scalar T0 = temperature[i];
+            Scalar T1 = temperature[i + 1];
+            Scalar m = (u1 - u0)/(T1 - T0);
+            Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + u0*(T1 - T0);
+            curU += deltaU;
+        }
+
+        internalEnergyFunction_.setXYContainers(T, u);
+    }
+
+    /*!
+     * \brief Return the function which maps temparature to the rock's volumetric
+     *        internal energy
+     *
+     * Currently we assume this function to be piecewise linear. (Assuming piecewise
+     * linear heat capacity, the real function is quadratic, but the difference should be
+     * negligible.)
+     */
+    const InternalEnergyFunction& internalEnergyFunction() const
+    { EnsureFinalized::check(); return internalEnergyFunction_; }
+
+private:
+    InternalEnergyFunction internalEnergyFunction_;
+};
+
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclThcLaw.hpp
+++ b/opm/material/thermal/EclThcLaw.hpp
@@ -1,0 +1,81 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclThcLaw
+ */
+#ifndef OPM_ECL_THC_LAW_HPP
+#define OPM_ECL_THC_LAW_HPP
+
+#include "EclThcLawParams.hpp"
+
+#include <opm/material/densead/Math.hpp>
+
+namespace Opm
+{
+/*!
+ * \ingroup material
+ *
+ * \brief Implements the total heat conductivity and rock enthalpy relations used by ECL.
+ *
+ * This is the heat conduction law based on the THCROCK, THCOIL, THCGAS and THCWATER
+ * keywords.
+ */
+template <class ScalarT,
+          class ParamsT = EclThcLawParams<ScalarT> >
+class EclThcLaw
+{
+public:
+    typedef ParamsT Params;
+    typedef typename Params::Scalar Scalar;
+
+    /*!
+     * \brief Given a fluid state, return the total heat conductivity [W/m^2 / (K/m)] of the porous
+     *        medium.
+      */
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
+    static Evaluation heatConductivity(const Params& params,
+                                       const FluidState& fluidState)
+    {
+        // The thermal conductivity approach based on the THC* keywords.
+
+        // let's assume that the porosity of the rock at standard condition is meant
+        Scalar poro = params.porosity();
+
+        // IMO this approach is very questionable because the total heat conductivity
+        // should at least depend on the current solution's phase saturation. Since ECL
+        // is king, let's follow their lead and throw ourselfs down the cliff of obvious
+        // incorrectness.
+        //
+        // TODO: also follow their fine leadership in the twophase case.
+        Scalar numPhases = 3.0;
+        Scalar thconAvg =
+            poro*(params.thcoil() + params.thcgas() + params.thcwater()) / numPhases
+            + (1.0 - poro)*params.thcrock();
+
+        return thconAvg;
+    }
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclThcLawParams.hpp
+++ b/opm/material/thermal/EclThcLawParams.hpp
@@ -1,0 +1,119 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclThcLawParams
+ */
+#ifndef OPM_ECL_THC_LAW_PARAMS_HPP
+#define OPM_ECL_THC_LAW_PARAMS_HPP
+
+#include <opm/material/common/EnsureFinalized.hpp>
+
+namespace Opm {
+
+/*!
+ * \brief The default implementation of a parameter object for the
+ *        heat conduction law based on the THC* keywords from ECL.
+ */
+template <class ScalarT>
+class EclThcLawParams : public EnsureFinalized
+{
+public:
+    typedef ScalarT Scalar;
+
+    EclThcLawParams(const EclThcLawParams&) = default;
+
+    EclThcLawParams()
+    { }
+
+    /*!
+     * \brief Set the porosity
+     */
+    void setPorosity(Scalar value)
+    { porosity_ = value; }
+
+    /*!
+     * \brief Return the porosity
+     */
+    Scalar porosity() const
+    { EnsureFinalized::check(); return porosity_; }
+
+    /*!
+     * \brief Set thermal conductivity of pure rock [W/(m*K)]
+     */
+    void setThcrock(Scalar value)
+    { thcrock_ = value; }
+
+    /*!
+     * \brief Return thermal conductivity of pure rock [W/(m*K)]
+     */
+    Scalar thcrock() const
+    { EnsureFinalized::check(); return thcrock_; }
+
+    /*!
+     * \brief Set thermal conductivity of pure oil [W/(m*K)]
+     */
+    void setThcoil(Scalar value)
+    { thcoil_ = value; }
+
+    /*!
+     * \brief Return thermal conductivity of pure oil [W/(m*K)]
+     */
+    Scalar thcoil() const
+    { EnsureFinalized::check(); return thcoil_; }
+
+    /*!
+     * \brief Set thermal conductivity of pure gas [W/(m*K)]
+     */
+    void setThcgas(Scalar value)
+    { thcgas_ = value; }
+
+    /*!
+     * \brief Return thermal conductivity of pure gas [W/(m*K)]
+     */
+    Scalar thcgas() const
+    { EnsureFinalized::check(); return thcgas_; }
+
+    /*!
+     * \brief Set thermal conductivity of pure water [W/(m*K)]
+     */
+    void setThcwater(Scalar value)
+    { thcwater_ = value; }
+
+    /*!
+     * \brief Return thermal conductivity of pure water [W/(m*K)]
+     */
+    Scalar thcwater() const
+    { EnsureFinalized::check(); return thcwater_; }
+
+private:
+    Scalar porosity_;
+    Scalar thcrock_;
+    Scalar thcoil_;
+    Scalar thcgas_;
+    Scalar thcwater_;
+};
+
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclThconrLaw.hpp
+++ b/opm/material/thermal/EclThconrLaw.hpp
@@ -1,0 +1,69 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclThconrLaw
+ */
+#ifndef OPM_ECL_THCONR_LAW_HPP
+#define OPM_ECL_THCONR_LAW_HPP
+
+#include "EclThconrLawParams.hpp"
+
+#include <opm/material/densead/Math.hpp>
+
+namespace Opm
+{
+/*!
+ * \ingroup material
+ *
+ * \brief Implements the total heat conductivity and rock enthalpy relations used by ECL.
+ */
+template <class ScalarT,
+          class FluidSystem,
+          class ParamsT = EclThconrLawParams<ScalarT> >
+class EclThconrLaw
+{
+public:
+    typedef ParamsT Params;
+    typedef typename Params::Scalar Scalar;
+
+    /*!
+     * \brief Given a fluid state, return the total heat conductivity [W/m^2 / (K/m)] of the porous
+     *        medium.
+     */
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
+    static Evaluation heatConductivity(const Params& params,
+                                       const FluidState& fluidState)
+    {
+        // THCONR + THCONSF approach.
+        Scalar lambdaRef = params.referenceTotalHeatConductivity();
+        Scalar alpha = params.dTotalHeatConductivity_dSg();
+
+        static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
+        const Evaluation& Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        return lambdaRef*(1.0 - alpha*Sg);
+    }
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclThconrLawParams.hpp
+++ b/opm/material/thermal/EclThconrLawParams.hpp
@@ -1,0 +1,80 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclThconrLawParams
+ */
+#ifndef OPM_ECL_THCONR_LAW_PARAMS_HPP
+#define OPM_ECL_THCONR_LAW_PARAMS_HPP
+
+#include <opm/material/common/EnsureFinalized.hpp>
+
+namespace Opm {
+
+/*!
+ * \brief The default implementation of a parameter object for the
+ *        heat conduction law based on the THCONR keyword from ECL.
+ */
+template <class ScalarT>
+class EclThconrLawParams : public EnsureFinalized
+{
+public:
+    typedef ScalarT Scalar;
+
+    EclThconrLawParams(const EclThconrLawParams&) = default;
+
+    EclThconrLawParams()
+    { }
+
+    /*!
+     * \brief Set the total heat conductivity [J/m^2 / (K/m)] of at Sg = 0
+     */
+    void setReferenceTotalHeatConductivity(Scalar value)
+    { referenceTotalHeatConductivity_ = value; }
+
+    /*!
+     * \brief The total heat conductivity [J/m^2 / (K/m)] of at Sg = 0
+     */
+    Scalar referenceTotalHeatConductivity() const
+    { EnsureFinalized::check(); return referenceTotalHeatConductivity_; }
+
+    /*!
+     * \brief Set the gas saturation dependence of heat conductivity [-]
+     */
+    void setDTotalHeatConductivity_dSg(Scalar value)
+    { dTotalHeatConductivity_dSg_ = value; }
+
+    /*!
+     * \brief The gas saturation dependence of heat conductivity [-]
+     */
+    Scalar dTotalHeatConductivity_dSg() const
+    { EnsureFinalized::check(); return dTotalHeatConductivity_dSg_; }
+
+private:
+    Scalar referenceTotalHeatConductivity_;
+    Scalar dTotalHeatConductivity_dSg_;
+};
+
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/EclThermalLawManager.hpp
+++ b/opm/material/thermal/EclThermalLawManager.hpp
@@ -1,0 +1,325 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclThermalLawManager
+ */
+#if ! HAVE_OPM_PARSER
+#error "The opm-parser module is required to use the ECL thermal law manager!"
+#endif
+
+#ifndef OPM_ECL_THERMAL_LAW_MANAGER_HPP
+#define OPM_ECL_THERMAL_LAW_MANAGER_HPP
+
+#include "EclSolidHeatLawMultiplexer.hpp"
+#include "EclSolidHeatLawMultiplexerParams.hpp"
+
+#include "EclHeatConductionLawMultiplexer.hpp"
+#include "EclHeatConductionLawMultiplexerParams.hpp"
+
+#include <opm/common/Exceptions.hpp>
+#include <opm/common/ErrorMacros.hpp>
+
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+namespace Opm {
+
+/*!
+ * \ingroup fluidmatrixinteractions
+ *
+ * \brief Provides an simple way to create and manage the thermal law objects
+ *        for a complete ECL deck.
+ */
+template <class Scalar, class FluidSystem>
+class EclThermalLawManager
+{
+public:
+    typedef EclSolidHeatLawMultiplexer<Scalar, FluidSystem> SolidHeatLaw;
+    typedef typename SolidHeatLaw::Params SolidHeatLawParams;
+    typedef typename SolidHeatLawParams::HeatcrLawParams HeatcrLawParams;
+    typedef typename SolidHeatLawParams::SpecrockLawParams SpecrockLawParams;
+
+    typedef EclHeatConductionLawMultiplexer<Scalar, FluidSystem> HeatConductionLaw;
+    typedef typename HeatConductionLaw::Params HeatConductionLawParams;
+
+    EclThermalLawManager()
+    {
+        solidEnergyApproach_ = SolidHeatLawParams::undefinedApproach;
+        heatCondApproach_ = HeatConductionLawParams::undefinedApproach;
+    }
+
+    void initFromDeck(const Opm::Deck& deck,
+                      const Opm::EclipseState& eclState,
+                      const std::vector<int>& compressedToCartesianElemIdx)
+    {
+        const auto& props = eclState.get3DProperties();
+        if (props.hasDeckDoubleGridProperty("HEATCR"))
+            initHeatcr_(deck, eclState, compressedToCartesianElemIdx);
+        else if (deck.hasKeyword("SPECROCK"))
+            initSpecrock_(deck, eclState, compressedToCartesianElemIdx);
+        else
+            initNullRockEnergy_(deck, eclState, compressedToCartesianElemIdx);
+
+        if (props.hasDeckDoubleGridProperty("THCONR"))
+            initThconr_(deck, eclState, compressedToCartesianElemIdx);
+        else if (props.hasDeckDoubleGridProperty("THCROCK")
+                 || props.hasDeckDoubleGridProperty("THCOIL")
+                 || props.hasDeckDoubleGridProperty("THCGAS")
+                 || props.hasDeckDoubleGridProperty("THCWATER"))
+            initThc_(deck, eclState, compressedToCartesianElemIdx);
+        else
+            initNullCond_(deck, eclState, compressedToCartesianElemIdx);
+    }
+
+    const SolidHeatLawParams& solidHeatLawParams(unsigned elemIdx) const
+    {
+        switch (solidEnergyApproach_) {
+        case SolidHeatLawParams::heatcrApproach:
+            assert(0 <= elemIdx && elemIdx <  solidHeatLawParams_.size());
+            return solidHeatLawParams_[elemIdx];
+
+        case SolidHeatLawParams::specrockApproach:
+        {
+            assert(0 <= elemIdx && elemIdx <  elemToSatnumIdx_.size());
+            unsigned satnumIdx = elemToSatnumIdx_[elemIdx];
+            assert(0 <= satnumIdx && satnumIdx <  solidHeatLawParams_.size());
+            return solidHeatLawParams_[satnumIdx];
+        }
+
+        case SolidHeatLawParams::nullApproach:
+            return solidHeatLawParams_[0];
+
+        default:
+            OPM_THROW(std::runtime_error,
+                      "Attempting to retrieve solid energy storage parameters without "
+                      "a known approach being defined by the deck.");
+        }
+    }
+
+    const HeatConductionLawParams& heatConductionLawParams(unsigned elemIdx) const
+    {
+        switch (heatCondApproach_) {
+        case HeatConductionLawParams::thconrApproach:
+        case HeatConductionLawParams::thcApproach:
+            assert(0 <= elemIdx && elemIdx <  heatConductionLawParams_.size());
+            return heatConductionLawParams_[elemIdx];
+
+        case HeatConductionLawParams::nullApproach:
+            return heatConductionLawParams_[0];
+
+        default:
+            OPM_THROW(std::runtime_error,
+                      "Attempting to retrieve heat conduction parameters without "
+                      "a known approach being defined by the deck.");
+        }
+    }
+
+private:
+    /*!
+     * \brief Initialize the parameters for the rock heat law using using HEATCR and friends.
+     */
+    void initHeatcr_(const Opm::Deck& deck,
+                     const Opm::EclipseState& eclState,
+                     const std::vector<int>& compressedToCartesianElemIdx)
+    {
+        solidEnergyApproach_ = SolidHeatLawParams::heatcrApproach;
+
+        const auto& props = eclState.get3DProperties();
+
+        const std::vector<double>& heatcrData = props.getDoubleGridProperty("HEATCR").getData();
+        const std::vector<double>& heatcrtData = props.getDoubleGridProperty("HEATCRT").getData();
+
+        // actually the value of the reference temperature does not matter for energy
+        // conservation. We set it anyway to faciliate comparisons with ECL
+        HeatcrLawParams::setReferenceTemperature(FluidSystem::surfaceTemperature);
+
+        unsigned numElems = compressedToCartesianElemIdx.size();
+        solidHeatLawParams_.resize(numElems);
+        for (unsigned elemIdx = 0; elemIdx < numElems; ++elemIdx) {
+            int cartElemIdx = compressedToCartesianElemIdx[elemIdx];
+
+            auto& elemParam = solidHeatLawParams_[elemIdx];
+
+            elemParam.setSolidEnergyApproach(SolidHeatLawParams::heatcrApproach);
+
+            auto& heatcrElemParams = elemParam.template getRealParams<SolidHeatLawParams::heatcrApproach>();
+            heatcrElemParams.setReferenceRockHeatCapacity(heatcrData[cartElemIdx]);
+            heatcrElemParams.setDRockHeatCapacity_dT(heatcrtData[cartElemIdx]);
+            heatcrElemParams.finalize();
+
+            elemParam.finalize();
+        }
+    }
+
+    /*!
+     * \brief Initialize the parameters for the rock heat law using using SPECROCK and friends.
+     */
+    void initSpecrock_(const Opm::Deck& deck,
+                       const Opm::EclipseState& eclState,
+                       const std::vector<int>& compressedToCartesianElemIdx)
+    {
+        solidEnergyApproach_ = SolidHeatLawParams::specrockApproach;
+
+        // initialize the element index -> SATNUM index mapping
+        const auto& props = eclState.get3DProperties();
+        const std::vector<int>& satnumData = props.getIntGridProperty("SATNUM").getData();
+        elemToSatnumIdx_.resize(compressedToCartesianElemIdx.size());
+        for (unsigned elemIdx = 0; elemIdx < compressedToCartesianElemIdx.size(); ++ elemIdx) {
+            unsigned cartesianElemIdx = compressedToCartesianElemIdx[elemIdx];
+
+            // satnumData contains Fortran-style indices, i.e., they start with 1 instead
+            // of 0!
+            elemToSatnumIdx_[elemIdx] = satnumData[cartesianElemIdx] - 1;
+        }
+
+        // internalize the SPECROCK table
+        unsigned numSatRegions = eclState.runspec().tabdims().getNumSatTables();
+        const auto& tableManager = eclState.getTableManager();
+        solidHeatLawParams_.resize(numSatRegions);
+        for (unsigned satnumIdx = 0; satnumIdx < numSatRegions; ++satnumIdx) {
+            const auto& specrockTable = tableManager.getSpecrockTables()[satnumIdx];
+
+            auto& multiplexerParams = solidHeatLawParams_[satnumIdx];
+
+            multiplexerParams.setSolidEnergyApproach(SolidHeatLawParams::specrockApproach);
+
+            auto& specrockParams = multiplexerParams.template getRealParams<SolidHeatLawParams::specrockApproach>();
+            const auto& temperatureColumn = specrockTable.getColumn("TEMPERATURE");
+            const auto& cpRockColumn = specrockTable.getColumn("CP_ROCK");
+            specrockParams.setHeatCapacities(temperatureColumn, cpRockColumn);
+            specrockParams.finalize();
+
+            multiplexerParams.finalize();
+        }
+    }
+
+    /*!
+     * \brief Set the heat capacity of rock to 0
+     */
+    void initNullRockEnergy_(const Opm::Deck& deck,
+                      const Opm::EclipseState& eclState,
+                      const std::vector<int>& compressedToCartesianElemIdx)
+    {
+        solidEnergyApproach_ = SolidHeatLawParams::nullApproach;
+
+        solidHeatLawParams_.resize(1);
+        solidHeatLawParams_[0].finalize();
+    }
+
+    /*!
+     * \brief Initialize the parameters for the heat conduction law using THCONR and friends.
+     */
+    void initThconr_(const Opm::Deck& deck,
+                     const Opm::EclipseState& eclState,
+                     const std::vector<int>& compressedToCartesianElemIdx)
+    {
+        heatCondApproach_ = HeatConductionLawParams::thconrApproach;
+
+        const auto& props = eclState.get3DProperties();
+
+        const std::vector<double>& thconrData = props.getDoubleGridProperty("THCONR").getData();
+        const std::vector<double>& thconsfData = props.getDoubleGridProperty("THCONSF").getData();
+
+        unsigned numElems = compressedToCartesianElemIdx.size();
+        heatConductionLawParams_.resize(numElems);
+        for (unsigned elemIdx = 0; elemIdx < numElems; ++elemIdx) {
+            int cartElemIdx = compressedToCartesianElemIdx[elemIdx];
+
+            auto& elemParams = heatConductionLawParams_[elemIdx];
+
+            elemParams.setHeatConductionApproach(HeatConductionLawParams::thconrApproach);
+
+            auto& thconrElemParams = elemParams.template getRealParams<HeatConductionLawParams::thconrApproach>();
+            thconrElemParams.setReferenceTotalHeatConductivity(thconrData[cartElemIdx]);
+            thconrElemParams.setDTotalHeatConductivity_dSg(thconsfData[cartElemIdx]);
+            thconrElemParams.finalize();
+
+            elemParams.finalize();
+        }
+    }
+
+    /*!
+     * \brief Initialize the parameters for the heat conduction law using THCROCK and friends.
+     */
+    void initThc_(const Opm::Deck& deck,
+                  const Opm::EclipseState& eclState,
+                  const std::vector<int>& compressedToCartesianElemIdx)
+    {
+        heatCondApproach_ = HeatConductionLawParams::thcApproach;
+
+        const auto& props = eclState.get3DProperties();
+
+        const std::vector<double>& thcrockData = props.getDoubleGridProperty("THCROCK").getData();
+        const std::vector<double>& thcoilData = props.getDoubleGridProperty("THCOIL").getData();
+        const std::vector<double>& thcgasData = props.getDoubleGridProperty("THCGAS").getData();
+        const std::vector<double>& thcwaterData = props.getDoubleGridProperty("THCWATER").getData();
+        const std::vector<double>& poroData = props.getDoubleGridProperty("PORO").getData();
+
+        unsigned numElems = compressedToCartesianElemIdx.size();
+        heatConductionLawParams_.resize(numElems);
+        for (unsigned elemIdx = 0; elemIdx < numElems; ++elemIdx) {
+            int cartElemIdx = compressedToCartesianElemIdx[elemIdx];
+
+            auto& elemParams = heatConductionLawParams_[elemIdx];
+
+            elemParams.setHeatConductionApproach(HeatConductionLawParams::thcApproach);
+
+            auto& thcElemParams = elemParams.template getRealParams<HeatConductionLawParams::thcApproach>();
+            thcElemParams.setPorosity(poroData[cartElemIdx]);
+            thcElemParams.setThcrock(thcrockData[cartElemIdx]);
+            thcElemParams.setThcoil(thcoilData[cartElemIdx]);
+            thcElemParams.setThcgas(thcgasData[cartElemIdx]);
+            thcElemParams.setThcwater(thcwaterData[cartElemIdx]);
+            thcElemParams.finalize();
+
+            elemParams.finalize();
+        }
+    }
+
+    /*!
+     * \brief Disable heat conductivity
+     */
+    void initNullCond_(const Opm::Deck& deck,
+                       const Opm::EclipseState& eclState,
+                       const std::vector<int>& compressedToCartesianElemIdx)
+    {
+        heatCondApproach_ = HeatConductionLawParams::nullApproach;
+
+        heatConductionLawParams_.resize(1);
+        heatConductionLawParams_[0].finalize();
+    }
+
+private:
+    typename HeatConductionLawParams::HeatConductionApproach heatCondApproach_;
+    typename SolidHeatLawParams::SolidEnergyApproach solidEnergyApproach_;
+
+    std::vector<unsigned> elemToSatnumIdx_;
+
+    std::vector<SolidHeatLawParams> solidHeatLawParams_;
+    std::vector<HeatConductionLawParams> heatConductionLawParams_;
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/FluidHeatConductionLaw.hpp
+++ b/opm/material/thermal/FluidHeatConductionLaw.hpp
@@ -24,10 +24,10 @@
  * \file
  * \copydoc Opm::FluidHeatConduction
  */
-#ifndef OPM_FLUID_HEAT_CONDUCTION_HPP
-#define OPM_FLUID_HEAT_CONDUCTION_HPP
+#ifndef OPM_FLUID_HEAT_CONDUCTION_LAW_HPP
+#define OPM_FLUID_HEAT_CONDUCTION_LAW_HPP
 
-#include "FluidConductionParams.hpp"
+#include "FluidHeatConductionLawParams.hpp"
 
 #include <opm/material/common/Spline.hpp>
 
@@ -42,8 +42,8 @@ namespace Opm {
 template <class FluidSystem,
           class ScalarT,
           int phaseIdx,
-          class ParamsT = FluidHeatConductionParams<ScalarT> >
-class FluidHeatConduction
+          class ParamsT = FluidHeatConductionLawParams<ScalarT> >
+class FluidHeatConductionLaw
 {
 public:
     typedef ParamsT Params;

--- a/opm/material/thermal/FluidHeatConductionLawParams.hpp
+++ b/opm/material/thermal/FluidHeatConductionLawParams.hpp
@@ -24,24 +24,24 @@
  * \file
  * \copydoc Opm::FluidHeatConductionParams
  */
-#ifndef OPM_FLUID_HEAT_CONDUCTION_PARAMS_HPP
-#define OPM_FLUID_HEAT_CONDUCTION_PARAMS_HPP
+#ifndef OPM_FLUID_HEAT_CONDUCTION_LAW_PARAMS_HPP
+#define OPM_FLUID_HEAT_CONDUCTION_LAW_PARAMS_HPP
 
 namespace Opm {
 /*!
  * \brief Parameters for the heat conduction law which just takes the conductivity of a given fluid phase.
  */
 template <class ScalarT>
-class FluidHeatConductionParams
+class FluidHeatConductionLawParams
 {
     // do not copy!
-    FluidHeatConductionParams(const FluidHeatConductionParams&)
+    FluidHeatConductionLawParams(const FluidHeatConductionLawParams&)
     {}
 
 public:
     typedef ScalarT Scalar;
 
-    FluidHeatConductionParams()
+    FluidHeatConductionLawParams()
     { }
 
 };

--- a/opm/material/thermal/NullHeatConductionLaw.hpp
+++ b/opm/material/thermal/NullHeatConductionLaw.hpp
@@ -1,0 +1,64 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::NullHeatConductionLaw
+ */
+#ifndef OPM_NULL_HEATCONDUCTION_LAW_HPP
+#define OPM_NULL_HEATCONDUCTION_LAW_HPP
+
+#include <opm/common/Unused.hpp>
+#include <opm/common/Exceptions.hpp>
+#include <opm/common/ErrorMacros.hpp>
+
+namespace Opm
+{
+/*!
+ * \ingroup material
+ *
+ * \brief Implements a dummy law for heat conduction to which isothermal models
+ *        can fall back to.
+ *
+ * This law just returns 0 unconditionally.
+ */
+template <class ScalarT>
+class NullHeatConductionLaw
+{
+public:
+    typedef int Params;
+    typedef ScalarT Scalar;
+
+    /*!
+     * \brief Given a fluid state, return the effective heat conductivity [W/m^2 / (K/m)] of the porous
+     *        medium.
+     *
+     * If this method is called an exception is thrown at run time.
+     */
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
+    static Evaluation heatConductivity(const Params& params OPM_UNUSED,
+                                       const FluidState& fluidState OPM_UNUSED)
+    { return 0.0; }
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/NullSolidEnergyLaw.hpp
+++ b/opm/material/thermal/NullSolidEnergyLaw.hpp
@@ -1,0 +1,58 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::NullSolidEnergyLaw
+ */
+#ifndef OPM_NULL_SOLID_ENERGY_LAW_HPP
+#define OPM_NULL_SOLID_ENERGY_LAW_HPP
+
+#include <opm/material/densead/Math.hpp>
+
+namespace Opm
+{
+/*!
+ * \ingroup material
+ *
+ * \brief Implements a solid energy storage law which just returns 0.
+ */
+template <class ScalarT>
+class NullSolidEnergyLaw
+{
+public:
+    typedef int Params;
+    typedef ScalarT Scalar;
+
+    /*!
+     * \brief Given a fluid state, compute the volumetric internal energy of the solid
+     *        matrix [W/m^3].
+     *
+     * This solid energy law simply returns 0.
+     */
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
+    static Evaluation solidInternalEnergy(const Params& params, const FluidState& fluidState)
+    { return 0.0; }
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/thermal/SomertonHeatConductionLaw.hpp
+++ b/opm/material/thermal/SomertonHeatConductionLaw.hpp
@@ -22,12 +22,12 @@
 */
 /*!
  * \file
- * \copydoc Opm::Somerton
+ * \copydoc Opm::SomertonHeatConductionLaw
  */
-#ifndef OPM_SOMERTON_HPP
-#define OPM_SOMERTON_HPP
+#ifndef OPM_SOMERTON_HEAT_CONDUCTION_LAW_HPP
+#define OPM_SOMERTON_HEAT_CONDUCTION_LAW_HPP
 
-#include "SomertonParams.hpp"
+#include "SomertonHeatConductionLawParams.hpp"
 
 #include <opm/material/common/Spline.hpp>
 
@@ -59,8 +59,8 @@ namespace Opm
  */
 template <class FluidSystem,
           class ScalarT,
-          class ParamsT = SomertonParams<FluidSystem::numPhases, ScalarT> >
-class Somerton
+          class ParamsT = SomertonHeatConductionLawParams<FluidSystem::numPhases, ScalarT> >
+class SomertonHeatConductionLaw
 {
     enum { numPhases = FluidSystem::numPhases };
 
@@ -86,7 +86,7 @@ public:
      * phase \f$\alpha\f$ and \f$S_\alpha\f$ is the saturation of
      * phase \f$\alpha\f$.
      */
-    template <class FluidState, class Evaluation = Scalar>
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation heatConductivity(const Params& params,
                                        const FluidState& fluidState)
     {

--- a/opm/material/thermal/SomertonHeatConductionLawParams.hpp
+++ b/opm/material/thermal/SomertonHeatConductionLawParams.hpp
@@ -22,10 +22,10 @@
 */
 /*!
  * \file
- * \copydoc Opm::SomertonParams
+ * \copydoc Opm::SomertonHeatConductionLawParams
  */
-#ifndef OPM_SOMERTON_PARAMS_HPP
-#define OPM_SOMERTON_PARAMS_HPP
+#ifndef OPM_SOMERTON_HEAT_CONDUCTION_LAW_PARAMS_HPP
+#define OPM_SOMERTON_HEAT_CONDUCTION_LAW_PARAMS_HPP
 
 #include <cassert>
 
@@ -33,19 +33,19 @@ namespace Opm {
 
 /*!
  * \brief The default implementation of a parameter object for the
- *        Somerton heatconduction law.
+ *        Somerton heat conduction law.
  */
 template <unsigned numPhases, class ScalarT>
-class SomertonParams
+class SomertonHeatConductionLawParams
 {
     // do not copy!
-    SomertonParams(const SomertonParams&)
+    SomertonHeatConductionLawParams(const SomertonHeatConductionLawParams&)
     {}
 
 public:
     typedef ScalarT Scalar;
 
-    SomertonParams()
+    SomertonHeatConductionLawParams()
     { }
 
     /*!

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -43,6 +43,8 @@
 #include <opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp>
 #include <opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp>
 
+#include <opm/material/thermal/FluidHeatConductionLaw.hpp>
+
 // include all fluid states
 #include <opm/material/fluidstates/PressureOverlayFluidState.hpp>
 #include <opm/material/fluidstates/SaturationOverlayFluidState.hpp>


### PR DESCRIPTION
this implements the relations to provide full support for ECL-style temperature and thermal simulations. it requires OPM/ewoms#249 to mop-up and until OPM/opm-parser#1170 is merged a exception is thrown by the parser if the deck uses the `THC*` keyword family to specify thermal conductivity.