### PR TITLE
thoroughly rename the thermal laws

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -131,7 +131,14 @@ public:
 
                 std::vector<double> hSamples(temperatureColumn.size());
 
-                Scalar h = temperatureColumn[0]*cpGasColumn[0];
+                // the specific enthalpy of vaporization. since ECL does not seem to
+                // feature a proper way to specify this quantity, we use the value for
+                // methane. A proper model would also need to consider the enthalpy
+                // change due to dissolution, i.e. the enthalpies of the gas and oil
+                // phases should depend on the phase composition
+                const Scalar hVap = 480.6e3; // [J / kg]
+
+                Scalar h = temperatureColumn[0]*cpGasColumn[0] + hVap;
                 for (size_t i = 0;; ++i) {
                     hSamples[i] = h;
 

--- a/opm/material/thermal/EclSolidEnergyLawMultiplexer.hpp
+++ b/opm/material/thermal/EclSolidEnergyLawMultiplexer.hpp
@@ -22,12 +22,12 @@
 */
 /*!
  * \file
- * \copydoc Opm::EclSolidHeatLawMultiplexer
+ * \copydoc Opm::EclSolidEnergyLawMultiplexer
  */
-#ifndef OPM_ECL_SOLID_HEAT_LAW_MULTIPLEXER_HPP
-#define OPM_ECL_SOLID_HEAT_LAW_MULTIPLEXER_HPP
+#ifndef OPM_ECL_SOLID_ENERGY_LAW_MULTIPLEXER_HPP
+#define OPM_ECL_SOLID_ENERGY_LAW_MULTIPLEXER_HPP
 
-#include "EclSolidHeatLawMultiplexerParams.hpp"
+#include "EclSolidEnergyLawMultiplexerParams.hpp"
 
 #include "EclHeatcrLaw.hpp"
 #include "EclSpecrockLaw.hpp"
@@ -40,12 +40,12 @@ namespace Opm
 /*!
  * \ingroup material
  *
- * \brief Implements the total heat conductivity and rock enthalpy relations used by ECL.
+ * \brief Provides the energy storage relation of rock
  */
 template <class ScalarT,
           class FluidSystem,
-          class ParamsT = EclSolidHeatLawMultiplexerParams<ScalarT>>
-class EclSolidHeatLawMultiplexer
+          class ParamsT = EclSolidEnergyLawMultiplexerParams<ScalarT>>
+class EclSolidEnergyLawMultiplexer
 {
     enum { numPhases = FluidSystem::numPhases };
 

--- a/opm/material/thermal/EclSolidEnergyLawMultiplexerParams.hpp
+++ b/opm/material/thermal/EclSolidEnergyLawMultiplexerParams.hpp
@@ -22,10 +22,10 @@
 */
 /*!
  * \file
- * \copydoc Opm::EclSolidHeatLawMultiplexerParams
+ * \copydoc Opm::EclSolidEnergyLawMultiplexerParams
  */
-#ifndef OPM_ECL_SOLID_HEAT_LAW_MULTIPLEXER_PARAMS_HPP
-#define OPM_ECL_SOLID_HEAT_LAW_MULTIPLEXER_PARAMS_HPP
+#ifndef OPM_ECL_SOLID_ENERGY_LAW_MULTIPLEXER_PARAMS_HPP
+#define OPM_ECL_SOLID_ENERGY_LAW_MULTIPLEXER_PARAMS_HPP
 
 #include "EclHeatcrLawParams.hpp"
 #include "EclSpecrockLawParams.hpp"
@@ -41,7 +41,7 @@ namespace Opm {
  *        ECL thermal law.
  */
 template <class ScalarT>
-class EclSolidHeatLawMultiplexerParams : public EnsureFinalized
+class EclSolidEnergyLawMultiplexerParams : public EnsureFinalized
 {
     typedef void* ParamPointerType;
 
@@ -58,12 +58,12 @@ public:
     typedef Opm::EclHeatcrLawParams<ScalarT> HeatcrLawParams;
     typedef Opm::EclSpecrockLawParams<ScalarT> SpecrockLawParams;
 
-    EclSolidHeatLawMultiplexerParams(const EclSolidHeatLawMultiplexerParams&) = default;
+    EclSolidEnergyLawMultiplexerParams(const EclSolidEnergyLawMultiplexerParams&) = default;
 
-    EclSolidHeatLawMultiplexerParams()
+    EclSolidEnergyLawMultiplexerParams()
     { solidEnergyApproach_ = undefinedApproach; }
 
-    ~EclSolidHeatLawMultiplexerParams()
+    ~EclSolidEnergyLawMultiplexerParams()
     { destroy_(); }
 
     void setSolidEnergyApproach(SolidEnergyApproach newApproach)
@@ -74,7 +74,7 @@ public:
         switch (solidEnergyApproach()) {
         case undefinedApproach:
             OPM_THROW(std::logic_error,
-                      "Cannot set the approach for solid heat storage to 'undefined'!");
+                      "Cannot set the approach for solid energy storage to 'undefined'!");
 
         case heatcrApproach:
             realParams_ = new HeatcrLawParams;

--- a/opm/material/thermal/EclThcLaw.hpp
+++ b/opm/material/thermal/EclThcLaw.hpp
@@ -36,9 +36,9 @@ namespace Opm
 /*!
  * \ingroup material
  *
- * \brief Implements the total heat conductivity and rock enthalpy relations used by ECL.
+ * \brief Implements the total thermal conductivity and rock enthalpy relations used by ECL.
  *
- * This is the heat conduction law based on the THCROCK, THCOIL, THCGAS and THCWATER
+ * This is the thermal conduction law based on the THCROCK, THCOIL, THCGAS and THCWATER
  * keywords.
  */
 template <class ScalarT,
@@ -50,19 +50,19 @@ public:
     typedef typename Params::Scalar Scalar;
 
     /*!
-     * \brief Given a fluid state, return the total heat conductivity [W/m^2 / (K/m)] of the porous
+     * \brief Given a fluid state, return the total thermal conductivity [W/m^2 / (K/m)] of the porous
      *        medium.
       */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation heatConductivity(const Params& params,
-                                       const FluidState& fluidState)
+    static Evaluation thermalConductivity(const Params& params,
+                                          const FluidState& fluidState)
     {
         // The thermal conductivity approach based on the THC* keywords.
 
         // let's assume that the porosity of the rock at standard condition is meant
         Scalar poro = params.porosity();
 
-        // IMO this approach is very questionable because the total heat conductivity
+        // IMO this approach is very questionable because the total thermal conductivity
         // should at least depend on the current solution's phase saturation. Since ECL
         // is king, let's follow their lead and throw ourselfs down the cliff of obvious
         // incorrectness.

--- a/opm/material/thermal/EclThcLawParams.hpp
+++ b/opm/material/thermal/EclThcLawParams.hpp
@@ -33,7 +33,7 @@ namespace Opm {
 
 /*!
  * \brief The default implementation of a parameter object for the
- *        heat conduction law based on the THC* keywords from ECL.
+ *        thermal conduction law based on the THC* keywords from ECL.
  */
 template <class ScalarT>
 class EclThcLawParams : public EnsureFinalized

--- a/opm/material/thermal/EclThconrLaw.hpp
+++ b/opm/material/thermal/EclThconrLaw.hpp
@@ -36,7 +36,7 @@ namespace Opm
 /*!
  * \ingroup material
  *
- * \brief Implements the total heat conductivity and rock enthalpy relations used by ECL.
+ * \brief Implements the total thermal conductivity relations specified by the ECL THCONR.
  */
 template <class ScalarT,
           class FluidSystem,
@@ -48,16 +48,16 @@ public:
     typedef typename Params::Scalar Scalar;
 
     /*!
-     * \brief Given a fluid state, return the total heat conductivity [W/m^2 / (K/m)] of the porous
+     * \brief Given a fluid state, return the total thermal conductivity [W/m^2 / (K/m)] of the porous
      *        medium.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation heatConductivity(const Params& params,
-                                       const FluidState& fluidState)
+    static Evaluation thermalConductivity(const Params& params,
+                                          const FluidState& fluidState)
     {
         // THCONR + THCONSF approach.
-        Scalar lambdaRef = params.referenceTotalHeatConductivity();
-        Scalar alpha = params.dTotalHeatConductivity_dSg();
+        Scalar lambdaRef = params.referenceTotalThermalConductivity();
+        Scalar alpha = params.dTotalThermalConductivity_dSg();
 
         static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
         const Evaluation& Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));

--- a/opm/material/thermal/EclThconrLawParams.hpp
+++ b/opm/material/thermal/EclThconrLawParams.hpp
@@ -33,7 +33,7 @@ namespace Opm {
 
 /*!
  * \brief The default implementation of a parameter object for the
- *        heat conduction law based on the THCONR keyword from ECL.
+ *        thermal conduction law based on the THCONR keyword from ECL.
  */
 template <class ScalarT>
 class EclThconrLawParams : public EnsureFinalized
@@ -47,32 +47,32 @@ public:
     { }
 
     /*!
-     * \brief Set the total heat conductivity [J/m^2 / (K/m)] of at Sg = 0
+     * \brief Set the total thermal conductivity [J/m^2 / (K/m)] of at Sg = 0
      */
-    void setReferenceTotalHeatConductivity(Scalar value)
-    { referenceTotalHeatConductivity_ = value; }
+    void setReferenceTotalThermalConductivity(Scalar value)
+    { referenceTotalThermalConductivity_ = value; }
 
     /*!
-     * \brief The total heat conductivity [J/m^2 / (K/m)] of at Sg = 0
+     * \brief The total thermal conductivity [J/m^2 / (K/m)] of at Sg = 0
      */
-    Scalar referenceTotalHeatConductivity() const
-    { EnsureFinalized::check(); return referenceTotalHeatConductivity_; }
+    Scalar referenceTotalThermalConductivity() const
+    { EnsureFinalized::check(); return referenceTotalThermalConductivity_; }
 
     /*!
-     * \brief Set the gas saturation dependence of heat conductivity [-]
+     * \brief Set the gas saturation dependence of thermal conductivity [-]
      */
-    void setDTotalHeatConductivity_dSg(Scalar value)
-    { dTotalHeatConductivity_dSg_ = value; }
+    void setDTotalThermalConductivity_dSg(Scalar value)
+    { dTotalThermalConductivity_dSg_ = value; }
 
     /*!
-     * \brief The gas saturation dependence of heat conductivity [-]
+     * \brief The gas saturation dependence of thermal conductivity [-]
      */
-    Scalar dTotalHeatConductivity_dSg() const
-    { EnsureFinalized::check(); return dTotalHeatConductivity_dSg_; }
+    Scalar dTotalThermalConductivity_dSg() const
+    { EnsureFinalized::check(); return dTotalThermalConductivity_dSg_; }
 
 private:
-    Scalar referenceTotalHeatConductivity_;
-    Scalar dTotalHeatConductivity_dSg_;
+    Scalar referenceTotalThermalConductivity_;
+    Scalar dTotalThermalConductivity_dSg_;
 };
 
 } // namespace Opm

--- a/opm/material/thermal/EclThermalConductionLawMultiplexer.hpp
+++ b/opm/material/thermal/EclThermalConductionLawMultiplexer.hpp
@@ -22,16 +22,16 @@
 */
 /*!
  * \file
- * \copydoc Opm::EclHeatConductionLawMultiplexer
+ * \copydoc Opm::EclThermalConductionLawMultiplexer
  */
-#ifndef OPM_ECL_HEAT_CONDUCTION_LAW_MULTIPLEXER_HPP
-#define OPM_ECL_HEAT_CONDUCTION_LAW_MULTIPLEXER_HPP
+#ifndef OPM_ECL_THERMAL_CONDUCTION_LAW_MULTIPLEXER_HPP
+#define OPM_ECL_THERMAL_CONDUCTION_LAW_MULTIPLEXER_HPP
 
-#include "EclHeatConductionLawMultiplexerParams.hpp"
+#include "EclThermalConductionLawMultiplexerParams.hpp"
 
 #include "EclThconrLaw.hpp"
 #include "EclThcLaw.hpp"
-#include "NullHeatConductionLaw.hpp"
+#include "NullThermalConductionLaw.hpp"
 
 #include <opm/material/densead/Math.hpp>
 
@@ -40,18 +40,18 @@ namespace Opm
 /*!
  * \ingroup material
  *
- * \brief Implements the total heat conductivity and rock enthalpy relations used by ECL.
+ * \brief Implements the total thermal conductivity and rock enthalpy relations used by ECL.
  */
 template <class ScalarT,
           class FluidSystem,
-          class ParamsT = EclHeatConductionLawMultiplexerParams<ScalarT>>
-class EclHeatConductionLawMultiplexer
+          class ParamsT = EclThermalConductionLawMultiplexerParams<ScalarT>>
+class EclThermalConductionLawMultiplexer
 {
     enum { numPhases = FluidSystem::numPhases };
 
     typedef Opm::EclThconrLaw<ScalarT, FluidSystem, typename ParamsT::ThconrLawParams> ThconrLaw;
     typedef Opm::EclThcLaw<ScalarT, typename ParamsT::ThcLawParams> ThcLaw;
-    typedef Opm::NullHeatConductionLaw<ScalarT> NullLaw;
+    typedef Opm::NullThermalConductionLaw<ScalarT> NullLaw;
 
 public:
     typedef ParamsT Params;
@@ -61,24 +61,24 @@ public:
      * \brief Given a fluid state, compute the volumetric internal energy of the rock [W/m^3].
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation heatConductivity(const Params& params,
+    static Evaluation thermalConductivity(const Params& params,
                                        const FluidState& fluidState)
     {
-        switch (params.heatConductionApproach()) {
+        switch (params.thermalConductionApproach()) {
         case Params::thconrApproach:
             // relevant ECL keywords: THCONR and THCONSF
-            return ThconrLaw::heatConductivity(params.template getRealParams<Params::thconrApproach>(), fluidState);
+            return ThconrLaw::thermalConductivity(params.template getRealParams<Params::thconrApproach>(), fluidState);
 
         case Params::thcApproach:
             // relevant ECL keywords: THCROCK, THCOIL, THCGAS and THCWATER
-            return ThcLaw::heatConductivity(params.template getRealParams<Params::thcApproach>(), fluidState);
+            return ThcLaw::thermalConductivity(params.template getRealParams<Params::thcApproach>(), fluidState);
 
         case Params::nullApproach:
             // relevant ECL keywords: none or none recognized
-            return NullLaw::heatConductivity(0, fluidState);
+            return NullLaw::thermalConductivity(0, fluidState);
 
         default:
-            OPM_THROW(std::logic_error, "Invalid heat conductivity approach: " << params.heatConductionApproach());
+            OPM_THROW(std::logic_error, "Invalid thermal conductivity approach: " << params.thermalConductionApproach());
         }
     }
 };

--- a/opm/material/thermal/EclThermalConductionLawMultiplexerParams.hpp
+++ b/opm/material/thermal/EclThermalConductionLawMultiplexerParams.hpp
@@ -22,10 +22,10 @@
 */
 /*!
  * \file
- * \copydoc Opm::EclHeatConductivtyLawMultiplexerParams
+ * \copydoc Opm::EclThermalConductionLawMultiplexerParams
  */
-#ifndef OPM_ECL_HEAT_CONDUCTION_LAW_MULTIPLEXER_PARAMS_HPP
-#define OPM_ECL_HEAT_CONDUCTION_LAW_MULTIPLEXER_PARAMS_HPP
+#ifndef OPM_ECL_THERMAL_CONDUCTION_LAW_MULTIPLEXER_PARAMS_HPP
+#define OPM_ECL_THERMAL_CONDUCTION_LAW_MULTIPLEXER_PARAMS_HPP
 
 #include "EclThconrLawParams.hpp"
 #include "EclThcLawParams.hpp"
@@ -41,14 +41,14 @@ namespace Opm {
  *        ECL thermal law.
  */
 template <class ScalarT>
-class EclHeatConductionLawMultiplexerParams : public EnsureFinalized
+class EclThermalConductionLawMultiplexerParams : public EnsureFinalized
 {
     typedef void* ParamPointerType;
 
 public:
     typedef ScalarT Scalar;
 
-    enum HeatConductionApproach {
+    enum ThermalConductionApproach {
         undefinedApproach,
         thconrApproach, // keywords: THCONR, THCONSF
         thcApproach, // keywords: THCROCK, THCOIL, THCGAS, THCWATER
@@ -58,23 +58,23 @@ public:
     typedef Opm::EclThconrLawParams<ScalarT> ThconrLawParams;
     typedef Opm::EclThcLawParams<ScalarT> ThcLawParams;
 
-    EclHeatConductionLawMultiplexerParams(const EclHeatConductionLawMultiplexerParams&) = default;
+    EclThermalConductionLawMultiplexerParams(const EclThermalConductionLawMultiplexerParams&) = default;
 
-    EclHeatConductionLawMultiplexerParams()
-    { heatConductionApproach_ = undefinedApproach; }
+    EclThermalConductionLawMultiplexerParams()
+    { thermalConductionApproach_ = undefinedApproach; }
 
-    ~EclHeatConductionLawMultiplexerParams()
+    ~EclThermalConductionLawMultiplexerParams()
     { destroy_(); }
 
-    void setHeatConductionApproach(HeatConductionApproach newApproach)
+    void setThermalConductionApproach(ThermalConductionApproach newApproach)
     {
         destroy_();
 
-        heatConductionApproach_ = newApproach;
-        switch (heatConductionApproach()) {
+        thermalConductionApproach_ = newApproach;
+        switch (thermalConductionApproach()) {
         case undefinedApproach:
             OPM_THROW(std::logic_error,
-                      "Cannot set the approach for heat conduction to 'undefined'!");
+                      "Cannot set the approach for thermal conduction to 'undefined'!");
 
         case thconrApproach:
             realParams_ = new ThconrLawParams;
@@ -90,47 +90,47 @@ public:
         }
     }
 
-    HeatConductionApproach heatConductionApproach() const
-    { return heatConductionApproach_; }
+    ThermalConductionApproach thermalConductionApproach() const
+    { return thermalConductionApproach_; }
 
     // get the parameter object for the THCONR case
-    template <HeatConductionApproach approachV>
+    template <ThermalConductionApproach approachV>
     typename std::enable_if<approachV == thconrApproach, ThconrLawParams>::type&
     getRealParams()
     {
-        assert(heatConductionApproach() == approachV);
+        assert(thermalConductionApproach() == approachV);
         return *static_cast<ThconrLawParams*>(realParams_);
     }
 
-    template <HeatConductionApproach approachV>
+    template <ThermalConductionApproach approachV>
     typename std::enable_if<approachV == thconrApproach, const ThconrLawParams>::type&
     getRealParams() const
     {
-        assert(heatConductionApproach() == approachV);
+        assert(thermalConductionApproach() == approachV);
         return *static_cast<const ThconrLawParams*>(realParams_);
     }
 
     // get the parameter object for the THC* case
-    template <HeatConductionApproach approachV>
+    template <ThermalConductionApproach approachV>
     typename std::enable_if<approachV == thcApproach, ThcLawParams>::type&
     getRealParams()
     {
-        assert(heatConductionApproach() == approachV);
+        assert(thermalConductionApproach() == approachV);
         return *static_cast<ThcLawParams*>(realParams_);
     }
 
-    template <HeatConductionApproach approachV>
+    template <ThermalConductionApproach approachV>
     typename std::enable_if<approachV == thcApproach, const ThcLawParams>::type&
     getRealParams() const
     {
-        assert(heatConductionApproach() == approachV);
+        assert(thermalConductionApproach() == approachV);
         return *static_cast<const ThcLawParams*>(realParams_);
     }
 
 private:
     void destroy_()
     {
-        switch (heatConductionApproach()) {
+        switch (thermalConductionApproach()) {
         case undefinedApproach:
             break;
 
@@ -146,10 +146,10 @@ private:
             break;
         }
 
-        heatConductionApproach_ = undefinedApproach;
+        thermalConductionApproach_ = undefinedApproach;
     }
 
-    HeatConductionApproach heatConductionApproach_;
+    ThermalConductionApproach thermalConductionApproach_;
     ParamPointerType realParams_;
 };
 

--- a/opm/material/thermal/FluidThermalConductionLaw.hpp
+++ b/opm/material/thermal/FluidThermalConductionLaw.hpp
@@ -22,12 +22,12 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidHeatConduction
+ * \copydoc Opm::FluidThermalConduction
  */
-#ifndef OPM_FLUID_HEAT_CONDUCTION_LAW_HPP
-#define OPM_FLUID_HEAT_CONDUCTION_LAW_HPP
+#ifndef OPM_FLUID_THERMAL_CONDUCTION_LAW_HPP
+#define OPM_FLUID_THERMAL_CONDUCTION_LAW_HPP
 
-#include "FluidHeatConductionLawParams.hpp"
+#include "FluidThermalConductionLawParams.hpp"
 
 #include <opm/material/common/Spline.hpp>
 
@@ -37,25 +37,25 @@ namespace Opm {
 /*!
  * \ingroup material
  *
- * \brief Implements a heat conduction law which just takes the conductivity of a given fluid phase.
+ * \brief Implements a thermal conduction law which just takes the conductivity of a given fluid phase.
  */
 template <class FluidSystem,
           class ScalarT,
           int phaseIdx,
-          class ParamsT = FluidHeatConductionLawParams<ScalarT> >
-class FluidHeatConductionLaw
+          class ParamsT = FluidThermalConductionLawParams<ScalarT> >
+class FluidThermalConductionLaw
 {
 public:
     typedef ParamsT Params;
     typedef typename Params::Scalar Scalar;
 
     /*!
-     * \brief Given a fluid state, return the effective heat conductivity [W/m^2 / (K/m)] of the porous
+     * \brief Given a fluid state, return the effective thermal conductivity [W/m^2 / (K/m)] of the porous
      *        medium.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation heatConductivity(const Params& params OPM_UNUSED,
-                                       const FluidState& fluidState)
+    static Evaluation thermalConductivity(const Params& params OPM_UNUSED,
+                                          const FluidState& fluidState)
     {
         typename FluidSystem::template ParameterCache<Evaluation> paramCache;
         paramCache.updatePhase(fluidState, phaseIdx);

--- a/opm/material/thermal/FluidThermalConductionLawParams.hpp
+++ b/opm/material/thermal/FluidThermalConductionLawParams.hpp
@@ -22,43 +22,30 @@
 */
 /*!
  * \file
- * \copydoc Opm::NullHeatConductionLaw
+ * \copydoc Opm::FluidThermalConductionParams
  */
-#ifndef OPM_NULL_HEATCONDUCTION_LAW_HPP
-#define OPM_NULL_HEATCONDUCTION_LAW_HPP
+#ifndef OPM_FLUID_THERMAL_CONDUCTION_LAW_PARAMS_HPP
+#define OPM_FLUID_THERMAL_CONDUCTION_LAW_PARAMS_HPP
 
-#include <opm/common/Unused.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
-
-namespace Opm
-{
+namespace Opm {
 /*!
- * \ingroup material
- *
- * \brief Implements a dummy law for heat conduction to which isothermal models
- *        can fall back to.
- *
- * This law just returns 0 unconditionally.
+ * \brief Parameters for the thermal conduction law which just takes the conductivity of a given fluid phase.
  */
 template <class ScalarT>
-class NullHeatConductionLaw
+class FluidThermalConductionLawParams
 {
+    // do not copy!
+    FluidThermalConductionLawParams(const FluidThermalConductionLawParams&)
+    {}
+
 public:
-    typedef int Params;
     typedef ScalarT Scalar;
 
-    /*!
-     * \brief Given a fluid state, return the effective heat conductivity [W/m^2 / (K/m)] of the porous
-     *        medium.
-     *
-     * If this method is called an exception is thrown at run time.
-     */
-    template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation heatConductivity(const Params& params OPM_UNUSED,
-                                       const FluidState& fluidState OPM_UNUSED)
-    { return 0.0; }
+    FluidThermalConductionLawParams()
+    { }
+
 };
+
 } // namespace Opm
 
 #endif

--- a/opm/material/thermal/NullThermalConductionLaw.hpp
+++ b/opm/material/thermal/NullThermalConductionLaw.hpp
@@ -22,30 +22,43 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidHeatConductionParams
+ * \copydoc Opm::NullThermalConductionLaw
  */
-#ifndef OPM_FLUID_HEAT_CONDUCTION_LAW_PARAMS_HPP
-#define OPM_FLUID_HEAT_CONDUCTION_LAW_PARAMS_HPP
+#ifndef OPM_NULL_THERMAL_CONDUCTION_LAW_HPP
+#define OPM_NULL_THERMAL_CONDUCTION_LAW_HPP
+
+#include <opm/common/Unused.hpp>
+#include <opm/common/Exceptions.hpp>
+#include <opm/common/ErrorMacros.hpp>
 
 namespace Opm {
+
 /*!
- * \brief Parameters for the heat conduction law which just takes the conductivity of a given fluid phase.
+ * \ingroup material
+ *
+ * \brief Implements a dummy law for thermal conduction to which isothermal models
+ *        can fall back to.
+ *
+ * This law just returns 0 unconditionally.
  */
 template <class ScalarT>
-class FluidHeatConductionLawParams
+class NullThermalConductionLaw
 {
-    // do not copy!
-    FluidHeatConductionLawParams(const FluidHeatConductionLawParams&)
-    {}
-
 public:
+    typedef int Params;
     typedef ScalarT Scalar;
 
-    FluidHeatConductionLawParams()
-    { }
-
+    /*!
+     * \brief Given a fluid state, return the effective thermal conductivity [W/m^2 / (K/m)] of the porous
+     *        medium.
+     *
+     * If this method is called an exception is thrown at run time.
+     */
+    template <class FluidState, class Evaluation = typename FluidState::Scalar>
+    static Evaluation thermalConductivity(const Params& params OPM_UNUSED,
+                                          const FluidState& fluidState OPM_UNUSED)
+    { return 0.0; }
 };
-
 } // namespace Opm
 
 #endif

--- a/opm/material/thermal/SomertonThermalConductionLaw.hpp
+++ b/opm/material/thermal/SomertonThermalConductionLaw.hpp
@@ -22,12 +22,12 @@
 */
 /*!
  * \file
- * \copydoc Opm::SomertonHeatConductionLaw
+ * \copydoc Opm::SomertonThermalConductionLaw
  */
-#ifndef OPM_SOMERTON_HEAT_CONDUCTION_LAW_HPP
-#define OPM_SOMERTON_HEAT_CONDUCTION_LAW_HPP
+#ifndef OPM_SOMERTON_THERMAL_CONDUCTION_LAW_HPP
+#define OPM_SOMERTON_THERMAL_CONDUCTION_LAW_HPP
 
-#include "SomertonHeatConductionLawParams.hpp"
+#include "SomertonThermalConductionLawParams.hpp"
 
 #include <opm/material/common/Spline.hpp>
 
@@ -36,13 +36,13 @@
 
 #include <algorithm>
 
-namespace Opm
-{
+namespace Opm {
+
 /*!
  * \ingroup material
  *
- * \brief Implements the Somerton law of heat conductivity in a
- * porous medium.
+ * \brief Implements the Somerton law of thermal conductivity in a
+ *        porous medium.
  *
  * See:
  *
@@ -59,8 +59,8 @@ namespace Opm
  */
 template <class FluidSystem,
           class ScalarT,
-          class ParamsT = SomertonHeatConductionLawParams<FluidSystem::numPhases, ScalarT> >
-class SomertonHeatConductionLaw
+          class ParamsT = SomertonThermalConductionLawParams<FluidSystem::numPhases, ScalarT> >
+class SomertonThermalConductionLaw
 {
     enum { numPhases = FluidSystem::numPhases };
 
@@ -69,7 +69,7 @@ public:
     typedef typename Params::Scalar Scalar;
 
     /*!
-     * \brief Given a fluid state, return the effective heat conductivity [W/m^2 / (K/m)] of the porous
+     * \brief Given a fluid state, return the effective thermal conductivity [W/m^2 / (K/m)] of the porous
      *        medium.
      *
      * For two phases, the Somerton law is given by:
@@ -80,14 +80,14 @@ public:
      \sqrt{S_n}(\lambda_{ful,n} - \lambda_{vac})
      \f]
      *
-     * where \f$\lambda_{vac}\f$ is the heat conductivity of the
-     * porous medium at vacuum, \f$\lambda_{ful,\alpha}\f$ is the heat
+     * where \f$\lambda_{vac}\f$ is the thermal conductivity of the
+     * porous medium at vacuum, \f$\lambda_{ful,\alpha}\f$ is the thermal
      * conductivty of the porous medium if it is fully saturated by
      * phase \f$\alpha\f$ and \f$S_\alpha\f$ is the saturation of
      * phase \f$\alpha\f$.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation heatConductivity(const Params& params,
+    static Evaluation thermalConductivity(const Params& params,
                                        const FluidState& fluidState)
     {
         Valgrind::CheckDefined(params.vacuumLambda());

--- a/opm/material/thermal/SomertonThermalConductionLawParams.hpp
+++ b/opm/material/thermal/SomertonThermalConductionLawParams.hpp
@@ -22,10 +22,10 @@
 */
 /*!
  * \file
- * \copydoc Opm::SomertonHeatConductionLawParams
+ * \copydoc Opm::SomertonThermalConductionLawParams
  */
-#ifndef OPM_SOMERTON_HEAT_CONDUCTION_LAW_PARAMS_HPP
-#define OPM_SOMERTON_HEAT_CONDUCTION_LAW_PARAMS_HPP
+#ifndef OPM_SOMERTON_THERMAL_CONDUCTION_LAW_PARAMS_HPP
+#define OPM_SOMERTON_THERMAL_CONDUCTION_LAW_PARAMS_HPP
 
 #include <cassert>
 
@@ -33,23 +33,23 @@ namespace Opm {
 
 /*!
  * \brief The default implementation of a parameter object for the
- *        Somerton heat conduction law.
+ *        Somerton thermal conduction law.
  */
 template <unsigned numPhases, class ScalarT>
-class SomertonHeatConductionLawParams
+class SomertonThermalConductionLawParams
 {
     // do not copy!
-    SomertonHeatConductionLawParams(const SomertonHeatConductionLawParams&)
+    SomertonThermalConductionLawParams(const SomertonThermalConductionLawParams&)
     {}
 
 public:
     typedef ScalarT Scalar;
 
-    SomertonHeatConductionLawParams()
+    SomertonThermalConductionLawParams()
     { }
 
     /*!
-     * \brief Return the "fully saturated" heat conductivity of the
+     * \brief Return the "fully saturated" thermal conductivity of the
      *        porous medium [W/m^2 / (K/m)].
      *
      * In this context "fully saturated" means that the whole pore
@@ -63,7 +63,7 @@ public:
     }
 
     /*!
-     * \brief Set the "fully saturated" heat conductivity of the
+     * \brief Set the "fully saturated" thermal conductivity of the
      *        porous medium [W/m^2 / (K/m)].
      *
      * In this context "fully saturated" means that the whole pore
@@ -78,7 +78,7 @@ public:
     }
 
     /*!
-     * \brief Return the heat conductivity of the porous medium at
+     * \brief Return the thermal conductivity of the porous medium at
      *        vacuum [W/m^2 / (K/m)].
      */
     Scalar vacuumLambda() const
@@ -87,7 +87,7 @@ public:
     }
 
     /*!
-     * \brief Set the "fully saturated" heat conductivity of the
+     * \brief Set the "fully saturated" thermal conductivity of the
      *        porous medium [W/m^2 / (K/m)].
      *
      * In this context "fully saturated" means that the whole pore

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -43,7 +43,7 @@
 #include <opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp>
 #include <opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp>
 
-#include <opm/material/thermal/FluidHeatConductionLaw.hpp>
+#include <opm/material/thermal/FluidThermalConductionLaw.hpp>
 
 // include all fluid states
 #include <opm/material/fluidstates/PressureOverlayFluidState.hpp>


### PR DESCRIPTION
this was only partially done so far: the term "heat" should be avoided if possible because it is a somewhat fuzzy concept. Thus, replace it by "energy" and "thermal" where it is not a well established term. ("well established" basically means "heat capacity".)

this PR needs some downstream mop-up. (currently "downstream" == "eWoms")