### PR TITLE
compute the inverse formation volume factor for generic fluid states

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -251,17 +251,23 @@ public:
      */
     static void initBegin(size_t numPvtRegions)
     {
+        isInitialized_ = false;
+
         enableDissolvedGas_ = true;
         enableVaporizedOil_ = false;
 
+        oilPvt_ = nullptr;
+        gasPvt_ = nullptr;
+        waterPvt_ = nullptr;
+
         surfaceTemperature = 273.15 + 15.56; // [K]
         surfacePressure = 1.01325e5; // [Pa]
+        setReservoirTemperature(surfaceTemperature);
+
         numActivePhases_ = numPhases;
         std::fill(&phaseIsActive_[0], &phaseIsActive_[numPhases], true);
 
         resizeArrays_(numPvtRegions);
-
-        setReservoirTemperature(surfaceTemperature);
     }
 
     /*!


### PR DESCRIPTION
before this change, if the fluid state did not provide an invB() method, Opm::getInvB_() just returned 0.0. with this, it uses the composition and density of the phase in question to compute that quantity.

also, this commit contains a few mostly stylistic cleanups for BlackOilFluidSystem.