### PR TITLE
Fix fluid state getters for blackoil quantities

### DIFF
--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -53,13 +53,13 @@ unsigned getPvtRegionIndex_(typename std::enable_if<!HasMember_pvtRegionIndex<Fl
 OPM_GENERATE_HAS_MEMBER(invB, ) // Creates 'HasMember_invB<T>'.
 
 template <class FluidState, class FluidSystem, class LhsEval>
-LhsEval getInvB_(typename std::enable_if<HasMember_pvtRegionIndex<FluidState>::value,
+LhsEval getInvB_(typename std::enable_if<HasMember_invB<FluidState>::value,
                                          const FluidState&>::type fluidState,
                  unsigned phaseIdx)
 { return Opm::decay<LhsEval>(fluidState.invB(phaseIdx)); }
 
 template <class FluidState, class FluidSystem, class LhsEval>
-LhsEval getInvB_(typename std::enable_if<!HasMember_pvtRegionIndex<FluidState>::value,
+LhsEval getInvB_(typename std::enable_if<!HasMember_invB<FluidState>::value,
                                          const FluidState&>::type fluidState,
                  unsigned phaseIdx)
 {

--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -65,7 +65,7 @@ LhsEval getInvB_(typename std::enable_if<!HasMember_invB<FluidState>::value,
 {
     const auto& rho = fluidState.density(phaseIdx);
     const auto& Xsolvent =
-        fluidState.massFraction(phaseIdx, FluidSystem::solventComponentIndx(phaseIdx));
+        fluidState.massFraction(phaseIdx, FluidSystem::solventComponentIndex(phaseIdx));
 
     unsigned pvtRegionIdx = getPvtRegionIndex_(fluidState);
     return

--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -52,14 +52,14 @@ unsigned getPvtRegionIndex_(typename std::enable_if<!HasMember_pvtRegionIndex<Fl
 
 OPM_GENERATE_HAS_MEMBER(invB, ) // Creates 'HasMember_invB<T>'.
 
-template <class FluidState, class FluidSystem, class LhsEval>
+template <class FluidSystem, class FluidState, class LhsEval>
 LhsEval getInvB_(typename std::enable_if<HasMember_invB<FluidState>::value,
                                          const FluidState&>::type fluidState,
                  unsigned phaseIdx,
                  unsigned pvtRegionIdx OPM_UNUSED)
 { return Opm::decay<LhsEval>(fluidState.invB(phaseIdx)); }
 
-template <class FluidState, class FluidSystem, class LhsEval>
+template <class FluidSystem, class FluidState, class LhsEval>
 LhsEval getInvB_(typename std::enable_if<!HasMember_invB<FluidState>::value,
                                          const FluidState&>::type fluidState,
                  unsigned phaseIdx,
@@ -144,8 +144,8 @@ public:
 
         unsigned pvtRegionIdx = getPvtRegionIndex_<FluidState>(fs);
         setPvtRegionIndex(pvtRegionIdx);
-        setRs(Opm::BlackOil::getRs_<FluidSystem, Scalar, FluidState>(fs, pvtRegionIdx));
-        setRv(Opm::BlackOil::getRv_<FluidSystem, Scalar, FluidState>(fs, pvtRegionIdx));
+        setRs(Opm::BlackOil::getRs_<FluidSystem, FluidState, Scalar>(fs, pvtRegionIdx));
+        setRv(Opm::BlackOil::getRv_<FluidSystem, FluidState, Scalar>(fs, pvtRegionIdx));
 
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             setSaturation(phaseIdx, fs.saturation(phaseIdx));
@@ -155,7 +155,7 @@ public:
             if (enableEnergy)
                 setEnthalpy(phaseIdx, fs.enthalpy(phaseIdx));
 
-            setInvB(phaseIdx, getInvB_<FluidState, FluidSystem, Scalar>(fs, phaseIdx, pvtRegionIdx));
+            setInvB(phaseIdx, getInvB_<FluidSystem, FluidState, Scalar>(fs, phaseIdx, pvtRegionIdx));
         }
     }
 

--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -55,24 +55,24 @@ OPM_GENERATE_HAS_MEMBER(invB, ) // Creates 'HasMember_invB<T>'.
 template <class FluidState, class FluidSystem, class LhsEval>
 LhsEval getInvB_(typename std::enable_if<HasMember_invB<FluidState>::value,
                                          const FluidState&>::type fluidState,
-                 unsigned phaseIdx)
+                 unsigned phaseIdx,
+                 unsigned pvtRegionIdx OPM_UNUSED)
 { return Opm::decay<LhsEval>(fluidState.invB(phaseIdx)); }
 
 template <class FluidState, class FluidSystem, class LhsEval>
 LhsEval getInvB_(typename std::enable_if<!HasMember_invB<FluidState>::value,
                                          const FluidState&>::type fluidState,
-                 unsigned phaseIdx)
+                 unsigned phaseIdx,
+                 unsigned pvtRegionIdx)
 {
     const auto& rho = fluidState.density(phaseIdx);
     const auto& Xsolvent =
         fluidState.massFraction(phaseIdx, FluidSystem::solventComponentIndex(phaseIdx));
 
-    unsigned pvtRegionIdx = getPvtRegionIndex_(fluidState);
     return
         Opm::decay<LhsEval>(rho)
         *Opm::decay<LhsEval>(Xsolvent)
         /FluidSystem::referenceDensity(phaseIdx, pvtRegionIdx);
-
 }
 
 /*!
@@ -142,9 +142,10 @@ public:
         if (enableTemperature || enableEnergy)
             setTemperature(fs.temperature(/*phaseIdx=*/0));
 
-        setPvtRegionIndex(getPvtRegionIndex_<FluidState>(fs));
-        setRs(Opm::BlackOil::getRs_<FluidSystem, Scalar, FluidState>(fs, /*regionIdx=*/0));
-        setRv(Opm::BlackOil::getRv_<FluidSystem, Scalar, FluidState>(fs, /*regionIdx=*/0));
+        unsigned pvtRegionIdx = getPvtRegionIndex_<FluidState>(fs);
+        setPvtRegionIndex(pvtRegionIdx);
+        setRs(Opm::BlackOil::getRs_<FluidSystem, Scalar, FluidState>(fs, pvtRegionIdx));
+        setRv(Opm::BlackOil::getRv_<FluidSystem, Scalar, FluidState>(fs, pvtRegionIdx));
 
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             setSaturation(phaseIdx, fs.saturation(phaseIdx));
@@ -154,7 +155,7 @@ public:
             if (enableEnergy)
                 setEnthalpy(phaseIdx, fs.enthalpy(phaseIdx));
 
-            setInvB(phaseIdx, getInvB_<FluidState, FluidSystem, Scalar>(fs, phaseIdx));
+            setInvB(phaseIdx, getInvB_<FluidState, FluidSystem, Scalar>(fs, phaseIdx, pvtRegionIdx));
         }
     }
 


### PR DESCRIPTION
this improves the getter functions of blackoil quantities from fluid states. While I consider the unification of the template arguments of these functions as minor improvements, getInvB_() had a few outright bugs.

(note that the template-argument unification needs a small mob up patch in eWoms.)