### PR TITLE
fix Opm::getInvB_(fluidState) once more

### DIFF
--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -50,13 +50,14 @@ unsigned getPvtRegionIndex_(typename std::enable_if<!HasMember_pvtRegionIndex<Fl
                                                     const FluidState&>::type fluidState OPM_UNUSED)
 { return 0; }
 
-OPM_GENERATE_HAS_MEMBER(invB, ) // Creates 'HasMember_invB<T>'.
+OPM_GENERATE_HAS_MEMBER(invB, /*phaseIdx=*/0) // Creates 'HasMember_invB<T>'.
 
 template <class FluidSystem, class FluidState, class LhsEval>
-LhsEval getInvB_(typename std::enable_if<HasMember_invB<FluidState>::value,
-                                         const FluidState&>::type fluidState,
-                 unsigned phaseIdx,
-                 unsigned pvtRegionIdx OPM_UNUSED)
+auto getInvB_(typename std::enable_if<HasMember_invB<FluidState>::value,
+                                      const FluidState&>::type fluidState,
+              unsigned phaseIdx,
+              unsigned pvtRegionIdx OPM_UNUSED)
+    -> decltype(Opm::decay<LhsEval>(fluidState.invB(phaseIdx)))
 { return Opm::decay<LhsEval>(fluidState.invB(phaseIdx)); }
 
 template <class FluidSystem, class FluidState, class LhsEval>

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -62,11 +62,8 @@ LhsEval getRs_(typename std::enable_if<!HasMember_Rs<FluidState>::value, const F
 template <class FluidSystem, class FluidState, class LhsEval>
 auto getRs_(typename std::enable_if<HasMember_Rs<FluidState>::value, const FluidState&>::type fluidState,
             unsigned regionIdx OPM_UNUSED)
-    -> decltype(Opm::MathToolbox<typename FluidState::Scalar>
-                ::template decay<LhsEval>(fluidState.Rs()))
-{
-    return Opm::decay<LhsEval>(fluidState.Rs());
-}
+    -> decltype(Opm::decay<LhsEval>(fluidState.Rs()))
+{ return Opm::decay<LhsEval>(fluidState.Rs()); }
 
 template <class FluidSystem, class FluidState, class LhsEval>
 LhsEval getRv_(typename std::enable_if<!HasMember_Rv<FluidState>::value, const FluidState&>::type fluidState,
@@ -81,11 +78,9 @@ LhsEval getRv_(typename std::enable_if<!HasMember_Rv<FluidState>::value, const F
 template <class FluidSystem, class FluidState, class LhsEval>
 auto getRv_(typename std::enable_if<HasMember_Rv<FluidState>::value, const FluidState&>::type fluidState,
             unsigned regionIdx OPM_UNUSED)
-    -> decltype(Opm::MathToolbox<typename FluidState::Scalar>
-                ::template decay<LhsEval>(fluidState.Rv()))
-{
-    return Opm::decay<LhsEval>(fluidState.Rv());
-}
+    -> decltype(Opm::decay<LhsEval>(fluidState.Rv()))
+{ return Opm::decay<LhsEval>(fluidState.Rv()); }
+
 }
 
 namespace FluidSystems {


### PR DESCRIPTION
after #278, the generic version of getInvB_() was always used because no argument for fluidState.invB() was specified when invoking the GENERATE_HAS_MEMBER() macro, so has_invB<FluidState>() returned false for any fluid state. since the getInvB_() function is not used by the master version of `flow` yet, it was unaffected by this issue and this is also the reason why neither Jenkins complained nor any performance regression could be seen after #278. That said, for implementing non-trivial boundary conditions, it is very helpful to have a unified code path for the case where boundary conditions are specified using generic fluid states and black-oil model specific ones as well as with the flux computations in the interior of the domain.

Note that I only found this issue due to the fact that on my current WIP branch linearization got 10% slower for Norne. This means that the generic version of this function must be correct and, considering the
fact that the massFraction() method is quite elaborate for BlackOilFluidState, this is also a very strong indication that on modern processors the performance of even the linearization part of the simulation is more limited by memory latency than by the execution speed of the ALUs.