### PR TITLE
move some basic infrastructure from opm-common to here

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ include (OpmLibMain)
 add_custom_target(opm-material_prepare)
 
 opm_add_test(test_blackoilfluidstate)
+opm_add_test(test_ConditionalStorage)
 opm_add_test(test_eclblackoilfluidsystem CONDITION OPM_PARSER_FOUND)
 opm_add_test(test_eclblackoilpvt CONDITION OPM_PARSER_FOUND)
 opm_add_test(test_eclmateriallawmanager CONDITION OPM_PARSER_FOUND)

--- a/dune.module
+++ b/dune.module
@@ -10,5 +10,5 @@ Label: 2018.04-pre
 Maintainer: opm@opm-project.org
 MaintainerName: The Open Porous Media Project
 Url: http://opm-project.org
-Depends: dune-common (>= 2.4) opm-common
-Suggests: opm-parser
+Depends: dune-common (>= 2.4)
+Suggests: opm-common opm-parser

--- a/opm/material/binarycoefficients/Air_Mesitylene.hpp
+++ b/opm/material/binarycoefficients/Air_Mesitylene.hpp
@@ -46,7 +46,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation henry(const Evaluation& /*temperature*/)
-    { OPM_THROW(std::runtime_error, "Not implemented: Henry coefficient of air in mesitylene"); }
+    { throw std::runtime_error("Not implemented: Henry coefficient of air in mesitylene"); }
 
     /*!
      * \brief Binary diffusion coefficent [m^2/s] for air and mesitylene.
@@ -95,7 +95,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidDiffCoeff(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
-    { OPM_THROW(std::runtime_error, "Not implemented: Binary liquid diffusion coefficients of air and mesitylene"); }
+    { throw std::runtime_error("Not implemented: Binary liquid diffusion coefficients of air and mesitylene"); }
 };
 
 } // namespace BinaryCoeff

--- a/opm/material/binarycoefficients/Air_Xylene.hpp
+++ b/opm/material/binarycoefficients/Air_Xylene.hpp
@@ -44,7 +44,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation henry(const Evaluation& /*temperature*/)
-    { OPM_THROW(std::runtime_error, "Not implemented: Henry coefficient of air in xylene"); }
+    { throw std::runtime_error("Not implemented: Henry coefficient of air in xylene"); }
 
     /*!
      * \brief Binary diffusion coefficent [m^2/s] for air and xylene.
@@ -93,7 +93,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidDiffCoeff(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
-    { OPM_THROW(std::runtime_error, "Not implemented: Binary liquid diffusion coefficients of air and xylene"); }
+    { throw std::runtime_error("Not implemented: Binary liquid diffusion coefficients of air and xylene"); }
 };
 
 } // namespace BinaryCoeff

--- a/opm/material/binarycoefficients/H2O_CO2.hpp
+++ b/opm/material/binarycoefficients/H2O_CO2.hpp
@@ -89,7 +89,7 @@ public:
      */
     template <class Scalar, class Evaluation = Scalar>
     static Evaluation liquidDiffCoeff(const Evaluation& /*temperature*/, const Evaluation& /*pressure*/)
-    { OPM_THROW(std::runtime_error, "Not implemented: Binary liquid diffusion coefficients of CO2 and CH4"); }
+    { throw std::runtime_error("Not implemented: Binary liquid diffusion coefficients of CO2 and CH4"); }
 };
 
 } // namespace BinaryCoeff

--- a/opm/material/checkFluidSystem.hpp
+++ b/opm/material/checkFluidSystem.hpp
@@ -45,7 +45,7 @@
 #include <opm/material/fluidstates/NonEquilibriumFluidState.hpp>
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 #include <dune/common/classname.hh>
 
 #include <iostream>

--- a/opm/material/common/ConditionalStorage.hpp
+++ b/opm/material/common/ConditionalStorage.hpp
@@ -1,0 +1,166 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \copydoc Opm::ConditionalStorage
+ */
+#ifndef OPM_CONDITIONAL_STORAGE_HH
+#define OPM_CONDITIONAL_STORAGE_HH
+
+#include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Unused.hpp>
+
+#include <utility>
+
+namespace Opm {
+/*!
+ * \ingroup Common
+ *
+ * \brief A simple class which only stores a given member attribute if a boolean
+ *        condition is true
+ *
+ * If the condition is false, nothing is stored and an exception is thrown when trying to
+ * access the object.
+ */
+template <bool cond, class T>
+class ConditionalStorage
+{
+public:
+    typedef T type;
+    static constexpr bool condition = cond;
+
+    ConditionalStorage()
+    {}
+
+    ConditionalStorage(const T& v)
+        : data_(v)
+    {}
+
+    ConditionalStorage(T&& v)
+        : data_(std::move(v))
+    {}
+
+    template <class ...Args>
+    ConditionalStorage(Args... args)
+        : data_(args...)
+    {}
+
+    ConditionalStorage(const ConditionalStorage& t)
+        : data_(t.data_)
+    {};
+
+    ConditionalStorage(ConditionalStorage&& t)
+        : data_(std::move(t.data_))
+    {};
+
+    ConditionalStorage& operator=(const ConditionalStorage& v)
+    {
+        data_ = v.data_;
+        return *this;
+    }
+
+    ConditionalStorage& operator=(ConditionalStorage&& v)
+    {
+        data_ = std::move(v.data_);
+        return *this;
+    }
+
+    const T& operator*() const
+    { return data_; }
+    T& operator*()
+    { return data_; }
+
+    const T* operator->() const
+    { return &data_; }
+    T* operator->()
+    { return &data_; }
+
+private:
+    T data_;
+};
+
+template <class T>
+class ConditionalStorage<false, T>
+{
+public:
+    typedef T type;
+    static constexpr bool condition = false;
+
+    ConditionalStorage()
+    {
+        // ensure that T has a default constructor without actually calling it
+        if (false) {
+            T OPM_UNUSED dummy; // <- if the compiler bails out here, T does not have a default constructor
+        }
+    }
+
+    ConditionalStorage(const T& v)
+    {
+        // ensure that T has a default constructor without actually calling it
+        if (false) {
+            T OPM_UNUSED dummy(v); // <- if the compiler bails out here, T does not have a copy constructor
+        }
+    }
+
+    ConditionalStorage(const ConditionalStorage &)
+    {
+        // copying an empty conditional storage object does not do anything.
+    };
+
+    template <class ...Args>
+    ConditionalStorage(Args... args)
+    {
+        // ensure that the arguments are valid without actually calling the constructor
+        // of T
+        if (false) {
+            T OPM_UNUSED dummy(args...); // <- if the compiler bails out here, T does not have the requested constructor
+        }
+    }
+
+    ConditionalStorage& operator=(const ConditionalStorage&)
+    {
+        // ensure that the stored object can actually be assined to but not actually do
+        // anything
+        if (false) {
+            T *dummy;
+            (*dummy) = (*dummy);   // <- if the compiler bails out here, T does not have an assignment operator
+        }
+
+        return *this;
+    }
+
+    const T& operator*() const
+    { throw std::logic_error("data member deactivated"); }
+    T& operator*()
+    { throw std::logic_error("data member deactivated"); }
+
+    const T* operator->() const
+    { throw std::logic_error("data member deactivated"); }
+    T* operator->()
+    { throw std::logic_error("data member deactivated"); }
+};
+
+} // namespace Opm
+
+#endif

--- a/opm/material/common/EnsureFinalized.hpp
+++ b/opm/material/common/EnsureFinalized.hpp
@@ -28,7 +28,6 @@
 #define OPM_MATERIAL_ENSURE_FINALIZED_HPP
 
 #include <cassert>
-#include <opm/common/ErrorMacros.hpp>
 
 // TODO: move this variable to config.h
 #define OPM_CHECK_PARAM_FINALIZED 1
@@ -63,10 +62,8 @@ protected:
     void check() const
     {
 #if USE_OPM_CHECK_PARAM_FINALIZED
-        if( ! finalized_ )
-        {
-            OPM_THROW(std::runtime_error,"Parameter class has not been finalized before usage!");
-        }
+        if (!finalized_)
+            throw std::runtime_error("Parameter class has not been finalized before usage!");
 #endif
     }
 

--- a/opm/material/common/Exceptions.hpp
+++ b/opm/material/common/Exceptions.hpp
@@ -1,0 +1,58 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \brief Provides the opm-material specific exception classes.
+ */
+#ifndef OPM_MATERIAL_EXCEPTIONS_HPP
+#define OPM_MATERIAL_EXCEPTIONS_HPP
+
+#if HAVE_OPM_COMMON
+#include <opm/common/Exceptions.hpp>
+#endif
+
+#include <dune/common/exceptions.hh>
+
+#include <stdexcept>
+
+// the opm-material specific exception classes
+namespace Opm {
+class NumericalIssue
+#if HAVE_OPM_COMMON
+    : public Opm::NumericalProblem
+#else
+    : public std::runtime_error
+#endif
+{
+public:
+    explicit NumericalIssue(const std::string &message)
+#if HAVE_OPM_COMMON
+      : Opm::NumericalProblem(message)
+#else
+      : std::runtime_error(message)
+#endif
+    {}
+};
+}
+
+#endif // OPM_MATERIAL_EXCEPTIONS_HPP

--- a/opm/material/common/ResetLocale.hpp
+++ b/opm/material/common/ResetLocale.hpp
@@ -1,0 +1,62 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*!
+ * \file
+ * \brief Provides a free function to reset the localization settings
+ *
+ * Under some circumstances, some environments seem to set a locale which they do not
+ * install. In turn this leads to std::runtime_errror being thrown by some parts of Boost
+ * (for some versions) which causes unsolicited program aborts.
+ *
+ * This issue asside, it looks pretty weird if the e.g. the number format is inconsistent
+ * with the language used by rest of the simulation.
+ */
+#ifndef OPM_RESET_LOCALE_HH
+#define OPM_RESET_LOCALE_HH
+
+#include <stdlib.h>
+
+namespace Opm {
+
+inline void resetLocale()
+{
+#ifndef WIN32
+    // this probably only works for POSIX compatible operating systems. for all others,
+    // unsetting a few environment variables should not hurt, though.
+    unsetenv("LC_ALL");
+    unsetenv("LANG");
+    unsetenv("LANGUAGE");
+    unsetenv("LC_ADDRESS");
+    unsetenv("LC_COLLATE");
+    unsetenv("LC_CTYPE");
+    unsetenv("LC_IDENTIFICATION");
+    unsetenv("LC_MEASUREMENT");
+    unsetenv("LC_MESSAGES");
+    unsetenv("LC_MONETARY");
+    unsetenv("LC_NAME");
+    unsetenv("LC_NUMERIC");
+    unsetenv("LC_PAPER");
+    unsetenv("LC_TELEPHONE");
+    unsetenv("LC_TIME");
+#endif // !WIN32
+}
+
+} // namespace Opm
+
+#endif

--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -29,9 +29,8 @@
 
 #include <opm/material/common/TridiagonalMatrix.hpp>
 #include <opm/material/common/PolynomialUtils.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <ostream>
 #include <vector>
@@ -535,7 +534,7 @@ public:
         else if (splineType == Monotonic)
             this->makeMonotonicSpline_(slopeVec_);
         else
-            OPM_THROW(std::runtime_error, "Spline type " << splineType << " not supported at this place");
+            throw std::runtime_error("Spline type "+std::to_string(int(splineType))+" not supported at this place");
     }
 
     /*!
@@ -574,7 +573,7 @@ public:
         else if (splineType == Monotonic)
             this->makeMonotonicSpline_(slopeVec_);
         else
-            OPM_THROW(std::runtime_error, "Spline type " << splineType << " not supported at this place");
+            throw std::runtime_error("Spline type "+std::to_string(int(splineType))+" not supported at this place");
     }
 
     /*!
@@ -617,7 +616,7 @@ public:
         else if (splineType == Monotonic)
             this->makeMonotonicSpline_(slopeVec_);
         else
-            OPM_THROW(std::runtime_error, "Spline type " << splineType << " not supported at this place");
+            throw std::runtime_error("Spline type "+std::to_string(int(splineType))+" not supported at this place");
     }
 
     /*!
@@ -660,7 +659,7 @@ public:
         else if (splineType == Monotonic)
             this->makeMonotonicSpline_(slopeVec_);
         else
-            OPM_THROW(std::runtime_error, "Spline type " << splineType << " not supported at this place");
+            throw std::runtime_error("Spline type "+std::to_string(int(splineType))+" not supported at this place");
     }
 
     /*!
@@ -703,7 +702,7 @@ public:
         else if (splineType == Monotonic)
             this->makeMonotonicSpline_(slopeVec_);
         else
-            OPM_THROW(std::runtime_error, "Spline type " << splineType << " not supported at this place");
+            throw std::runtime_error("Spline type "+std::to_string(int(splineType))+" not supported at this place");
     }
 
     /*!
@@ -771,8 +770,7 @@ public:
                     mono = (dy_dx>0)?1:-1;
                 }
                 else {
-                    OPM_THROW(std::runtime_error,
-                              "The sampling points given to a spline must be sorted by their x value!");
+                    throw std::runtime_error("The sampling points given to a spline must be sorted by their x value!");
                 }
             }
             else {
@@ -800,8 +798,7 @@ public:
     Evaluation eval(const Evaluation& x, bool extrapolate = false) const
     {
         if (!extrapolate && !applies(x))
-            OPM_THROW(Opm::NumericalProblem,
-                      "Tried to evaluate a spline outside of its range");
+            throw Opm::NumericalIssue("Tried to evaluate a spline outside of its range");
 
         // handle extrapolation
         if (extrapolate) {
@@ -837,8 +834,7 @@ public:
     Evaluation evalDerivative(const Evaluation& x, bool extrapolate = false) const
     {
         if (!extrapolate && !applies(x))
-            OPM_THROW(Opm::NumericalProblem,
-                      "Tried to evaluate the derivative of a spline outside of its range");
+            throw Opm::NumericalIssue("Tried to evaluate the derivative of a spline outside of its range");
 
         // handle extrapolation
         if (extrapolate) {
@@ -867,8 +863,7 @@ public:
     Evaluation evalSecondDerivative(const Evaluation& x, bool extrapolate = false) const
     {
         if (!extrapolate && !applies(x))
-            OPM_THROW(Opm::NumericalProblem,
-                      "Tried to evaluate the second derivative of a spline outside of its range");
+            throw Opm::NumericalIssue("Tried to evaluate the second derivative of a spline outside of its range");
         else if (extrapolate)
             return 0.0;
 
@@ -891,8 +886,7 @@ public:
     Evaluation evalThirdDerivative(const Evaluation& x, bool extrapolate = false) const
     {
         if (!extrapolate && !applies(x))
-            OPM_THROW(Opm::NumericalProblem,
-                      "Tried to evaluate the third derivative of a spline outside of its range");
+            throw Opm::NumericalIssue("Tried to evaluate the third derivative of a spline outside of its range");
         else if (extrapolate)
             return 0.0;
 
@@ -941,14 +935,12 @@ public:
 
             nSol += nCur;
             if (nSol > 1) {
-                OPM_THROW(std::runtime_error,
-                          "Spline has more than one intersection"); //<<a<<"x^3 + "<<b<"x^2 + "<<c<"x + "<<d);
+                throw std::runtime_error("Spline has more than one intersection"); //<<a<<"x^3 + "<<b<"x^2 + "<<c<"x + "<<d);
             }
         }
 
         if (nSol != 1)
-            OPM_THROW(std::runtime_error,
-                      "Spline has no intersection"); //<<a<"x^3 + " <<b<"x^2 + "<<c<"x + "<<d<<"!");
+            throw std::runtime_error("Spline has no intersection"); //<<a<"x^3 + " <<b<"x^2 + "<<c<"x + "<<d<<"!");
 
         return sol;
     }

--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -28,9 +28,8 @@
 #define OPM_TABULATED_1D_FUNCTION_HPP
 
 #include <opm/material/densead/Math.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -426,8 +425,7 @@ public:
                     y = (x - xValues_[n])*dy_dx + yValues_[n];
                 }
                 else {
-                    OPM_THROW(std::runtime_error,
-                              "The sampling points given to a function must be sorted by their x value!");
+                    throw std::runtime_error("The sampling points given to a function must be sorted by their x value!");
                 }
             }
             else {
@@ -444,8 +442,7 @@ private:
     size_t findSegmentIndex_(const Evaluation& x, bool extrapolate = false) const
     {
         if (!extrapolate && !applies(x))
-            OPM_THROW(Opm::NumericalProblem,
-                      "Tried to evaluate a tabulated function outside of its range");
+            throw Opm::NumericalIssue("Tried to evaluate a tabulated function outside of its range");
 
         // we need at least two sampling points!
         assert(xValues_.size() >= 2);

--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -28,8 +28,7 @@
 #ifndef OPM_UNIFORM_TABULATED_2D_FUNCTION_HPP
 #define OPM_UNIFORM_TABULATED_2D_FUNCTION_HPP
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
 
@@ -176,7 +175,7 @@ public:
      * \brief Evaluate the function at a given (x,y) position.
      *
      * If this method is called for a value outside of the tabulated
-     * range, a \c Opm::NumericalProblem exception is thrown.
+     * range, a \c Opm::NumericalIssue exception is thrown.
      */
     template <class Evaluation>
     Evaluation eval(const Evaluation& x, const Evaluation& y) const
@@ -184,12 +183,11 @@ public:
 #ifndef NDEBUG
         if (!applies(x,y))
         {
-            OPM_THROW(NumericalProblem,
-                       "Attempt to get tabulated value for ("
-                       << x << ", " << y
-                       << ") on a table of extend "
-                       << xMin() << " to " << xMax() << " times "
-                       << yMin() << " to " << yMax());
+            throw NumericalIssue("Attempt to get tabulated value for ("
+                                   +std::to_string(double(Opm::scalarValue(x)))+", "+std::to_string(double(Opm::scalarValue(y)))
+                                   +") on a table of extend "
+                                   +std::to_string(xMin())+" to "+std::to_string(xMax())+" times "
+                                   +std::to_string(yMin())+" to "+std::to_string(yMax()));
         };
 #endif
 

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -28,18 +28,17 @@
 #ifndef OPM_UNIFORM_X_TABULATED_2D_FUNCTION_HPP
 #define OPM_UNIFORM_X_TABULATED_2D_FUNCTION_HPP
 
-#include <opm/common/Valgrind.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Unused.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
 #include <iostream>
 #include <vector>
 #include <limits>
 #include <tuple>
-
-#include <assert.h>
+#include <sstream>
+#include <cassert>
 
 namespace Opm {
 
@@ -265,15 +264,16 @@ public:
      * \brief Evaluate the function at a given (x,y) position.
      *
      * If this method is called for a value outside of the tabulated
-     * range, a \c Opm::NumericalProblem exception is thrown.
+     * range, a \c Opm::NumericalIssue exception is thrown.
      */
     template <class Evaluation>
     Evaluation eval(const Evaluation& x, const Evaluation& y, bool extrapolate=false) const
     {
 #ifndef NDEBUG
         if (!extrapolate && !applies(x, y)) {
-            OPM_THROW(NumericalProblem,
-                      "Attempt to get undefined table value (" << x << ", " << y << ")");
+            std::ostringstream oss;
+            oss << "Attempt to get undefined table value (" << x << ", " << y << ")";
+            throw NumericalIssue(oss.str());
         };
 #endif
 
@@ -319,9 +319,8 @@ public:
             samples_.insert(samples_.begin(), std::vector<SamplePoint>());
             return 0;
         }
-        OPM_THROW(std::invalid_argument,
-                  "Sampling points should be specified either monotonically "
-                  "ascending or descending.");
+        throw std::invalid_argument("Sampling points should be specified either monotonically "
+                                    "ascending or descending.");
     }
 
     /*!
@@ -344,9 +343,8 @@ public:
             return 0;
         }
 
-        OPM_THROW(std::invalid_argument,
-                  "Sampling points must be specified in either monotonically "
-                  "ascending or descending order.");
+        throw std::invalid_argument("Sampling points must be specified in either monotonically "
+                                    "ascending or descending order.");
     }
 
     /*!

--- a/opm/material/common/Unused.hpp
+++ b/opm/material/common/Unused.hpp
@@ -1,0 +1,43 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*!
+ * \file
+ * \brief Provides the OPM_UNUSED macro
+ *
+ * This macro can be used to mark variables as "potentially unused" which suppresses some
+ * bogus compiler warnings. If the compiler does not support this, the macro is a no-op.
+ */
+#ifndef OPM_UNUSED_HH
+#define OPM_UNUSED_HH
+
+#ifndef HAS_ATTRIBUTE_UNUSED
+#define OPM_UNUSED
+#else
+#define OPM_UNUSED __attribute__((unused))
+#endif
+
+#ifdef NDEBUG
+#define OPM_DEBUG_UNUSED
+#define OPM_OPTIM_UNUSED OPM_UNUSED
+#else
+#define OPM_DEBUG_UNUSED OPM_UNUSED
+#define OPM_OPTIM_UNUSED
+#endif
+
+#endif

--- a/opm/material/common/Valgrind.hpp
+++ b/opm/material/common/Valgrind.hpp
@@ -1,0 +1,311 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \brief Some templates to wrap the valgrind client request macros
+ */
+#ifndef OPM_VALGRIND_HPP
+#define OPM_VALGRIND_HPP
+
+#include <opm/material/common/Unused.hpp>
+
+#if HAVE_VALGRIND
+#include <valgrind/memcheck.h>
+#endif
+
+#if HAVE_VALGRIND
+#define OPM_VALGRIND_OPTIM_UNUSED OPM_OPTIM_UNUSED
+#else
+#define OPM_VALGRIND_OPTIM_UNUSED OPM_UNUSED
+#endif
+
+namespace Opm {
+namespace Valgrind {
+/*!
+ * \ingroup Valgrind
+ * \brief Returns whether the program is running under Valgrind or not.
+ */
+inline bool IsRunning()
+{
+#if !defined NDEBUG && HAVE_VALGRIND
+    return RUNNING_ON_VALGRIND;
+#else
+    return false;
+#endif
+}
+
+/*!
+ * \ingroup Valgrind
+ * \brief Make valgrind complain if any of the memory occupied by an object
+ *        is undefined.
+ *
+ * Please note that this does not check whether the destinations of an
+ * object's pointers or references are defined. Also, for performance
+ * reasons the compiler might insert "padding bytes" between within
+ * the objects which leads to false positives.
+ *
+ * Example:
+ *
+ * \code
+ * int i;
+ * Valgrind::CheckDefined(i); // Valgrind complains!
+ * \endcode
+ *
+ * \tparam T The type of the object which ought to be checked
+ *
+ * \param value the object which valgrind should check
+ *
+ * \return true iff there are no undefined bytes in the memory
+ *         occupied by the object.
+ */
+template <class T>
+inline bool CheckDefined(const T& value OPM_VALGRIND_OPTIM_UNUSED)
+{
+#if !defined NDEBUG && HAVE_VALGRIND
+    auto tmp = VALGRIND_CHECK_MEM_IS_DEFINED(&value, sizeof(T));
+    return tmp == 0;
+#else
+    return true;
+#endif
+}
+
+
+
+/*!
+ * \ingroup Valgrind
+ * \brief Make valgrind complain if any of the memory occupied by an object
+ *        is not addressable.
+ *
+ * Example:
+ *
+ * \code
+ * int* i = NULL;
+ * Valgrind::CheckAddressable(*i); // Valgrind complains!
+ * \endcode
+ *
+ * \tparam T The type of the object which ought to be checked
+ *
+ * \param value the object which valgrind should check
+ *
+ * \return true iff there are no unadressable bytes in the memory
+ *         occupied by the object.
+ */
+template <class T>
+inline bool CheckAddressable(const T& value OPM_VALGRIND_OPTIM_UNUSED)
+{
+#if !defined NDEBUG && HAVE_VALGRIND
+    auto tmp = VALGRIND_CHECK_MEM_IS_ADDRESSABLE(&value, sizeof(T));
+    return tmp == 0;
+#else
+    return true;
+#endif
+}
+
+/*!
+ * \ingroup Valgrind
+ * \brief Make valgrind complain if any of the the memory occupied
+ *        by a C-style array objects is undefined.
+ *
+ * Please note that this does not check whether the destinations of an
+ * object's pointers or references are defined. Also, for performance
+ * reasons the compiler might insert "padding bytes" between within
+ * the objects which leads to false positives.
+ *
+ * Example:
+ *
+ * \code
+ * int i[2];
+ * Valgrind::CheckDefined(i, 2); // Valgrind complains!
+ * \endcode
+ *
+ * \tparam T The type of the object which ought to be checked
+ *
+ * \param value Pointer to the first object of the array.
+ * \param size The size of the array in number of objects
+ *
+ * \return true iff there are no undefined bytes in the memory
+ *         occupied by the array.
+ */
+template <class T>
+inline bool CheckDefined(const T* value OPM_VALGRIND_OPTIM_UNUSED, int size OPM_VALGRIND_OPTIM_UNUSED)
+{
+#if !defined NDEBUG && HAVE_VALGRIND
+    auto tmp = VALGRIND_CHECK_MEM_IS_DEFINED(value, size*sizeof(T));
+    return tmp == 0;
+#else
+    return true;
+#endif
+}
+
+/*!
+ * \ingroup Valgrind
+ * \brief Make the memory on which an object resides undefined in
+ *        valgrind runs.
+ *
+ * Example:
+ *
+ * \code
+ * int i = 0;
+ * Valgrind::SetUndefined(i);
+ * Valgrind::CheckDefined(i); // Valgrind complains!
+ * \endcode
+ *
+ * \tparam T The type of the object which ought to be set to undefined
+ *
+ * \param value The object which's memory valgrind should be told is undefined
+ */
+template <class T>
+inline void SetUndefined(const T &value OPM_VALGRIND_OPTIM_UNUSED)
+{
+#if !defined NDEBUG && HAVE_VALGRIND
+    VALGRIND_MAKE_MEM_UNDEFINED(&value, sizeof(T));
+#endif
+}
+
+/*!
+ * \ingroup Valgrind
+ * \brief Make the memory on which an array of object resides
+ *        undefined in valgrind runs.
+ *
+ * Example:
+ *
+ * \code
+ * int i[3] = {0, 1, 3};
+ * Valgrind::SetUndefined(&i[1], 2);
+ * Valgrind::CheckDefined(i, 3); // Valgrind complains!
+ * \endcode
+ *
+ * \tparam T The type of the object which ought to be set to undefined
+ *
+ * \param value Pointer to the first object of the array.
+ * \param size The size of the array in number of objects
+ */
+template <class T>
+inline void SetUndefined(const T* value OPM_VALGRIND_OPTIM_UNUSED, int size OPM_VALGRIND_OPTIM_UNUSED)
+{
+#if !defined NDEBUG && HAVE_VALGRIND
+    VALGRIND_MAKE_MEM_UNDEFINED(value, size*sizeof(T));
+#endif
+}
+
+/*!
+ * \ingroup Valgrind
+ * \brief Make the memory on which an object resides defined.
+ *
+ * Example:
+ *
+ * \code
+ * int i;
+ * Valgrind::SetDefined(i);
+ * Valgrind::CheckDefined(i); // Valgrind does not complain!
+ * \endcode
+ *
+ * \tparam T The type of the object which valgrind should consider as defined
+ *
+ * \param value The object which's memory valgrind should consider as defined
+ */
+template <class T>
+inline void SetDefined(const T& value OPM_VALGRIND_OPTIM_UNUSED)
+{
+#if !defined NDEBUG && HAVE_VALGRIND
+    VALGRIND_MAKE_MEM_DEFINED(&value, sizeof(T));
+#endif
+}
+
+/*!
+ * \ingroup Valgrind
+ * \brief Make the memory on which a C-style array of objects resides
+ *        defined.
+ *
+ * Example:
+ *
+ * \code
+ * int i[3];
+ * Valgrind::SetDefined(i, 3);
+ * Valgrind::CheckDefined(i, 3); // Valgrind does not complain!
+ * \endcode
+ *
+ * \tparam T The type of the object which valgrind should consider as defined
+ *
+ * \param value Pointer to the first object of the array.
+ * \param n The size of the array in number of objects
+ */
+template <class T>
+inline void SetDefined(const T *value OPM_VALGRIND_OPTIM_UNUSED, int n OPM_VALGRIND_OPTIM_UNUSED)
+{
+#if !defined NDEBUG && HAVE_VALGRIND
+    VALGRIND_MAKE_MEM_DEFINED(value, n*sizeof(T));
+#endif
+}
+
+/*!
+ * \ingroup Valgrind
+ * \brief Make valgrind complain if an object's memory is accessed.
+ *
+ * Example:
+ *
+ * \code
+ * int i = 1;
+ * Valgrind::SetNoAccess(i);
+ * int j = i; // Valgrind complains!
+ * \endcode
+ *
+ * \tparam T The type of the object which valgrind should complain if accessed
+ *
+ * \param value The object which's memory valgrind should complain if accessed
+ */
+template <class T>
+inline void SetNoAccess(const T &value OPM_VALGRIND_OPTIM_UNUSED)
+{
+#if !defined NDEBUG && HAVE_VALGRIND
+    VALGRIND_MAKE_MEM_NOACCESS(&value, sizeof(T));
+#endif
+}
+
+/*!
+ * \ingroup Valgrind
+ * \brief Make valgrind complain if the memory of a C-style array of
+ *        objects is accessed.
+ *
+ * Example:
+ *
+ * \code
+ * int i[3] = {0, 1, 2};
+ * Valgrind::SetNoAccess(i, 2);
+ * int j = i[1]; // Valgrind complains!
+ * \endcode
+ *
+ * \param value Pointer to the first object of the array.
+ * \param size The size of the array in number of objects
+ */
+template <class T>
+inline void SetNoAccess(const T *value OPM_VALGRIND_OPTIM_UNUSED, int size OPM_VALGRIND_OPTIM_UNUSED)
+{
+#if !defined NDEBUG && HAVE_VALGRIND
+    VALGRIND_MAKE_MEM_NOACCESS(value, size*sizeof(T));
+#endif
+}
+
+}} // namespace Valgrind, Opm
+
+#endif

--- a/opm/material/components/Air.hpp
+++ b/opm/material/components/Air.hpp
@@ -31,9 +31,8 @@
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/IdealGas.hpp>
 
-#include <opm/common/Unused.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Unused.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 namespace Opm {
 
@@ -54,7 +53,7 @@ public:
      * \brief Returns true iff the liquid phase is assumed to be compressible
      */
     static bool liquidIsCompressible()
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidIsCompressible()"); }
+    { throw std::runtime_error("Not implemented: Component::liquidIsCompressible()"); }
 
     /*!
      * \brief A human readable name for the \f$Air\f$.
@@ -162,8 +161,7 @@ public:
     static Evaluation simpleGasViscosity(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         if(temperature < 273.15 || temperature > 660.) {
-            OPM_THROW(NumericalProblem,
-                      "Air: Temperature (" << temperature << "K) out of range");
+            throw NumericalIssue("Air: Temperature "+std::to_string(Opm::scalarValue(temperature))+"K out of range");
         }
         return 1.496e-6*Opm::pow(temperature, 1.5)/(temperature + 120);
     }

--- a/opm/material/components/CO2.hpp
+++ b/opm/material/components/CO2.hpp
@@ -28,8 +28,6 @@
 #ifndef OPM_CO2_HPP
 #define OPM_CO2_HPP
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
 #include <opm/material/Constants.hpp>
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/components/Component.hpp>

--- a/opm/material/components/Component.hpp
+++ b/opm/material/components/Component.hpp
@@ -27,8 +27,7 @@
 #ifndef OPM_COMPONENT_HPP
 #define OPM_COMPONENT_HPP
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 namespace Opm {
 
@@ -67,55 +66,55 @@ public:
      * \brief Returns true iff the gas phase is assumed to be compressible
      */
     static bool gasIsCompressible()
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::gasIsCompressible()"); }
+    { throw std::runtime_error("Not implemented: Component::gasIsCompressible()"); }
 
     /*!
      * \brief Returns true iff the gas phase is assumed to be ideal
      */
     static bool gasIsIdeal()
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::gasIsIdeal()"); }
+    { throw std::runtime_error("Not implemented: Component::gasIsIdeal()"); }
 
     /*!
      * \brief Returns true iff the liquid phase is assumed to be compressible
      */
     static bool liquidIsCompressible()
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidIsCompressible()"); }
+    { throw std::runtime_error("Not implemented: Component::liquidIsCompressible()"); }
 
     /*!
      * \brief A human readable name for the component.
      */
     static const char* name()
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::name()"); }
+    { throw std::runtime_error("Not implemented: Component::name()"); }
 
     /*!
      * \brief The molar mass in \f$\mathrm{[kg]}\f$ of the component.
      */
     static Scalar molarMass()
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::molarMass()"); }
+    { throw std::runtime_error("Not implemented: Component::molarMass()"); }
 
     /*!
      * \brief Returns the critical temperature in \f$\mathrm{[K]}\f$ of the component.
      */
     static Scalar criticalTemperature()
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::criticalTemperature()"); }
+    { throw std::runtime_error("Not implemented: Component::criticalTemperature()"); }
 
     /*!
      * \brief Returns the critical pressure in \f$\mathrm{[Pa]}\f$ of the component.
      */
     static Scalar criticalPressure()
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::criticalPressure()"); }
+    { throw std::runtime_error("Not implemented: Component::criticalPressure()"); }
 
     /*!
      * \brief Returns the temperature in \f$\mathrm{[K]}\f$ at the component's triple point.
      */
     static Scalar tripleTemperature()
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::tripleTemperature()"); }
+    { throw std::runtime_error("Not implemented: Component::tripleTemperature()"); }
 
     /*!
      * \brief Returns the pressure in \f$\mathrm{[Pa]}\f$ at the component's triple point.
      */
     static Scalar triplePressure()
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::triplePressure()"); }
+    { throw std::runtime_error("Not implemented: Component::triplePressure()"); }
 
     /*!
      * \brief The vapor pressure in \f$\mathrm{[Pa]}\f$ of the component at a given
@@ -125,7 +124,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation vaporPressure(const Evaluation& /* temperature */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::vaporPressure()"); }
+    { throw std::runtime_error("Not implemented: Component::vaporPressure()"); }
 
     /*!
      * \brief The density in \f$\mathrm{[kg/m^3]}\f$ of the component at a given pressure in \f$\mathrm{[Pa]}\f$ and temperature in \f$\mathrm{[K]}\f$.
@@ -135,7 +134,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasDensity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::gasDensity()"); }
+    { throw std::runtime_error("Not implemented: Component::gasDensity()"); }
 
     /*!
      * \brief The density \f$\mathrm{[kg/m^3]}\f$ of the liquid component at a given pressure in \f$\mathrm{[Pa]}\f$ and temperature in \f$\mathrm{[K]}\f$.
@@ -145,7 +144,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidDensity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidDensity()"); }
+    { throw std::runtime_error("Not implemented: Component::liquidDensity()"); }
 
     /*!
      * \brief Specific enthalpy \f$\mathrm{[J/kg]}\f$ of the pure component in gas.
@@ -155,7 +154,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::gasEnthalpy()"); }
+    { throw std::runtime_error("Not implemented: Component::gasEnthalpy()"); }
 
     /*!
      * \brief Specific enthalpy \f$\mathrm{[J/kg]}\f$ of the pure component in liquid.
@@ -165,7 +164,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidEnthalpy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidEnthalpy()"); }
+    { throw std::runtime_error("Not implemented: Component::liquidEnthalpy()"); }
 
     /*!
      * \brief Specific internal energy \f$\mathrm{[J/kg]}\f$ of the pure component in gas.
@@ -175,7 +174,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasInternalEnergy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::gasInternalEnergy()"); }
+    { throw std::runtime_error("Not implemented: Component::gasInternalEnergy()"); }
 
     /*!
      * \brief Specific internal energy \f$\mathrm{[J/kg]}\f$ of pure the pure component in liquid.
@@ -185,7 +184,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidInternalEnergy(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidInternalEnergy()"); }
+    { throw std::runtime_error("Not implemented: Component::liquidInternalEnergy()"); }
 
     /*!
      * \brief The dynamic viscosity \f$\mathrm{[Pa*s]}\f$ of the pure component at a given pressure in \f$\mathrm{[Pa]}\f$ and
@@ -196,7 +195,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasViscosity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::gasViscosity()"); }
+    { throw std::runtime_error("Not implemented: Component::gasViscosity()"); }
 
     /*!
      * \brief The dynamic liquid viscosity \f$\mathrm{[Pa*s]}\f$ of the pure component.
@@ -206,35 +205,35 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidViscosity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidViscosity()"); }
+    { throw std::runtime_error("Not implemented: Component::liquidViscosity()"); }
 
     /*!
      * \brief Thermal conductivity of the component [W/(m^2 K/m)] as a gas.
      */
     template <class Evaluation>
     static Evaluation gasThermalConductivity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::gasThermalConductivity()"); }
+    { throw std::runtime_error("Not implemented: Component::gasThermalConductivity()"); }
 
     /*!
      * \brief Thermal conductivity of the component [W/(m^2 K/m)] as a liquid.
      */
     template <class Evaluation>
     static Evaluation liquidThermalConductivity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidThermalConductivity()"); }
+    { throw std::runtime_error("Not implemented: Component::liquidThermalConductivity()"); }
 
     /*!
      * \brief Specific isobaric heat capacity of the component [J/kg] as a gas.
      */
     template <class Evaluation>
     static Evaluation gasHeatCapacity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::gasHeatCapacity()"); }
+    { throw std::runtime_error("Not implemented: Component::gasHeatCapacity()"); }
 
     /*!
      * \brief Specific isobaric heat capacity of the component [J/kg] as a liquid.
      */
     template <class Evaluation>
     static Evaluation liquidHeatCapacity(const Evaluation& /* temperature */, const Evaluation& /* pressure */)
-    { OPM_THROW(std::runtime_error, "Not implemented: Component::liquidHeatCapacity()"); }
+    { throw std::runtime_error("Not implemented: Component::liquidHeatCapacity()"); }
 };
 
 } // namespace Opm

--- a/opm/material/components/Dnapl.hpp
+++ b/opm/material/components/Dnapl.hpp
@@ -32,7 +32,7 @@
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 
 namespace Opm {
 /*!

--- a/opm/material/components/H2O.hpp
+++ b/opm/material/components/H2O.hpp
@@ -27,20 +27,20 @@
 #ifndef OPM_H2O_HPP
 #define OPM_H2O_HPP
 
-#include <cmath>
-#include <cassert>
-
-#include <opm/material/IdealGas.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Valgrind.hpp>
-
-#include "Component.hpp"
-
 #include "iapws/Common.hpp"
 #include "iapws/Region1.hpp"
 #include "iapws/Region2.hpp"
 #include "iapws/Region4.hpp"
+
+#include "Component.hpp"
+
+#include <opm/material/IdealGas.hpp>
+#include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Valgrind.hpp>
+
+#include <cmath>
+#include <cassert>
+#include <sstream>
 
 namespace Opm {
 
@@ -179,9 +179,11 @@ public:
     {
         if (!Region2::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Enthalpy of steam is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Enthalpy of steam is only implemented for temperatures below 623.15K and "
+                << "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+
+            throw NumericalIssue(oss.str());
         }
 
         // regularization
@@ -230,9 +232,11 @@ public:
     {
         if (!Region1::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Enthalpy of water is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Enthalpy of water is only implemented for temperatures below 623.15K and "
+                << "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+
+            throw NumericalIssue(oss.str());
         }
 
         // regularization
@@ -272,9 +276,11 @@ public:
     {
         if (!Region2::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Heat capacity of steam is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Heat capacity of steam is only implemented for temperatures below 623.15K and "
+                << "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+
+            throw NumericalIssue(oss.str());
         }
 
         // regularization
@@ -307,9 +313,10 @@ public:
     {
         if (!Region1::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "heat Capacity of water is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Heat capacity of water is only implemented for temperatures below 623.15K and "
+                << "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+            throw NumericalIssue(oss.str());
         }
 
         // regularization
@@ -341,9 +348,11 @@ public:
     {
         if (!Region1::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Internal Energy of water is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Internal Energy of water is only implemented for temperatures below 623.15K and "
+                << "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+
+            throw NumericalIssue(oss.str());
         }
 
 
@@ -398,9 +407,10 @@ public:
     {
         if (!Region2::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Internal Energy of steam is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss <<"Internal energy of steam is only implemented for temperatures below 623.15K and "
+                << "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+            throw NumericalIssue(oss.str());
         }
 
         // regularization
@@ -473,9 +483,11 @@ public:
     {
         if (!Region1::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Heat capacity of water is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Heat capacity of water is only implemented for temperatures below 623.15K and "
+                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+
+            throw NumericalIssue(oss.str());
         }
 
 
@@ -507,9 +519,10 @@ public:
     {
         if (!Region2::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Heat capacity of steam is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Heat capacity of steam is only implemented for temperatures below 623.15K and "
+                << "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+            throw NumericalIssue(oss.str());
         }
 
         // regularization
@@ -554,9 +567,10 @@ public:
     {
         if (!Region2::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Density of steam is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Density of steam is only implemented for temperatures below 623.15K and "
+                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+            throw NumericalIssue(oss.str());
         }
 
         // regularization
@@ -679,9 +693,10 @@ public:
     {
         if (!Region1::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Density of water is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Density of water is only implemented for temperatures below 623.15K and "
+                << "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+            throw NumericalIssue(oss.str());
         }
 
         // regularization
@@ -780,9 +795,10 @@ public:
     {
         if (!Region2::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Viscosity of steam is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Viscosity of steam is only implemented for temperatures below 623.15K and "
+                << "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+            throw NumericalIssue(oss.str());
         }
 
         Evaluation rho = gasDensity(temperature, pressure);
@@ -805,9 +821,10 @@ public:
     {
         if (!Region1::isValid(temperature, pressure))
         {
-            OPM_THROW(NumericalProblem,
-                      "Viscosity of water is only implemented for temperatures below 623.15K and "
-                      "pressures below 100MPa. (T = " << temperature << ", p=" << pressure);
+            std::ostringstream oss;
+            oss << "Viscosity of water is only implemented for temperatures below 623.15K and "
+                << "pressures below 100MPa. (T = " << temperature << ", p=" << pressure;
+            throw NumericalIssue(oss.str());
         };
 
         const Evaluation& rho = liquidDensity(temperature, pressure);

--- a/opm/material/components/Lnapl.hpp
+++ b/opm/material/components/Lnapl.hpp
@@ -29,7 +29,7 @@
 
 #include "Component.hpp"
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 
 namespace Opm {
 /*!

--- a/opm/material/components/Mesitylene.hpp
+++ b/opm/material/components/Mesitylene.hpp
@@ -80,13 +80,13 @@ public:
      * \brief Returns the temperature \f$\mathrm{[K]}\f$ at mesitylene's triple point.
      */
     static Scalar tripleTemperature()
-    { OPM_THROW(std::runtime_error, "Not implemented: tripleTemperature for mesitylene"); }
+    { throw std::runtime_error("Not implemented: tripleTemperature for mesitylene"); }
 
     /*!
      * \brief Returns the pressure \f$\mathrm{[Pa]}\f$ at mesitylene's triple point.
      */
     static Scalar triplePressure()
-    { OPM_THROW(std::runtime_error, "Not implemented: triplePressure for mesitylene"); }
+    { throw std::runtime_error("Not implemented: triplePressure for mesitylene"); }
 
     /*!
      * \brief The saturation vapor pressure in \f$\mathrm{[Pa]}\f$ of

--- a/opm/material/components/N2.hpp
+++ b/opm/material/components/N2.hpp
@@ -32,7 +32,7 @@
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <cmath>
 

--- a/opm/material/components/SimpleH2O.hpp
+++ b/opm/material/components/SimpleH2O.hpp
@@ -32,7 +32,7 @@
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <cmath>
 
@@ -304,8 +304,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidPressure(const Evaluation& /*temperature*/, const Evaluation& /*density*/)
     {
-        OPM_THROW(std::logic_error,
-                  "The liquid pressure is undefined for incompressible fluids");
+        throw std::logic_error("The liquid pressure is undefined for incompressible fluids");
     }
 
     /*!

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -33,9 +33,6 @@
 #include <cassert>
 #include <iostream>
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
-
 #include <opm/material/common/MathToolbox.hpp>
 
 namespace Opm {

--- a/opm/material/components/Xylene.hpp
+++ b/opm/material/components/Xylene.hpp
@@ -77,13 +77,13 @@ public:
      * \brief Returns the temperature \f$\mathrm{[K]}\f$ at xylene's triple point.
      */
     static Scalar tripleTemperature()
-    { OPM_THROW(std::runtime_error, "Not implemented: tripleTemperature for xylene"); }
+    { throw std::runtime_error("Not implemented: tripleTemperature for xylene"); }
 
     /*!
      * \brief Returns the pressure \f$\mathrm{[Pa]}\f$ at xylene's triple point.
      */
     static Scalar triplePressure()
-    { OPM_THROW(std::runtime_error, "Not implemented: triplePressure for xylene"); }
+    { throw std::runtime_error("Not implemented: triplePressure for xylene"); }
 
     /*!
      * \brief The saturation vapor pressure in \f$\mathrm{[Pa]}\f$ of pure xylene

--- a/opm/material/constraintsolvers/CompositionFromFugacities.hpp
+++ b/opm/material/constraintsolvers/CompositionFromFugacities.hpp
@@ -28,19 +28,11 @@
 #define OPM_COMPOSITION_FROM_FUGACITIES_HPP
 
 #include <opm/material/common/MathToolbox.hpp>
-
-
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
-
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
-
-
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/Valgrind.hpp>
 
 #include <limits>
 
@@ -141,7 +133,7 @@ public:
             x = 0.0;
             try { J.solve(x, b); }
             catch (Dune::FMatrixError e)
-            { throw Opm::NumericalProblem(e.what()); }
+            { throw Opm::NumericalIssue(e.what()); }
 
             //std::cout << "original delta: " << x << "\n";
 
@@ -175,12 +167,13 @@ public:
             }
         }
 
-        OPM_THROW(Opm::NumericalProblem,
-                  "Calculating the " << FluidSystem::phaseName(phaseIdx)
-                  << "Phase composition failed. Initial {x} = {"
-                  << xInit
-                  << "}, {fug_t} = {" << targetFug << "}, p = " << fluidState.pressure(phaseIdx)
-                  << ", T = " << fluidState.temperature(phaseIdx));
+        std::ostringstream oss;
+        oss << "Calculating the " << FluidSystem::phaseName(phaseIdx)
+            << "Phase composition failed. Initial {x} = {"
+            << xInit
+            << "}, {fug_t} = {" << targetFug << "}, p = " << fluidState.pressure(phaseIdx)
+            << ", T = " << fluidState.temperature(phaseIdx);
+        throw Opm::NumericalIssue(oss.str());
     }
 
 

--- a/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
+++ b/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
@@ -29,9 +29,8 @@
 
 #include <opm/material/constraintsolvers/CompositionFromFugacities.hpp>
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/fvector.hh>
 

--- a/opm/material/constraintsolvers/ImmiscibleFlash.hpp
+++ b/opm/material/constraintsolvers/ImmiscibleFlash.hpp
@@ -31,10 +31,8 @@
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/Valgrind.hpp>
-
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
@@ -202,7 +200,7 @@ public:
 
             try { J.solve(deltaX, b); }
             catch (Dune::FMatrixError e) {
-                throw Opm::NumericalProblem(e.what());
+                throw Opm::NumericalIssue(e.what());
             }
             Valgrind::CheckDefined(deltaX);
 
@@ -215,10 +213,11 @@ public:
             }
         }
 
-        OPM_THROW(Opm::NumericalProblem,
-                  "ImmiscibleFlash solver failed: "
-                  "{c_alpha^kappa} = {" << globalMolarities << "}, "
-                  << "T = " << fluidState.temperature(/*phaseIdx=*/0));
+        std::ostringstream oss;
+        oss << "ImmiscibleFlash solver failed:"
+            << " {c_alpha^kappa} = {" << globalMolarities << "},"
+            << " T = " << fluidState.temperature(/*phaseIdx=*/0);
+    throw Opm::NumericalIssue(oss.str());
     }
 
 

--- a/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
+++ b/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
@@ -29,18 +29,11 @@
 
 #include <opm/material/common/MathToolbox.hpp>
 
-
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
-
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
-
-
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Valgrind.hpp>
 
 namespace Opm {
 
@@ -261,8 +254,9 @@ public:
             M.solve(x, b);
         }
         catch (const Dune::FMatrixError& e) {
-            OPM_THROW(NumericalProblem,
-                      "Numerical problem in MiscibleMultiPhaseComposition::solve(): " << e.what() << "; M="<<M);
+            std::ostringstream oss;
+            oss << "Numerical problem in MiscibleMultiPhaseComposition::solve(): " << e.what() << "; M="<<M;
+            throw NumericalIssue(oss.str());
         }
         catch (...) {
             throw;

--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -33,15 +33,12 @@
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <limits>
 #include <iostream>
@@ -220,7 +217,7 @@ public:
             deltaX = 0.0;
             try { J.solve(deltaX, b); }
             catch (const Dune::FMatrixError& e) {
-                throw Opm::NumericalProblem(e.what());
+                throw Opm::NumericalIssue(e.what());
             }
             Valgrind::CheckDefined(deltaX);
 
@@ -233,10 +230,11 @@ public:
             }
         }
 
-        OPM_THROW(NumericalProblem,
-                  "NcpFlash solver failed: "
-                  "{c_alpha^kappa} = {" << globalMolarities << "}, "
-                  << "T = " << fluidState.temperature(/*phaseIdx=*/0));
+        std::ostringstream oss;
+        oss << "NcpFlash solver failed:"
+            << " {c_alpha^kappa} = {" << globalMolarities << "}, "
+            << " T = " << fluidState.temperature(/*phaseIdx=*/0);
+        throw NumericalIssue(oss.str());
     }
 
     /*!

--- a/opm/material/densead/Evaluation.hpp
+++ b/opm/material/densead/Evaluation.hpp
@@ -35,7 +35,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation1.hpp
+++ b/opm/material/densead/Evaluation1.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation10.hpp
+++ b/opm/material/densead/Evaluation10.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation11.hpp
+++ b/opm/material/densead/Evaluation11.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation12.hpp
+++ b/opm/material/densead/Evaluation12.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation2.hpp
+++ b/opm/material/densead/Evaluation2.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation3.hpp
+++ b/opm/material/densead/Evaluation3.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation4.hpp
+++ b/opm/material/densead/Evaluation4.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation5.hpp
+++ b/opm/material/densead/Evaluation5.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation6.hpp
+++ b/opm/material/densead/Evaluation6.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation7.hpp
+++ b/opm/material/densead/Evaluation7.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation8.hpp
+++ b/opm/material/densead/Evaluation8.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/densead/Evaluation9.hpp
+++ b/opm/material/densead/Evaluation9.hpp
@@ -34,7 +34,7 @@
 #include "Evaluation.hpp"
 #include "Math.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/version.hh>
 

--- a/opm/material/eos/PengRobinson.hpp
+++ b/opm/material/eos/PengRobinson.hpp
@@ -32,7 +32,7 @@
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/common/UniformTabulated2DFunction.hpp>
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 #include <opm/material/common/PolynomialUtils.hpp>
 
 #include <csignal>
@@ -379,8 +379,10 @@ protected:
                         Vcrit = (maxVm + minVm)/2;
                         return;
                     }
-                    OPM_THROW(NumericalProblem,
-                               "Could not determine the critical point for a=" << a << ", b=" << b);
+
+                    std::ostringstream oss;
+                    oss << "Could not determine the critical point for a=" << a << ", b=" << b;
+                    throw NumericalIssue(oss.str());
                 }
 
                 if (findExtrema_(minVm, maxVm, minP, maxP, a, b, T - delta)) {

--- a/opm/material/eos/PengRobinsonParams.hpp
+++ b/opm/material/eos/PengRobinsonParams.hpp
@@ -27,7 +27,7 @@
 #ifndef OPM_PENG_ROBINSON_PARAMS_HPP
 #define OPM_PENG_ROBINSON_PARAMS_HPP
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 namespace Opm
 {

--- a/opm/material/fluidmatrixinteractions/BrooksCorey.hpp
+++ b/opm/material/fluidmatrixinteractions/BrooksCorey.hpp
@@ -30,8 +30,7 @@
 #include "BrooksCoreyParams.hpp"
 
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -294,9 +293,8 @@ public:
                 return Sw;
         }
 
-        OPM_THROW(NumericalProblem,
-                  "Couldn't invert the Brooks-Corey non-wetting phase"
-                  " relperm within 20 iterations");
+        throw NumericalIssue("Couldn't invert the Brooks-Corey non-wetting phase"
+                               " relperm within 20 iterations");
     }
 };
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
+++ b/opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
@@ -27,7 +27,7 @@
 #ifndef OPM_BROOKS_COREY_PARAMS_HPP
 #define OPM_BROOKS_COREY_PARAMS_HPP
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/EnsureFinalized.hpp>
 
 #include <cassert>

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -29,11 +29,9 @@
 
 #include "EclDefaultMaterialParams.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/MathToolbox.hpp>
-
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 
@@ -252,7 +250,7 @@ public:
                             const Params& /*params*/,
                             const FluidState& /*fluidState*/)
     {
-        OPM_THROW(std::logic_error, "Not implemented: saturations()");
+        throw std::logic_error("Not implemented: saturations()");
     }
 
     /*!
@@ -262,7 +260,7 @@ public:
     static Evaluation Sg(const Params& /*params*/,
                          const FluidState& /*fluidState*/)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sg()");
+        throw std::logic_error("Not implemented: Sg()");
     }
 
     /*!
@@ -272,7 +270,7 @@ public:
     static Evaluation Sn(const Params& /*params*/,
                          const FluidState& /*fluidState*/)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sn()");
+        throw std::logic_error("Not implemented: Sn()");
     }
 
     /*!
@@ -282,7 +280,7 @@ public:
     static Evaluation Sw(const Params& /*params*/,
                          const FluidState& /*fluidState*/)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sw()");
+        throw std::logic_error("Not implemented: Sw()");
     }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -35,9 +35,8 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #endif
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <string>
 #include <cassert>
@@ -201,10 +200,9 @@ public:
             }
 
             if (enablePcScaling_ && enableLeverettScaling_)
-                OPM_THROW(std::runtime_error,
-                          "Capillary pressure scaling and the Leverett scaling function are "
-                          "mutually exclusive: The deck contains the PCW property and the "
-                          "JFUNC keyword applies to the water phase.");
+                throw std::runtime_error("Capillary pressure scaling and the Leverett scaling function are "
+                                         "mutually exclusive: The deck contains the PCW property and the "
+                                         "JFUNC keyword applies to the water phase.");
         }
         else {
             assert(twoPhaseSystemType == EclGasOilSystem);
@@ -219,10 +217,9 @@ public:
             }
 
             if (enablePcScaling_ && enableLeverettScaling_)
-                OPM_THROW(std::runtime_error,
-                          "Capillary pressure scaling and the Leverett scaling function are "
-                          "mutually exclusive: The deck contains the PCG property and the "
-                          "JFUNC keyword applies to the gas phase.");
+                throw std::runtime_error("Capillary pressure scaling and the Leverett scaling function are "
+                                         "mutually exclusive: The deck contains the PCG property and the "
+                                         "JFUNC keyword applies to the gas phase.");
         }
 
         // check if we are supposed to scale the Y axis of the wetting phase relperm

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -381,8 +381,8 @@ struct EclEpsScalingPointsInfo
                     Opm::arithmeticMean((*epsProperties.permx)[cartesianCellIdx],
                                         (*epsProperties.permy)[cartesianCellIdx]);
             else
-                OPM_THROW(std::runtime_error, "Illegal direction indicator for the JFUNC "
-                          "keyword ("<<static_cast<int>(jfuncDir)<<")");
+                throw std::runtime_error("Illegal direction indicator for the JFUNC "
+                                         "keyword ("+std::to_string(int(jfuncDir))+")");
 
             // convert permeability from m^2 to mD
             perm *= 1.01325e15;

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -30,8 +30,7 @@
 #include "EclEpsTwoPhaseLawParams.hpp"
 
 #include <opm/material/fluidstates/SaturationOverlayFluidState.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 namespace Opm {
 /*!
@@ -110,8 +109,7 @@ public:
     template <class Container, class FluidState>
     static void capillaryPressures(Container& /*values*/, const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        OPM_THROW(NotImplemented,
-                  "The capillaryPressures(fs) method is not yet implemented");
+        throw std::invalid_argument("The capillaryPressures(fs) method is not yet implemented");
     }
 
     /*!
@@ -127,8 +125,7 @@ public:
     template <class Container, class FluidState>
     static void relativePermeabilities(Container& /*values*/, const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        OPM_THROW(NotImplemented,
-                  "The pcnw(fs) method is not yet implemented");
+        throw std::invalid_argument("The pcnw(fs) method is not yet implemented");
     }
 
     /*!
@@ -145,8 +142,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation pcnw(const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        OPM_THROW(NotImplemented,
-                  "The pcnw(fs) method is not yet implemented");
+        throw std::invalid_argument("The pcnw(fs) method is not yet implemented");
     }
 
     template <class Evaluation>
@@ -171,8 +167,7 @@ public:
     template <class Container, class FluidState>
     static void saturations(Container& /*values*/, const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        OPM_THROW(NotImplemented,
-                  "The saturations(fs) method is not yet implemented");
+        throw std::invalid_argument("The saturations(fs) method is not yet implemented");
     }
 
     /*!
@@ -182,15 +177,13 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sw(const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        OPM_THROW(NotImplemented,
-                  "The Sw(fs) method is not yet implemented");
+        throw std::invalid_argument("The Sw(fs) method is not yet implemented");
     }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatSw(const Params& /*params*/, const Evaluation& /*pc*/)
     {
-        OPM_THROW(NotImplemented,
-                  "The twoPhaseSatSw(pc) method is not yet implemented");
+        throw std::invalid_argument("The twoPhaseSatSw(pc) method is not yet implemented");
     }
 
     /*!
@@ -200,15 +193,13 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sn(const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        OPM_THROW(NotImplemented,
-                  "The Sn(pc) method is not yet implemented");
+        throw std::invalid_argument("The Sn(pc) method is not yet implemented");
     }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatSn(const Params& /*params*/, const Evaluation& /*pc*/)
     {
-        OPM_THROW(NotImplemented,
-                  "The twoPhaseSatSn(pc) method is not yet implemented");
+        throw std::invalid_argument("The twoPhaseSatSn(pc) method is not yet implemented");
     }
 
     /*!
@@ -223,8 +214,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation krw(const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        OPM_THROW(NotImplemented,
-                  "The krw(fs) method is not yet implemented");
+        throw std::invalid_argument("The krw(fs) method is not yet implemented");
     }
 
     template <class Evaluation>
@@ -249,8 +239,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation krn(const Params& /*params*/, const FluidState& /*fluidState*/)
     {
-        OPM_THROW(NotImplemented,
-                  "The krn(fs) method is not yet implemented");
+        throw std::invalid_argument("The krn(fs) method is not yet implemented");
     }
 
     template <class Evaluation>

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -34,8 +34,7 @@
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #endif
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <string>
 #include <cassert>
@@ -138,9 +137,8 @@ public:
             return;
 
         if (!deck.hasKeyword("EHYSTR"))
-            OPM_THROW(std::runtime_error,
-                      "Enabling hysteresis via the HYST parameter for SATOPTS requires the "
-                      "presence of the EHYSTR keyword");
+            throw std::runtime_error("Enabling hysteresis via the HYST parameter for SATOPTS requires the "
+                                     "presence of the EHYSTR keyword");
 
         const auto& ehystrKeyword = deck.getKeyword("EHYSTR");
         if (deck.hasKeyword("NOHYKR"))
@@ -148,9 +146,8 @@ public:
         else {
             krHysteresisModel_ = ehystrKeyword.getRecord(0).getItem("relative_perm_hyst").get< int >(0);
             if (krHysteresisModel_ != 0)
-                OPM_THROW(std::runtime_error,
-                          "Only the Carlson kr hystersis model (indicated by a 0 on the second item"
-                          " of the 'EHYSTR' keyword) is supported");
+                throw std::runtime_error("Only the Carlson kr hystersis model (indicated by a 0 on the second item"
+                                         " of the 'EHYSTR' keyword) is supported");
         }
 
         if (deck.hasKeyword("NOHYPC"))

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -103,8 +103,7 @@ public:
                                    const Params& /* params */,
                                    const FluidState& /* fs */)
     {
-        OPM_THROW(NotImplemented,
-                  "The capillaryPressures(fs) method is not yet implemented");
+        throw std::invalid_argument("The capillaryPressures(fs) method is not yet implemented");
     }
 
     /*!
@@ -122,8 +121,7 @@ public:
                                        const Params& /* params */,
                                        const FluidState& /* fs */)
     {
-        OPM_THROW(NotImplemented,
-                  "The pcnw(fs) method is not yet implemented");
+        throw std::invalid_argument("The pcnw(fs) method is not yet implemented");
     }
 
     /*!
@@ -141,8 +139,7 @@ public:
     static Evaluation pcnw(const Params& /* params */,
                            const FluidState& /* fs */)
     {
-        OPM_THROW(NotImplemented,
-                  "The pcnw(fs) method is not yet implemented");
+        throw std::invalid_argument("The pcnw(fs) method is not yet implemented");
     }
 
     template <class Evaluation>
@@ -172,8 +169,7 @@ public:
                             const Params& /* params */,
                             const FluidState& /* fs */)
     {
-        OPM_THROW(NotImplemented,
-                  "The saturations(fs) method is not yet implemented");
+        throw std::invalid_argument("The saturations(fs) method is not yet implemented");
     }
 
     /*!
@@ -184,16 +180,14 @@ public:
     static Evaluation Sw(const Params& /* params */,
                          const FluidState& /* fs */)
     {
-        OPM_THROW(NotImplemented,
-                  "The Sw(fs) method is not yet implemented");
+        throw std::invalid_argument("The Sw(fs) method is not yet implemented");
     }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatSw(const Params& /* params */,
                                     const Evaluation& /* pc */)
     {
-        OPM_THROW(NotImplemented,
-                  "The twoPhaseSatSw(pc) method is not yet implemented");
+        throw std::invalid_argument("The twoPhaseSatSw(pc) method is not yet implemented");
     }
 
     /*!
@@ -204,16 +198,14 @@ public:
     static Evaluation Sn(const Params& /* params */,
                          const FluidState& /* fs */)
     {
-        OPM_THROW(NotImplemented,
-                  "The Sn(pc) method is not yet implemented");
+        throw std::invalid_argument("The Sn(pc) method is not yet implemented");
     }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatSn(const Params& /* params */,
                                     const Evaluation& /* pc */)
     {
-        OPM_THROW(NotImplemented,
-                  "The twoPhaseSatSn(pc) method is not yet implemented");
+        throw std::invalid_argument("The twoPhaseSatSn(pc) method is not yet implemented");
     }
 
     /*!
@@ -229,8 +221,7 @@ public:
     static Evaluation krw(const Params& /* params */,
                           const FluidState& /* fs */)
     {
-        OPM_THROW(NotImplemented,
-                  "The krw(fs) method is not yet implemented");
+        throw std::invalid_argument("The krw(fs) method is not yet implemented");
     }
 
     template <class Evaluation>
@@ -257,8 +248,7 @@ public:
     static Evaluation krn(const Params& /* params */,
                           const FluidState& /* fs */)
     {
-        OPM_THROW(NotImplemented,
-                  "The krn(fs) method is not yet implemented");
+        throw std::invalid_argument("The krn(fs) method is not yet implemented");
     }
 
     template <class Evaluation>

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -42,8 +42,11 @@
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 #include <opm/material/fluidstates/SimpleModularFluidState.hpp>
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#if HAVE_OPM_COMMON
+#include <opm/common/OpmLog/OpmLog.hpp>
+#endif
+
+#include <opm/material/common/Exceptions.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
@@ -229,9 +232,10 @@ public:
     {
         MaterialLawParams& mlp = *materialLawParams_[elemIdx];
 
-        if (enableHysteresis()) {
-            OPM_MESSAGE("Warning: Using non-defautl satnum regions for conenction is not tested in combination with hysteresis");
-        }
+#if HAVE_OPM_COMMON
+        if (enableHysteresis())
+            OpmLog::warning("Warning: Using non-default satnum regions for conenction is not tested in combination with hysteresis");
+#endif
         // Currently we don't support COMPIMP. I.e. use the same table lookup for the hysteresis curves.
         // unsigned impRegionIdx = satRegionIdx;
 
@@ -299,7 +303,7 @@ public:
             break;
 
         default:
-            OPM_THROW(std::logic_error, "Enum value for material approach unknown!");
+            throw std::logic_error("Enum value for material approach unknown!");
         }
 
         return mlp;
@@ -330,7 +334,7 @@ public:
                                   unsigned elemIdx) const
     {
         if (!enableHysteresis()) {
-            OPM_THROW(std::runtime_error, "Cannot get hysteresis parameters if hysteresis not enabled.");
+            throw std::runtime_error("Cannot get hysteresis parameters if hysteresis not enabled.");
         }
         const auto& params = materialLawParams(elemIdx);
         MaterialLaw::oilWaterHysteresisParams(pcSwMdc, krnSwMdc, params);
@@ -341,7 +345,7 @@ public:
                                      unsigned elemIdx)
     {
         if (!enableHysteresis()) {
-            OPM_THROW(std::runtime_error, "Cannot set hysteresis parameters if hysteresis not enabled.");
+            throw std::runtime_error("Cannot set hysteresis parameters if hysteresis not enabled.");
         }
         auto& params = materialLawParams(elemIdx);
         MaterialLaw::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc, params);
@@ -352,7 +356,7 @@ public:
                                 unsigned elemIdx) const
     {
         if (!enableHysteresis()) {
-            OPM_THROW(std::runtime_error, "Cannot get hysteresis parameters if hysteresis not enabled.");
+            throw std::runtime_error("Cannot get hysteresis parameters if hysteresis not enabled.");
         }
         const auto& params = materialLawParams(elemIdx);
         MaterialLaw::gasOilHysteresisParams(pcSwMdc, krnSwMdc, params);
@@ -363,7 +367,7 @@ public:
                                    unsigned elemIdx)
     {
         if (!enableHysteresis()) {
-            OPM_THROW(std::runtime_error, "Cannot set hysteresis parameters if hysteresis not enabled.");
+            throw std::runtime_error("Cannot set hysteresis parameters if hysteresis not enabled.");
         }
         auto& params = materialLawParams(elemIdx);
         MaterialLaw::setGasOilHysteresisParams(pcSwMdc, krnSwMdc, params);
@@ -393,7 +397,7 @@ public:
             return realParams.oilWaterParams().drainageParams().scaledPoints();
         }
         default:
-            OPM_THROW(std::logic_error, "Enum value for material approach unknown!");
+            throw std::logic_error("Enum value for material approach unknown!");
         }
     }
 
@@ -433,8 +437,7 @@ private:
             + (waterEnabled?1:0);
 
         if (numEnabled < 2)
-            OPM_THROW(std::runtime_error,
-                      "At least two fluid phases must be enabled. (Is: " << numEnabled << ")");
+            throw std::runtime_error("At least two fluid phases must be enabled. (Is: "+std::to_string(numEnabled)+")");
 
         if (numEnabled == 2) {
             threePhaseApproach_ = Opm::EclTwoPhaseApproach;

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -33,10 +33,9 @@
 #include "EclStone2Material.hpp"
 #include "EclTwoPhaseMaterial.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 
@@ -304,7 +303,7 @@ public:
     static Evaluation pcgn(const Params& /* params */,
                            const FluidState& /* fs */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: pcgn()");
+        throw std::logic_error("Not implemented: pcgn()");
     }
 
     /*!
@@ -320,7 +319,7 @@ public:
     static Evaluation pcnw(const Params& /* params */,
                            const FluidState& /* fs */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: pcnw()");
+        throw std::logic_error("Not implemented: pcnw()");
     }
 
     /*!
@@ -331,7 +330,7 @@ public:
                             const Params& /* params */,
                             const FluidState& /* fs */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: saturations()");
+        throw std::logic_error("Not implemented: saturations()");
     }
 
     /*!
@@ -341,7 +340,7 @@ public:
     static Evaluation Sg(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sg()");
+        throw std::logic_error("Not implemented: Sg()");
     }
 
     /*!
@@ -351,7 +350,7 @@ public:
     static Evaluation Sn(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sn()");
+        throw std::logic_error("Not implemented: Sn()");
     }
 
     /*!
@@ -361,7 +360,7 @@ public:
     static Evaluation Sw(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sw()");
+        throw std::logic_error("Not implemented: Sw()");
     }
 
     /*!
@@ -418,7 +417,7 @@ public:
     static Evaluation krg(const Params& /* params */,
                           const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: krg()");
+        throw std::logic_error("Not implemented: krg()");
     }
 
     /*!
@@ -428,7 +427,7 @@ public:
     static Evaluation krw(const Params& /* params */,
                           const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: krw()");
+        throw std::logic_error("Not implemented: krw()");
     }
 
     /*!
@@ -438,7 +437,7 @@ public:
     static Evaluation krn(const Params& /* params */,
                           const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: krn()");
+        throw std::logic_error("Not implemented: krn()");
     }
 
 

--- a/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
@@ -29,11 +29,10 @@
 
 #include "EclStone1MaterialParams.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -253,7 +252,7 @@ public:
                             const Params& /* params */,
                             const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: saturations()");
+        throw std::logic_error("Not implemented: saturations()");
     }
 
     /*!
@@ -263,7 +262,7 @@ public:
     static Evaluation Sg(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sg()");
+        throw std::logic_error("Not implemented: Sg()");
     }
 
     /*!
@@ -273,7 +272,7 @@ public:
     static Evaluation Sn(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sn()");
+        throw std::logic_error("Not implemented: Sn()");
     }
 
     /*!
@@ -283,7 +282,7 @@ public:
     static Evaluation Sw(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sw()");
+        throw std::logic_error("Not implemented: Sw()");
     }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
@@ -29,11 +29,10 @@
 
 #include "EclStone2MaterialParams.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 
@@ -254,7 +253,7 @@ public:
                             const Params& /* params */,
                             const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: saturations()");
+        throw std::logic_error("Not implemented: saturations()");
     }
 
     /*!
@@ -264,7 +263,7 @@ public:
     static Evaluation Sg(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sg()");
+        throw std::logic_error("Not implemented: Sg()");
     }
 
     /*!
@@ -274,7 +273,7 @@ public:
     static Evaluation Sn(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sn()");
+        throw std::logic_error("Not implemented: Sn()");
     }
 
     /*!
@@ -284,7 +283,7 @@ public:
     static Evaluation Sw(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sw()");
+        throw std::logic_error("Not implemented: Sw()");
     }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -29,11 +29,10 @@
 
 #include "EclTwoPhaseMaterialParams.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 
@@ -237,7 +236,7 @@ public:
     static Evaluation pcgn(const Params& /* params */,
                            const FluidState& /* fs */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: pcgn()");
+        throw std::logic_error("Not implemented: pcgn()");
     }
 
     /*!
@@ -253,7 +252,7 @@ public:
     static Evaluation pcnw(const Params& /* params */,
                            const FluidState& /* fs */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: pcnw()");
+        throw std::logic_error("Not implemented: pcnw()");
     }
 
     /*!
@@ -264,7 +263,7 @@ public:
                             const Params& /* params */,
                             const FluidState& /* fs */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: saturations()");
+        throw std::logic_error("Not implemented: saturations()");
     }
 
     /*!
@@ -274,7 +273,7 @@ public:
     static Evaluation Sg(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sg()");
+        throw std::logic_error("Not implemented: Sg()");
     }
 
     /*!
@@ -284,7 +283,7 @@ public:
     static Evaluation Sn(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sn()");
+        throw std::logic_error("Not implemented: Sn()");
     }
 
     /*!
@@ -294,7 +293,7 @@ public:
     static Evaluation Sw(const Params& /* params */,
                          const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: Sw()");
+        throw std::logic_error("Not implemented: Sw()");
     }
 
     /*!
@@ -356,7 +355,7 @@ public:
     static Evaluation krg(const Params& /* params */,
                           const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: krg()");
+        throw std::logic_error("Not implemented: krg()");
     }
 
     /*!
@@ -366,7 +365,7 @@ public:
     static Evaluation krw(const Params& /* params */,
                           const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: krw()");
+        throw std::logic_error("Not implemented: krw()");
     }
 
     /*!
@@ -376,7 +375,7 @@ public:
     static Evaluation krn(const Params& /* params */,
                           const FluidState& /* fluidState */)
     {
-        OPM_THROW(std::logic_error, "Not implemented: krn()");
+        throw std::logic_error("Not implemented: krn()");
     }
 
 

--- a/opm/material/fluidmatrixinteractions/LinearMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/LinearMaterial.hpp
@@ -30,9 +30,8 @@
 #include "LinearMaterialParams.hpp"
 
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/Valgrind.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 #include <type_traits>
@@ -122,7 +121,7 @@ public:
                             const Params& /*params*/,
                             const FluidState& /*state*/)
     {
-        OPM_THROW(std::runtime_error, "Not implemented: LinearMaterial::saturations()");
+        throw std::runtime_error("Not implemented: LinearMaterial::saturations()");
     }
 
     /*!
@@ -191,12 +190,12 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sw(const Params& /*params*/, const FluidState& /*fs*/)
-    { OPM_THROW(std::runtime_error, "Not implemented: Sw()"); }
+    { throw std::runtime_error("Not implemented: Sw()"); }
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
     twoPhaseSatSw(const Params& /*params*/, const Evaluation& /*Sw*/)
-    { OPM_THROW(std::runtime_error, "Not implemented: twoPhaseSatSw()"); }
+    { throw std::runtime_error("Not implemented: twoPhaseSatSw()"); }
 
     /*!
      * \brief Calculate non-wetting liquid phase saturation given that
@@ -204,12 +203,12 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sn(const Params& /*params*/, const FluidState& /*fs*/)
-    { OPM_THROW(std::runtime_error, "Not implemented: Sn()"); }
+    { throw std::runtime_error("Not implemented: Sn()"); }
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
     twoPhaseSatSn(const Params& /*params*/, const Evaluation& /*Sw*/)
-    { OPM_THROW(std::runtime_error, "Not implemented: twoPhaseSatSn()"); }
+    { throw std::runtime_error("Not implemented: twoPhaseSatSn()"); }
 
     /*!
      * \brief Calculate gas phase saturation given that the rest of
@@ -220,7 +219,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if<Traits::numPhases == 3, Evaluation>::type
     Sg(const Params& /*params*/, const FluidState& /*fs*/)
-    { OPM_THROW(std::runtime_error, "Not implemented: Sg()"); }
+    { throw std::runtime_error("Not implemented: Sg()"); }
 
     /*!
      * \brief The relative permability of the wetting phase

--- a/opm/material/fluidmatrixinteractions/NullMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/NullMaterial.hpp
@@ -29,8 +29,7 @@
 
 #include "NullMaterialParams.hpp"
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
 #include <algorithm>
@@ -104,7 +103,7 @@ public:
     static void saturations(ContainerT& /*values*/,
                             const Params& /*params*/,
                             const FluidState& /*fluidState*/)
-    { OPM_THROW(std::logic_error, "Not defined: NullMaterial::saturations()"); }
+    { throw std::logic_error("Not defined: NullMaterial::saturations()"); }
 
     /*!
      * \brief The relative permeability of all phases.
@@ -142,12 +141,12 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Scalar Sw(const Params& /*params*/, const FluidState& /*fluidState*/)
-    { OPM_THROW(std::logic_error, "Not defined: Sw()"); }
+    { throw std::logic_error("Not defined: Sw()"); }
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
     twoPhaseSatSw(const Params& /*params*/, const Evaluation& /*pcnw*/)
-    { OPM_THROW(std::logic_error, "Not defined: twoPhaseSatSw()"); }
+    { throw std::logic_error("Not defined: twoPhaseSatSw()"); }
 
     /*!
      * \brief Calculate non-wetting phase saturation given that the
@@ -155,12 +154,12 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Scalar Sn(const Params& /*params*/, const FluidState& /*fluidState*/)
-    { OPM_THROW(std::logic_error, "Not defined: Sn()"); }
+    { throw std::logic_error("Not defined: Sn()"); }
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
     twoPhaseSatSn(const Params& /*params*/, const Evaluation& /*pcnw*/)
-    { OPM_THROW(std::logic_error, "Not defined: twoPhaseSatSn()"); }
+    { throw std::logic_error("Not defined: twoPhaseSatSn()"); }
 
     /*!
      * \brief Calculate gas phase saturation given that the rest of
@@ -171,7 +170,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static typename std::enable_if< (numPhases > 2), Evaluation>::type
     Sg(const Params& /*params*/, const FluidState& /*fluidState*/)
-    { OPM_THROW(std::logic_error, "Not defined: Sg()"); }
+    { throw std::logic_error("Not defined: Sg()"); }
 
     /*!
      * \brief The relative permability of the wetting phase

--- a/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
+++ b/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
@@ -354,7 +354,7 @@ public:
      */
     template <class Container, class FluidState>
     static void saturations(Container& /*values*/, const Params& /*params*/, const FluidState& /*fs*/)
-    { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::saturations()"); }
+    { throw std::logic_error("Not implemented: ParkerLenhard::saturations()"); }
 
     /*!
      * \brief Returns the relative permeabilities of the phases
@@ -422,11 +422,11 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sw(const Params& /*params*/, const FluidState& /*fs*/)
-    { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::Sw()"); }
+    { throw std::logic_error("Not implemented: ParkerLenhard::Sw()"); }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatSw(const Params& /*params*/, const Evaluation& /*pc*/)
-    { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::twoPhaseSatSw()"); }
+    { throw std::logic_error("Not implemented: ParkerLenhard::twoPhaseSatSw()"); }
 
     /*!
      * \brief Calculate the non-wetting phase saturations depending on
@@ -438,7 +438,7 @@ public:
 
     template <class Evaluation>
     static Evaluation twoPhaseSatSn(const Params& /*params*/, const Evaluation& /*pc*/)
-    { OPM_THROW(std::logic_error, "Not implemented: ParkerLenhard::twoPhaseSatSn()"); }
+    { throw std::logic_error("Not implemented: ParkerLenhard::twoPhaseSatSn()"); }
 
     /*!
      * \brief The relative permeability for the wetting phase of

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -29,8 +29,7 @@
 
 #include "PiecewiseLinearTwoPhaseMaterialParams.hpp"
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
 #include <algorithm>
@@ -111,7 +110,7 @@ public:
      */
     template <class Container, class FluidState>
     static void saturations(Container& /* values */, const Params& /* params */, const FluidState& /* fs */)
-    { OPM_THROW(std::logic_error, "Not implemented: saturations()"); }
+    { throw std::logic_error("Not implemented: saturations()"); }
 
     /*!
      * \brief The relative permeabilities
@@ -153,11 +152,11 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sw(const Params& /* params */, const FluidState& /* fs */)
-    { OPM_THROW(std::logic_error, "Not implemented: Sw()"); }
+    { throw std::logic_error("Not implemented: Sw()"); }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatSw(const Params& /* params */, const Evaluation& /* pC */)
-    { OPM_THROW(std::logic_error, "Not implemented: twoPhaseSatSw()"); }
+    { throw std::logic_error("Not implemented: twoPhaseSatSw()"); }
 
     /*!
      * \brief Calculate the non-wetting phase saturations depending on

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
@@ -29,8 +29,7 @@
 
 #include "SplineTwoPhaseMaterialParams.hpp"
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -106,7 +105,7 @@ public:
      */
     template <class Container, class FluidState>
     static void saturations(Container& /*values*/, const Params& /*params*/, const FluidState& /*fluidState*/)
-    { OPM_THROW(std::logic_error, "Not implemented: saturations()"); }
+    { throw std::logic_error("Not implemented: saturations()"); }
 
     /*!
      * \brief The relative permeabilities
@@ -170,11 +169,11 @@ public:
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sw(const Params& /*params*/, const FluidState& /*fluidState*/)
-    { OPM_THROW(std::logic_error, "Not implemented: Sw()"); }
+    { throw std::logic_error("Not implemented: Sw()"); }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatSw(const Params& /*params*/, const Evaluation& /*pC*/)
-    { OPM_THROW(std::logic_error, "Not implemented: twoPhaseSatSw()"); }
+    { throw std::logic_error("Not implemented: twoPhaseSatSw()"); }
 
     /*!
      * \brief Calculate the non-wetting phase saturations depending on

--- a/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
@@ -222,28 +222,28 @@ public:
     static void saturations(ContainerT& /*values*/,
                             const Params& /*params*/,
                             const FluidState& /*fluidState*/)
-    { OPM_THROW(std::logic_error, "Not implemented: inverse capillary pressures"); }
+    { throw std::logic_error("Not implemented: inverse capillary pressures"); }
 
     /*!
      * \brief The saturation of the gas phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sg(const Params& /*params*/, const FluidState& /*fluidState*/)
-    { OPM_THROW(std::logic_error, "Not implemented: Sg()"); }
+    { throw std::logic_error("Not implemented: Sg()"); }
 
     /*!
      * \brief The saturation of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sn(const Params& /*params*/, const FluidState& /*fluidState*/)
-    { OPM_THROW(std::logic_error, "Not implemented: Sn()"); }
+    { throw std::logic_error("Not implemented: Sn()"); }
 
     /*!
      * \brief The saturation of the wetting (i.e., water) phase.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation Sw(const Params& /*params*/, const FluidState& /*fluidState*/)
-    { OPM_THROW(std::logic_error, "Not implemented: Sw()"); }
+    { throw std::logic_error("Not implemented: Sw()"); }
 
     /*!
      * \brief The relative permeability of all phases.

--- a/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchtenParams.hpp
@@ -27,16 +27,10 @@
 #ifndef OPM_THREE_PHASE_PARKER_VAN_GENUCHTEN_PARAMS_HPP
 #define OPM_THREE_PHASE_PARKER_VAN_GENUCHTEN_PARAMS_HPP
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/fvector.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
-
-#include <opm/common/Valgrind.hpp>
-
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
 
 #include <opm/material/common/EnsureFinalized.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <cassert>
 

--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -31,11 +31,10 @@
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/common/HasMemberGeneratorMacros.hpp>
 
-#include <opm/common/Valgrind.hpp>
-#include <opm/common/Unused.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/utility/ConditionalStorage.hpp>
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
+#include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/ConditionalStorage.hpp>
 
 namespace Opm {
 OPM_GENERATE_HAS_MEMBER(pvtRegionIndex, ) // Creates 'HasMember_pvtRegionIndex<T>'.
@@ -392,8 +391,7 @@ public:
             break;
         }
 
-        OPM_THROW(std::logic_error,
-                  "Invalid phase or component index!");
+        throw std::logic_error("Invalid phase or component index!");
     }
 
     /*!
@@ -434,8 +432,7 @@ public:
             break;
         }
 
-        OPM_THROW(std::logic_error,
-                  "Invalid phase or component index!");
+        throw std::logic_error("Invalid phase or component index!");
     }
 
     /*!

--- a/opm/material/fluidstates/CompositionalFluidState.hpp
+++ b/opm/material/fluidstates/CompositionalFluidState.hpp
@@ -32,7 +32,7 @@
 
 #include "ModularFluidState.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <algorithm>
 
 namespace Opm {

--- a/opm/material/fluidstates/FluidStateCompositionModules.hpp
+++ b/opm/material/fluidstates/FluidStateCompositionModules.hpp
@@ -28,11 +28,10 @@
 #ifndef OPM_FLUID_STATE_COMPOSITION_MODULES_HPP
 #define OPM_FLUID_STATE_COMPOSITION_MODULES_HPP
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -266,13 +265,13 @@ public:
      * \brief The mole fraction of a component in a phase []
      */
     Scalar moleFraction(unsigned /* phaseIdx */, unsigned /* compIdx */) const
-    { OPM_THROW(std::logic_error, "Mole fractions are not provided by this fluid state"); }
+    { throw std::logic_error("Mole fractions are not provided by this fluid state"); }
 
     /*!
      * \brief The mass fraction of a component in a phase []
      */
     Scalar massFraction(unsigned /* phaseIdx */, unsigned /* compIdx */) const
-    { OPM_THROW(std::logic_error, "Mass fractions are not provided by this fluid state"); }
+    { throw std::logic_error("Mass fractions are not provided by this fluid state"); }
 
     /*!
      * \brief The mean molar mass of a fluid phase [kg/mol]
@@ -283,7 +282,7 @@ public:
      * \f[ \bar M_\alpha = \sum_\kappa M^\kappa x_\alpha^\kappa \f]
      */
     Scalar averageMolarMass(unsigned /* phaseIdx */) const
-    { OPM_THROW(std::logic_error, "Mean molar masses are not provided by this fluid state"); }
+    { throw std::logic_error("Mean molar masses are not provided by this fluid state"); }
 
     /*!
      * \brief The concentration of a component in a phase [mol/m^3]
@@ -295,7 +294,7 @@ public:
      * http://en.wikipedia.org/wiki/Concentration
      */
     Scalar molarity(unsigned /* phaseIdx */, unsigned /* compIdx */) const
-    { OPM_THROW(std::logic_error, "Molarities are not provided by this fluid state"); }
+    { throw std::logic_error("Molarities are not provided by this fluid state"); }
 
     /*!
      * \brief Make sure that all attributes are defined.

--- a/opm/material/fluidstates/FluidStateDensityModules.hpp
+++ b/opm/material/fluidstates/FluidStateDensityModules.hpp
@@ -28,11 +28,10 @@
 #ifndef OPM_FLUID_STATE_DENSITY_MODULES_HPP
 #define OPM_FLUID_STATE_DENSITY_MODULES_HPP
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <algorithm>
 
@@ -124,19 +123,19 @@ public:
      * \brief The density of a fluid phase [kg/m^3]
      */
     const Scalar& density(unsigned /* phaseIdx */) const
-    { OPM_THROW(std::logic_error, "Density is not provided by this fluid state"); }
+    { throw std::logic_error("Density is not provided by this fluid state"); }
 
     /*!
      * \brief The molar density of a fluid phase [mol/m^3]
      */
     const Scalar& molarDensity(unsigned /* phaseIdx */) const
-    { OPM_THROW(std::logic_error, "Molar density is not provided by this fluid state"); }
+    { throw std::logic_error("Molar density is not provided by this fluid state"); }
 
     /*!
      * \brief The molar volume of a fluid phase [m^3/mol]
      */
     const Scalar& molarVolume(unsigned /* phaseIdx */) const
-    { OPM_THROW(std::logic_error, "Molar volume is not provided by this fluid state"); }
+    { throw std::logic_error("Molar volume is not provided by this fluid state"); }
 
     /*!
      * \brief Retrieve all parameters from an arbitrary fluid

--- a/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
+++ b/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
@@ -28,11 +28,10 @@
 #ifndef OPM_FLUID_STATE_ENTHALPY_MODULES_HPP
 #define OPM_FLUID_STATE_ENTHALPY_MODULES_HPP
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <algorithm>
 

--- a/opm/material/fluidstates/FluidStateFugacityModules.hpp
+++ b/opm/material/fluidstates/FluidStateFugacityModules.hpp
@@ -28,10 +28,8 @@
 #ifndef OPM_FLUID_STATE_FUGACITY_MODULES_HPP
 #define OPM_FLUID_STATE_FUGACITY_MODULES_HPP
 
-#include <opm/common/Valgrind.hpp>
-
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 #include <limits>
@@ -188,13 +186,13 @@ public:
      * \brief The fugacity coefficient of a component in a phase []
      */
     const Scalar& fugacityCoefficient(unsigned /* phaseIdx */, unsigned /* compIdx */) const
-    { OPM_THROW(std::logic_error, "Fugacity coefficients are not provided by this fluid state"); }
+    { throw std::logic_error("Fugacity coefficients are not provided by this fluid state"); }
 
     /*!
      * \brief The fugacity of a component in a phase [Pa]
      */
     const Scalar& fugacity(unsigned /* phaseIdx */, unsigned /* compIdx */) const
-    { OPM_THROW(std::logic_error, "Fugacities coefficients are not provided by this fluid state"); }
+    { throw std::logic_error("Fugacities coefficients are not provided by this fluid state"); }
 
     /*!
      * \brief Make sure that all attributes are defined.

--- a/opm/material/fluidstates/FluidStatePressureModules.hpp
+++ b/opm/material/fluidstates/FluidStatePressureModules.hpp
@@ -29,9 +29,8 @@
 #define OPM_FLUID_STATE_PRESSURE_MODULES_HPP
 
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/Valgrind.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 
@@ -107,7 +106,7 @@ public:
      * \brief The pressure of a fluid phase [Pa]
      */
     const Scalar& pressure(unsigned /* phaseIdx */) const
-    { OPM_THROW(std::logic_error, "Pressure is not provided by this fluid state"); }
+    { throw std::logic_error("Pressure is not provided by this fluid state"); }
 
 
     /*!

--- a/opm/material/fluidstates/FluidStateSaturationModules.hpp
+++ b/opm/material/fluidstates/FluidStateSaturationModules.hpp
@@ -28,11 +28,10 @@
 #ifndef OPM_FLUID_STATE_SATURATION_MODULES_HPP
 #define OPM_FLUID_STATE_SATURATION_MODULES_HPP
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <algorithm>
 
@@ -107,7 +106,7 @@ public:
      * \brief The saturation of a fluid phase [-]
      */
     const Scalar& saturation(unsigned /* phaseIdx */) const
-    { OPM_THROW(std::runtime_error, "Saturation is not provided by this fluid state"); }
+    { throw std::runtime_error("Saturation is not provided by this fluid state"); }
 
     /*!
      * \brief Retrieve all parameters from an arbitrary fluid

--- a/opm/material/fluidstates/FluidStateTemperatureModules.hpp
+++ b/opm/material/fluidstates/FluidStateTemperatureModules.hpp
@@ -28,11 +28,10 @@
 #ifndef OPM_FLUID_STATE_TEMPERATURE_MODULES_HPP
 #define OPM_FLUID_STATE_TEMPERATURE_MODULES_HPP
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -167,7 +166,7 @@ public:
      * \brief The temperature of a fluid phase [-]
      */
     const Scalar& temperature(unsigned /* phaseIdx */) const
-    { OPM_THROW(std::runtime_error, "Temperature is not provided by this fluid state"); }
+    { throw std::runtime_error("Temperature is not provided by this fluid state"); }
 
     /*!
      * \brief Retrieve all parameters from an arbitrary fluid

--- a/opm/material/fluidstates/FluidStateViscosityModules.hpp
+++ b/opm/material/fluidstates/FluidStateViscosityModules.hpp
@@ -28,11 +28,10 @@
 #ifndef OPM_FLUID_STATE_VISCOSITY_MODULES_HPP
 #define OPM_FLUID_STATE_VISCOSITY_MODULES_HPP
 
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <algorithm>
 
@@ -108,7 +107,7 @@ public:
      * \brief The viscosity of a fluid phase [-]
      */
     const Scalar& viscosity(unsigned /* phaseIdx */) const
-    { OPM_THROW(std::logic_error, "Viscosity is not provided by this fluid state"); }
+    { throw std::logic_error("Viscosity is not provided by this fluid state"); }
 
     /*!
      * \brief Retrieve all parameters from an arbitrary fluid

--- a/opm/material/fluidstates/ImmiscibleFluidState.hpp
+++ b/opm/material/fluidstates/ImmiscibleFluidState.hpp
@@ -32,7 +32,7 @@
 
 #include "ModularFluidState.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <algorithm>
 

--- a/opm/material/fluidstates/ModularFluidState.hpp
+++ b/opm/material/fluidstates/ModularFluidState.hpp
@@ -36,7 +36,7 @@
 #include "FluidStateViscosityModules.hpp"
 #include "FluidStateEnthalpyModules.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <algorithm>
 
 namespace Opm {

--- a/opm/material/fluidstates/NonEquilibriumFluidState.hpp
+++ b/opm/material/fluidstates/NonEquilibriumFluidState.hpp
@@ -32,7 +32,7 @@
 
 #include "ModularFluidState.hpp"
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <algorithm>
 
 namespace Opm {

--- a/opm/material/fluidstates/PressureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/PressureOverlayFluidState.hpp
@@ -27,7 +27,7 @@
 #ifndef OPM_PRESSURE_OVERLAY_FLUID_STATE_HPP
 #define OPM_PRESSURE_OVERLAY_FLUID_STATE_HPP
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <array>
 #include <utility>

--- a/opm/material/fluidstates/SaturationOverlayFluidState.hpp
+++ b/opm/material/fluidstates/SaturationOverlayFluidState.hpp
@@ -27,7 +27,7 @@
 #ifndef OPM_SATURATION_OVERLAY_FLUID_STATE_HPP
 #define OPM_SATURATION_OVERLAY_FLUID_STATE_HPP
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <array>
 #include <utility>

--- a/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
+++ b/opm/material/fluidstates/TemperatureOverlayFluidState.hpp
@@ -27,7 +27,7 @@
 #ifndef OPM_TEMPERATURE_OVERLAY_FLUID_STATE_HPP
 #define OPM_TEMPERATURE_OVERLAY_FLUID_STATE_HPP
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <utility>
 

--- a/opm/material/fluidsystems/BaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/BaseFluidSystem.hpp
@@ -29,8 +29,7 @@
 
 #include "NullParameterCache.hpp"
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 #include <dune/common/classname.hh>
 
 namespace Opm {
@@ -73,8 +72,7 @@ public:
      */
     static char* phaseName(unsigned /*phaseIdx*/)
     {
-        OPM_THROW(std::runtime_error,
-                  "Not implemented: The fluid system '" << Dune::className<Implementation>() << "' does not provide a phaseName() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"' does not provide a phaseName() method!");
     }
 
     /*!
@@ -84,8 +82,7 @@ public:
      */
     static bool isLiquid(unsigned /*phaseIdx*/)
     {
-        OPM_THROW(std::runtime_error,
-                  "Not implemented: The fluid system '" << Dune::className<Implementation>() << "' does not provide a isLiquid() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"' does not provide a isLiquid() method!");
     }
 
     /*!
@@ -104,8 +101,7 @@ public:
      */
     static bool isIdealMixture(unsigned /*phaseIdx*/)
     {
-        OPM_THROW(std::runtime_error,
-                  "Not implemented: The fluid system '" << Dune::className<Implementation>() << "' does not provide a isIdealMixture() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"' does not provide a isIdealMixture() method!");
     }
 
     /*!
@@ -119,8 +115,7 @@ public:
      */
     static bool isCompressible(unsigned /*phaseIdx*/)
     {
-        OPM_THROW(std::runtime_error,
-                  "Not implemented: The fluid system '" << Dune::className<Implementation>() << "' does not provide a isCompressible() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"' does not provide a isCompressible() method!");
     }
 
     /*!
@@ -131,8 +126,7 @@ public:
      */
     static bool isIdealGas(unsigned /*phaseIdx*/)
     {
-        OPM_THROW(std::runtime_error,
-                  "Not implemented: The fluid system '" << Dune::className<Implementation>() << "' does not provide a isIdealGas() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"' does not provide a isIdealGas() method!");
     }
 
     /*!
@@ -142,8 +136,7 @@ public:
      */
     static const char* componentName(unsigned /*compIdx*/)
     {
-        OPM_THROW(std::runtime_error,
-                  "Not implemented: The fluid system '" << Dune::className<Implementation>() << "' does not provide a componentName() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"' does not provide a componentName() method!");
     }
 
     /*!
@@ -153,8 +146,7 @@ public:
      */
     static Scalar molarMass(unsigned /*compIdx*/)
     {
-        OPM_THROW(std::runtime_error,
-                  "Not implemented: The fluid system '" << Dune::className<Implementation>() << "' does not provide a molarMass() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"' does not provide a molarMass() method!");
     }
 
     /*!
@@ -174,8 +166,7 @@ public:
                            const ParamCache& /*paramCache*/,
                            unsigned /*phaseIdx*/)
     {
-        OPM_THROW(std::runtime_error,
-                  "Not implemented: The fluid system '" << Dune::className<Implementation>() << "' does not provide a density() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"' does not provide a density() method!");
     }
 
     /*!
@@ -198,7 +189,7 @@ public:
                                        unsigned /*phaseIdx*/,
                                        unsigned /*compIdx*/)
     {
-        OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Dune::className<Implementation>() << "'  does not provide a fugacityCoefficient() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"'  does not provide a fugacityCoefficient() method!");
     }
 
     /*!
@@ -212,7 +203,7 @@ public:
                              ParamCache& /*paramCache*/,
                              unsigned /*phaseIdx*/)
     {
-        OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Dune::className<Implementation>() << "'  does not provide a viscosity() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"'  does not provide a viscosity() method!");
     }
 
     /*!
@@ -238,7 +229,7 @@ public:
                                         unsigned /*phaseIdx*/,
                                         unsigned /*compIdx*/)
     {
-        OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Dune::className<Implementation>() << "'  does not provide a diffusionCoefficient() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"'  does not provide a diffusionCoefficient() method!");
     }
 
     /*!
@@ -253,7 +244,7 @@ public:
                             ParamCache& /*paramCache*/,
                             unsigned /*phaseIdx*/)
     {
-        OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Dune::className<Implementation>() << "'  does not provide an enthalpy() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"'  does not provide an enthalpy() method!");
     }
 
     /*!
@@ -267,7 +258,7 @@ public:
                                        ParamCache& /*paramCache*/,
                                        unsigned /*phaseIdx*/)
     {
-        OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Dune::className<Implementation>() << "'  does not provide a thermalConductivity() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"'  does not provide a thermalConductivity() method!");
     }
 
     /*!
@@ -281,7 +272,7 @@ public:
                                 ParamCache& /*paramCache*/,
                                 unsigned /*phaseIdx*/)
     {
-        OPM_THROW(std::runtime_error, "Not implemented: The fluid system '" << Dune::className<Implementation>() << "'  does not provide a heatCapacity() method!");
+        throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"'  does not provide a heatCapacity() method!");
     }
 };
 

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -35,10 +35,9 @@
 #include <opm/material/Constants.hpp>
 
 #include <opm/material/common/MathToolbox.hpp>
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/HasMemberGeneratorMacros.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <memory>
 #include <vector>
@@ -591,7 +590,7 @@ public:
                 * waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p);
         }
 
-        OPM_THROW(std::logic_error, "Unhandled phase index " << phaseIdx);
+        throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
     }
 
     /*!
@@ -655,7 +654,7 @@ public:
                 *inverseFormationVolumeFactor<FluidState, LhsEval>(fluidState, waterPhaseIdx, regionIdx);
         }
 
-        OPM_THROW(std::logic_error, "Unhandled phase index " << phaseIdx);
+        throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
     }
 
     /*!
@@ -730,7 +729,7 @@ public:
         }
         case waterPhaseIdx:
             return waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p);
-        default: OPM_THROW(std::logic_error, "Unhandled phase index " << phaseIdx);
+        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
     }
 
@@ -756,7 +755,7 @@ public:
         case oilPhaseIdx: return oilPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
         case gasPhaseIdx: return gasPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
         case waterPhaseIdx: return waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p);
-        default: OPM_THROW(std::logic_error, "Unhandled phase index " << phaseIdx);
+        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
     }
 
@@ -822,8 +821,7 @@ public:
                 return phi_gG*1e6;
 
             default:
-                OPM_THROW(std::logic_error,
-                          "Invalid component index " << compIdx);
+                throw std::logic_error("Invalid component index "+std::to_string(compIdx));
             }
 
         case oilPhaseIdx: // fugacity coefficients for all components in the oil phase
@@ -858,8 +856,7 @@ public:
                 return phi_oO*1e6;
 
             default:
-                OPM_THROW(std::logic_error,
-                          "Invalid component index " << compIdx);
+                throw std::logic_error("Invalid component index "+std::to_string(compIdx));
             }
 
         case waterPhaseIdx: // fugacity coefficients for all components in the water phase
@@ -874,16 +871,14 @@ public:
             case oilCompIdx: return 1.1e6*phi_wW;
             case gasCompIdx: return 1e6*phi_wW;
             default:
-                OPM_THROW(std::logic_error,
-                          "Invalid component index " << compIdx);
+                throw std::logic_error("Invalid component index "+std::to_string(compIdx));
             }
 
         default:
-            OPM_THROW(std::logic_error,
-                      "Invalid phase index " << phaseIdx);
+            throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
         }
 
-        OPM_THROW(std::logic_error, "Unhandled phase or component index");
+        throw std::logic_error("Unhandled phase or component index");
     }
 
     //! \copydoc BaseFluidSystem::viscosity
@@ -957,7 +952,7 @@ public:
             return waterPvt_->viscosity(regionIdx, T, p);
         }
 
-        OPM_THROW(std::logic_error, "Unhandled phase index " << phaseIdx);
+        throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
     }
 
     //! \copydoc BaseFluidSystem::enthalpy
@@ -988,10 +983,10 @@ public:
                 waterPvt_->internalEnergy(regionIdx, T, p)
                 + p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
 
-        default: OPM_THROW(std::logic_error, "Unhandled phase index " << phaseIdx);
+        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
 
-        OPM_THROW(std::logic_error, "Unhandled phase index " << phaseIdx);
+        throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
     }
 
     /*!
@@ -1017,7 +1012,7 @@ public:
         case oilPhaseIdx: return oilPvt_->saturatedGasDissolutionFactor(regionIdx, T, p, So, maxOilSaturation);
         case gasPhaseIdx: return gasPvt_->saturatedOilVaporizationFactor(regionIdx, T, p, So, maxOilSaturation);
         case waterPhaseIdx: return 0.0;
-        default: OPM_THROW(std::logic_error, "Unhandled phase index " << phaseIdx);
+        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
     }
 
@@ -1044,7 +1039,7 @@ public:
         case oilPhaseIdx: return oilPvt_->saturatedGasDissolutionFactor(regionIdx, T, p);
         case gasPhaseIdx: return gasPvt_->saturatedOilVaporizationFactor(regionIdx, T, p);
         case waterPhaseIdx: return 0.0;
-        default: OPM_THROW(std::logic_error, "Unhandled phase index " << phaseIdx);
+        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
     }
 
@@ -1093,7 +1088,7 @@ public:
         case oilPhaseIdx: return oilPvt_->saturationPressure(regionIdx, T, Opm::BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
         case gasPhaseIdx: return gasPvt_->saturationPressure(regionIdx, T, Opm::BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
         case waterPhaseIdx: return 0.0;
-        default: OPM_THROW(std::logic_error, "Unhandled phase index " << phaseIdx);
+        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
     }
 

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -43,7 +43,7 @@
 #include <opm/material/binarycoefficients/Brine_CO2.hpp>
 #include <opm/material/binarycoefficients/H2O_N2.hpp>
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <iostream>
 
@@ -487,14 +487,16 @@ private:
         Valgrind::CheckDefined(xlCO2);
 
         if(T < 273.15) {
-            OPM_THROW(NumericalProblem,
-                      "Liquid density for Brine and CO2 is only "
-                      "defined above 273.15K (is " << T << "K)");
+            std::ostringstream oss;
+            oss << "Liquid density for Brine and CO2 is only "
+                "defined above 273.15K (is "<<T<<"K)";
+            throw NumericalIssue(oss.str());
         }
         if(pl >= 2.5e8) {
-            OPM_THROW(NumericalProblem,
-                      "Liquid density for Brine and CO2 is only "
-                      "defined below 250MPa (is " << pl << "Pa)");
+            std::ostringstream oss;
+            oss << "Liquid density for Brine and CO2 is only "
+                "defined below 250MPa (is "<<pl<<"Pa)";
+            throw NumericalIssue(oss.str());
         }
 
         const LhsEval& rho_brine = Brine::liquidDensity(T, pl);

--- a/opm/material/fluidsystems/H2OAirFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirFluidSystem.hpp
@@ -35,10 +35,9 @@
 #include <opm/material/components/Air.hpp>
 #include <opm/material/components/H2O.hpp>
 #include <opm/material/components/TabulatedComponent.hpp>
-#include <opm/common/Valgrind.hpp>
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <iostream>
 #include <cassert>
@@ -90,7 +89,7 @@ public:
         case liquidPhaseIdx: return "liquid";
         case gasPhaseIdx: return "gas";
         };
-        OPM_THROW(std::logic_error, "Invalid phase index " << phaseIdx);
+        throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
     }
 
     //! \copydoc BaseFluidSystem::isLiquid
@@ -151,7 +150,7 @@ public:
         case H2OIdx: return H2O::name();
         case AirIdx: return Air::name();
         };
-        OPM_THROW(std::logic_error, "Invalid component index " << compIdx);
+        throw std::logic_error("Invalid component index "+std::to_string(compIdx));
     }
 
     //! \copydoc BaseFluidSystem::molarMass
@@ -299,7 +298,7 @@ public:
 
             return H2O::gasDensity(T, partialPressureH2O) + Air::gasDensity(T, partialPressureAir);
         }
-        OPM_THROW(std::logic_error, "Invalid phase index " << phaseIdx);
+        throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
     }
 
     //! \copydoc BaseFluidSystem::viscosity
@@ -351,7 +350,7 @@ public:
             }
             return muResult;
         }
-        OPM_THROW(std::logic_error, "Invalid phase index " << phaseIdx);
+        throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
     }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
@@ -424,7 +423,7 @@ public:
                 Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, AirIdx));
             return result;
         }
-        OPM_THROW(std::logic_error, "Invalid phase index " << phaseIdx);
+        throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
     }
 
     //! \copydoc BaseFluidSystem::thermalConductivity

--- a/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
@@ -169,7 +169,7 @@ public:
         case naplPhaseIdx: return "napl";
         case gasPhaseIdx: return "gas";
         };
-        OPM_THROW(std::logic_error, "Invalid phase index " << phaseIdx);
+        throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
     }
 
     //! \copydoc BaseFluidSystem::componentName
@@ -180,7 +180,7 @@ public:
         case airIdx: return Air::name();
         case NAPLIdx: return NAPL::name();
         };
-        OPM_THROW(std::logic_error, "Invalid component index " << compIdx);
+        throw std::logic_error("Invalid component index "+std::to_string(compIdx));
     }
 
     //! \copydoc BaseFluidSystem::molarMass
@@ -194,7 +194,7 @@ public:
             : (compIdx == NAPLIdx)
             ? NAPL::molarMass()
             : -1e10;
-        //OPM_THROW(std::logic_error, "Invalid component index " << compIdx);
+        //throw std::logic_error("Invalid component index "+std::to_string(compIdx));
     }
 
     //! \copydoc BaseFluidSystem::density
@@ -330,9 +330,8 @@ public:
 
             if (compIdx==NAPLIdx) return (1 - xgw)/(xga/diffAW + xgc/diffWC);
             else if (compIdx==H2OIdx) return (1 - xgc)/(xgw/diffWC + xga/diffAC);
-            else if (compIdx==airIdx) OPM_THROW(std::logic_error,
-                                                "Diffusivity of air in the gas phase "
-                                                "is constraint by sum of diffusive fluxes = 0 !\n");
+            else if (compIdx==airIdx) throw std::logic_error("Diffusivity of air in the gas phase "
+                                                             "is constraint by sum of diffusive fluxes = 0 !\n");
         }
         else if (phaseIdx==waterPhaseIdx){
             const LhsEval& diffACl = 1.e-9; // BinaryCoeff::Air_Mesitylene::liquidDiffCoeff(temperature, pressure);
@@ -351,15 +350,13 @@ public:
                 diffCont = (1.- xwc)/(xww/diffWCl + xwa/diffACl);
                 return diffCont;
             case H2OIdx:
-                OPM_THROW(std::logic_error,
-                          "Diffusivity of water in the water phase "
-                          "is constraint by sum of diffusive fluxes = 0 !\n");
+                throw std::logic_error("Diffusivity of water in the water phase "
+                                       "is constraint by sum of diffusive fluxes = 0 !\n");
             };
         }
         else if (phaseIdx==naplPhaseIdx) {
-            OPM_THROW(std::logic_error,
-                      "Diffusion coefficients of "
-                      "substances in liquid phase are undefined!\n");
+            throw std::logic_error("Diffusion coefficients of "
+                                   "substances in liquid phase are undefined!\n");
         }
         return 0;
 #endif
@@ -436,7 +433,7 @@ public:
 
             return result;
         }
-        OPM_THROW(std::logic_error, "Invalid phase index " << phaseIdx);
+        throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
     }
 
     //! \copydoc BaseFluidSystem::thermalConductivity

--- a/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
@@ -134,7 +134,7 @@ public:
         case naplPhaseIdx: return "napl";
         case gasPhaseIdx: return "gas";
         };
-        OPM_THROW(std::logic_error, "Invalid phase index " << phaseIdx);
+        throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
     }
 
     //! \copydoc BaseFluidSystem::componentName
@@ -145,7 +145,7 @@ public:
         case airIdx: return Air::name();
         case NAPLIdx: return NAPL::name();
         };
-        OPM_THROW(std::logic_error, "Invalid component index " << compIdx);
+        throw std::logic_error("Invalid component index "+std::to_string(compIdx));
     }
 
     //! \copydoc BaseFluidSystem::molarMass
@@ -288,9 +288,8 @@ public:
 
             if (compIdx==NAPLIdx) return (1.- xgw)/(xga/diffAW + xgc/diffWC);
             else if (compIdx==H2OIdx) return (1.- xgc)/(xgw/diffWC + xga/diffAC);
-            else if (compIdx==airIdx) OPM_THROW(std::logic_error,
-                                                "Diffusivity of air in the gas phase "
-                                                "is constraint by sum of diffusive fluxes = 0 !\n");
+            else if (compIdx==airIdx) throw std::logic_error("Diffusivity of air in the gas phase "
+                                                             "is constraint by sum of diffusive fluxes = 0 !\n");
         } else if (phaseIdx==waterPhaseIdx){
             Scalar diffACl = 1.e-9; // BinaryCoeff::Air_Xylene::liquidDiffCoeff(temperature, pressure);
             Scalar diffWCl = 1.e-9; // BinaryCoeff::H2O_Xylene::liquidDiffCoeff(temperature, pressure);
@@ -306,15 +305,13 @@ public:
             case airIdx:
                 return (1.- xwc)/(xww/diffWCl + xwa/diffACl);
             case H2OIdx:
-                OPM_THROW(std::logic_error,
-                          "Diffusivity of water in the water phase "
-                          "is constraint by sum of diffusive fluxes = 0 !\n");
+                throw std::logic_error("Diffusivity of water in the water phase "
+                                       "is constraint by sum of diffusive fluxes = 0 !\n");
             };
         } else if (phaseIdx==naplPhaseIdx) {
 
-            OPM_THROW(std::logic_error,
-                      "Diffusion coefficients of "
-                      "substances in liquid phase are undefined!\n");
+            throw std::logic_error("Diffusion coefficients of "
+                                   "substances in liquid phase are undefined!\n");
         }
         return 0;
     }
@@ -389,7 +386,7 @@ public:
 
             return result;
         }
-        OPM_THROW(std::logic_error, "Invalid phase index " << phaseIdx);
+        throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
     }
 
 private:

--- a/opm/material/fluidsystems/H2ON2FluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2FluidSystem.hpp
@@ -36,10 +36,9 @@
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/components/TabulatedComponent.hpp>
 #include <opm/material/binarycoefficients/H2O_N2.hpp>
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <iostream>
 #include <cassert>

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -36,10 +36,9 @@
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/components/TabulatedComponent.hpp>
 #include <opm/material/binarycoefficients/H2O_N2.hpp>
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <iostream>
 #include <cassert>

--- a/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
@@ -37,7 +37,7 @@
 #include <opm/material/components/N2.hpp>
 #include <opm/material/components/TabulatedComponent.hpp>
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <limits>
 #include <cassert>

--- a/opm/material/fluidsystems/Spe5FluidSystem.hpp
+++ b/opm/material/fluidsystems/Spe5FluidSystem.hpp
@@ -432,7 +432,7 @@ protected:
         case C10Idx: return 1e10;
         case C15Idx: return 1e10;
         case C20Idx: return 1e10;
-        default: OPM_THROW(std::logic_error, "Unknown component index " << compIdx);
+        default: throw std::logic_error("Unknown component index "+std::to_string(compIdx));
         }
     }
 };

--- a/opm/material/fluidsystems/Spe5ParameterCache.hpp
+++ b/opm/material/fluidsystems/Spe5ParameterCache.hpp
@@ -114,9 +114,8 @@ public:
         case oilPhaseIdx: return oilPhaseParams_.a();
         case gasPhaseIdx: return gasPhaseParams_.a();
         default:
-            OPM_THROW(std::logic_error,
-                       "The a() parameter is only defined for "
-                       "oil and gas phases");
+            throw std::logic_error("The a() parameter is only defined for "
+                                   "oil and gas phases");
         };
     }
 
@@ -132,9 +131,8 @@ public:
         case oilPhaseIdx: return oilPhaseParams_.b();
         case gasPhaseIdx: return gasPhaseParams_.b();
         default:
-            OPM_THROW(std::logic_error,
-                       "The b() parameter is only defined for "
-                       "oil and gas phases");
+            throw std::logic_error("The b() parameter is only defined for "
+                                   "oil and gas phases");
         };
     }
 
@@ -153,9 +151,8 @@ public:
         case oilPhaseIdx: return oilPhaseParams_.pureParams(compIdx).a();
         case gasPhaseIdx: return gasPhaseParams_.pureParams(compIdx).a();
         default:
-            OPM_THROW(std::logic_error,
-                       "The a() parameter is only defined for "
-                       "oil and gas phases");
+            throw std::logic_error("The a() parameter is only defined for "
+                                   "oil and gas phases");
         };
     }
 
@@ -173,9 +170,8 @@ public:
         case oilPhaseIdx: return oilPhaseParams_.pureParams(compIdx).b();
         case gasPhaseIdx: return gasPhaseParams_.pureParams(compIdx).b();
         default:
-            OPM_THROW(std::logic_error,
-                       "The b() parameter is only defined for "
-                       "oil and gas phases");
+            throw std::logic_error("The b() parameter is only defined for "
+                                   "oil and gas phases");
         };
     }
 

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -172,8 +172,7 @@ public:
                         const Evaluation& pressure OPM_UNUSED,
                         const Evaluation& Rs OPM_UNUSED) const
     {
-        OPM_THROW(std::runtime_error,
-                  "Requested the enthalpy of oil but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of oil but the thermal option is not enabled");
     }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -167,8 +167,7 @@ public:
                         const Evaluation& temperature OPM_UNUSED,
                         const Evaluation& pressure OPM_UNUSED) const
     {
-        OPM_THROW(std::runtime_error,
-                  "Requested the enthalpy of water but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of water but the thermal option is not enabled");
     }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -174,8 +174,7 @@ public:
                         const Evaluation& pressure OPM_UNUSED,
                         const Evaluation& Rs OPM_UNUSED) const
     {
-        OPM_THROW(std::runtime_error,
-                  "Requested the enthalpy of oil but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of oil but the thermal option is not enabled");
     }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -200,8 +200,7 @@ public:
                         const Evaluation& pressure OPM_UNUSED,
                         const Evaluation& Rv OPM_UNUSED) const
     {
-        OPM_THROW(std::runtime_error,
-                  "Requested the enthalpy of gas but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of gas but the thermal option is not enabled");
     }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -57,7 +57,7 @@ namespace Opm {
         break;                                                          \
     }                                                                   \
     case NoGasPvt:                                                      \
-        OPM_THROW(std::logic_error, "Not implemented: Gas PVT of this deck!"); \
+        throw std::logic_error("Not implemented: Gas PVT of this deck!"); \
     }
 
 
@@ -148,7 +148,7 @@ public:
             break;
 
         case NoGasPvt:
-            OPM_THROW(std::logic_error, "Not implemented: Gas PVT of this deck!");
+            throw std::logic_error("Not implemented: Gas PVT of this deck!");
         }
 
         gasPvtApproach_ = gasPvtAppr;

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -205,8 +205,7 @@ public:
                               const Evaluation& Rv OPM_UNUSED) const
     {
         if (!enableInternalEnergy_)
-            OPM_THROW(std::runtime_error,
-                      "Requested the internal energy of oil but it is disabled");
+            throw std::runtime_error("Requested the internal energy of oil but it is disabled");
 
         // compute the specific internal energy for the specified tempature. We use linear
         // interpolation here despite the fact that the underlying heat capacities are

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -40,6 +40,10 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #endif
 
+#if HAVE_OPM_COMMON
+#include <opm/common/OpmLog/OpmLog.hpp>
+#endif
+
 namespace Opm {
 /*!
  * \brief This class represents the Pressure-Volume-Temperature relations of the oil phas
@@ -155,9 +159,8 @@ public:
                 }
 
                 if (masterTableIdx >= saturatedTable.numRows())
-                    OPM_THROW(std::runtime_error,
-                              "PVTO tables are invalid: The last table must exhibit at least one "
-                              "entry for undersaturated oil!");
+                    throw std::runtime_error("PVTO tables are invalid: The last table must exhibit at least one "
+                                             "entry for undersaturated oil!");
 
                 // extend the current table using the master table.
                 extendPvtoTable_(regionIdx,
@@ -417,8 +420,7 @@ public:
                         const Evaluation& pressure OPM_UNUSED,
                         const Evaluation& Rs OPM_UNUSED) const
     {
-        OPM_THROW(std::runtime_error,
-                  "Requested the enthalpy of oil but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of oil but the thermal option is not enabled");
     }
 
     /*!
@@ -570,8 +572,10 @@ public:
         errlog << "Finding saturation pressure did not converge:"
                << " pSat = " << pSat
                << ", Rs = " << Rs;
+#if HAVE_OPM_COMMON
         OpmLog::debug("Live oil saturation pressure", errlog.str());
-        OPM_THROW_NOLOG(NumericalProblem, errlog.str());
+#endif
+        throw NumericalIssue(errlog.str());
     }
 
 private:

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -56,7 +56,7 @@ namespace Opm {
         break;                                                          \
     }                                                                   \
     case NoOilPvt:                                                      \
-        OPM_THROW(std::logic_error, "Not implemented: Oil PVT of this deck!"); \
+        throw std::logic_error("Not implemented: Oil PVT of this deck!"); \
     }
 
 /*!
@@ -251,7 +251,7 @@ public:
             break;
 
         case NoOilPvt:
-            OPM_THROW(std::logic_error, "Not implemented: Oil PVT of this deck!");
+            throw std::logic_error("Not implemented: Oil PVT of this deck!");
         }
 
         approach_ = appr;

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -216,8 +216,7 @@ public:
                               const Evaluation& Rs OPM_UNUSED) const
     {
         if (!enableInternalEnergy_)
-            OPM_THROW(std::runtime_error,
-                      "Requested the internal energy of oil but it is disabled");
+            throw std::runtime_error("Requested the internal energy of oil but it is disabled");
 
         // compute the specific internal energy for the specified tempature. We use linear
         // interpolation here despite the fact that the underlying heat capacities are

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -43,7 +43,7 @@
         break;                                                          \
     }                                                                   \
     case NoWaterPvt:                                                    \
-        OPM_THROW(std::logic_error, "Not implemented: Water PVT of this deck!"); \
+        throw std::logic_error("Not implemented: Water PVT of this deck!"); \
     }
 
 namespace Opm {
@@ -153,7 +153,7 @@ public:
             break;
 
         case NoWaterPvt:
-            OPM_THROW(std::logic_error, "Not implemented: Water PVT of this deck!");
+            throw std::logic_error("Not implemented: Water PVT of this deck!");
         }
 
         approach_ = appr;

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -207,8 +207,7 @@ public:
                               const Evaluation& pressure OPM_UNUSED) const
     {
         if (!enableInternalEnergy_)
-            OPM_THROW(std::runtime_error,
-                      "Requested the internal energy of oil but it is disabled");
+            throw std::runtime_error("Requested the internal energy of oil but it is disabled");
 
         // compute the specific internal energy for the specified tempature. We use linear
         // interpolation here despite the fact that the underlying heat capacities are

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -154,8 +154,7 @@ public:
                 }
 
                 if (masterTableIdx >= saturatedTable.numRows())
-                    OPM_THROW(std::runtime_error,
-                              "PVTG tables are invalid: The last table must exhibit at least one "
+                    throw std::runtime_error("PVTG tables are invalid: The last table must exhibit at least one "
                               "entry for undersaturated gas!");
 
 
@@ -447,8 +446,7 @@ public:
                         const Evaluation& pressure OPM_UNUSED,
                         const Evaluation& Rv OPM_UNUSED) const
     {
-        OPM_THROW(std::runtime_error,
-                  "Requested the enthalpy of gas but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of gas but the thermal option is not enabled");
     }
 
     /*!
@@ -598,8 +596,10 @@ public:
         errlog << "Finding saturation pressure did not converge:"
                << " pSat = " << pSat
                << ", Rv = " << Rv;
+#if HAVE_OPM_COMMON
         OpmLog::debug("Wet gas saturation pressure", errlog.str());
-        OPM_THROW_NOLOG(NumericalProblem, errlog.str());
+#endif
+        throw NumericalIssue(errlog.str());
     }
 
 private:

--- a/opm/material/thermal/EclSolidEnergyLawMultiplexer.hpp
+++ b/opm/material/thermal/EclSolidEnergyLawMultiplexer.hpp
@@ -77,7 +77,7 @@ public:
             return NullLaw::solidInternalEnergy(0, fluidState);
 
         default:
-            OPM_THROW(std::logic_error, "Invalid solid energy approach: " << params.solidEnergyApproach());
+            throw std::logic_error("Invalid solid energy approach: "+std::to_string(int(params.solidEnergyApproach())));
         }
     }
 };

--- a/opm/material/thermal/EclSolidEnergyLawMultiplexerParams.hpp
+++ b/opm/material/thermal/EclSolidEnergyLawMultiplexerParams.hpp
@@ -73,8 +73,7 @@ public:
         solidEnergyApproach_ = newApproach;
         switch (solidEnergyApproach()) {
         case undefinedApproach:
-            OPM_THROW(std::logic_error,
-                      "Cannot set the approach for solid energy storage to 'undefined'!");
+            throw std::logic_error("Cannot set the approach for solid energy storage to 'undefined'!");
 
         case heatcrApproach:
             realParams_ = new HeatcrLawParams;

--- a/opm/material/thermal/EclThermalConductionLawMultiplexer.hpp
+++ b/opm/material/thermal/EclThermalConductionLawMultiplexer.hpp
@@ -78,7 +78,7 @@ public:
             return NullLaw::thermalConductivity(0, fluidState);
 
         default:
-            OPM_THROW(std::logic_error, "Invalid thermal conductivity approach: " << params.thermalConductionApproach());
+            throw std::logic_error("Invalid thermal conductivity approach: "+std::to_string(int(params.thermalConductionApproach())));
         }
     }
 };

--- a/opm/material/thermal/EclThermalConductionLawMultiplexerParams.hpp
+++ b/opm/material/thermal/EclThermalConductionLawMultiplexerParams.hpp
@@ -73,8 +73,7 @@ public:
         thermalConductionApproach_ = newApproach;
         switch (thermalConductionApproach()) {
         case undefinedApproach:
-            OPM_THROW(std::logic_error,
-                      "Cannot set the approach for thermal conduction to 'undefined'!");
+            throw std::logic_error("Cannot set the approach for thermal conduction to 'undefined'!");
 
         case thconrApproach:
             realParams_ = new ThconrLawParams;

--- a/opm/material/thermal/EclThermalLawManager.hpp
+++ b/opm/material/thermal/EclThermalLawManager.hpp
@@ -37,8 +37,7 @@
 #include "EclThermalConductionLawMultiplexer.hpp"
 #include "EclThermalConductionLawMultiplexerParams.hpp"
 
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
@@ -112,9 +111,8 @@ public:
             return solidEnergyLawParams_[0];
 
         default:
-            OPM_THROW(std::runtime_error,
-                      "Attempting to retrieve solid energy storage parameters without "
-                      "a known approach being defined by the deck.");
+            throw std::runtime_error("Attempting to retrieve solid energy storage parameters "
+                                     "without a known approach being defined by the deck.");
         }
     }
 
@@ -130,9 +128,8 @@ public:
             return thermalConductionLawParams_[0];
 
         default:
-            OPM_THROW(std::runtime_error,
-                      "Attempting to retrieve thermal conduction parameters without "
-                      "a known approach being defined by the deck.");
+            throw std::runtime_error("Attempting to retrieve thermal conduction parameters without "
+                                     "a known approach being defined by the deck.");
         }
     }
 

--- a/opm/material/thermal/NullThermalConductionLaw.hpp
+++ b/opm/material/thermal/NullThermalConductionLaw.hpp
@@ -27,9 +27,8 @@
 #ifndef OPM_NULL_THERMAL_CONDUCTION_LAW_HPP
 #define OPM_NULL_THERMAL_CONDUCTION_LAW_HPP
 
-#include <opm/common/Unused.hpp>
-#include <opm/common/Exceptions.hpp>
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/material/common/Unused.hpp>
+#include <opm/material/common/Exceptions.hpp>
 
 namespace Opm {
 

--- a/opm/material/thermal/SomertonThermalConductionLaw.hpp
+++ b/opm/material/thermal/SomertonThermalConductionLaw.hpp
@@ -31,7 +31,7 @@
 
 #include <opm/material/common/Spline.hpp>
 
-#include <opm/common/Valgrind.hpp>
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
 #include <algorithm>

--- a/tests/checkComponent.hpp
+++ b/tests/checkComponent.hpp
@@ -27,7 +27,7 @@
 #ifndef OPM_CHECK_COMPONENT_HPP
 #define OPM_CHECK_COMPONENT_HPP
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 #include <dune/common/classname.hh>
 
 #include <iostream>

--- a/tests/test_2dtables.cpp
+++ b/tests/test_2dtables.cpp
@@ -32,9 +32,7 @@
 #include <opm/material/common/UniformXTabulated2DFunction.hpp>
 #include <opm/material/common/UniformTabulated2DFunction.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <memory>
 #include <cmath>

--- a/tests/test_ConditionalStorage.cpp
+++ b/tests/test_ConditionalStorage.cpp
@@ -1,0 +1,135 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief This is a simple test that illustrates how to use the Opm::ConditionalStorage
+ *        class.
+*/
+#include "config.h"
+
+#include <opm/material/common/Unused.hpp>
+#include <opm/material/common/ConditionalStorage.hpp>
+
+#include <string>
+#include <cstdlib>
+#include <type_traits>
+
+template <bool foo>
+class EnsureCompileTimeConstant
+{};
+
+class IAmAnIslandLeaveMeAlone
+{
+public:
+    IAmAnIslandLeaveMeAlone(int, int)
+    {}
+
+    IAmAnIslandLeaveMeAlone& operator=(const IAmAnIslandLeaveMeAlone&) = delete;
+};
+
+int main()
+{
+    {
+        typedef Opm::ConditionalStorage<true, std::string> ConditionalTrueString;
+        ConditionalTrueString foo; // default constructor
+        ConditionalTrueString bar("hello"); // construct using arguments
+        ConditionalTrueString baz(bar); // copy constructor
+
+        EnsureCompileTimeConstant<ConditionalTrueString::condition> hello OPM_UNUSED;
+        if (!std::is_same<typename ConditionalTrueString::type, std::string>::value)
+            // something went wrong with the exported type
+            std::abort();
+
+        if (ConditionalTrueString::condition != true)
+            // the condition is not exported correctly
+            std::abort();
+
+        if (*bar != "hello")
+            // value constructor did not work
+            std::abort();
+
+        if (*bar != *baz)
+            // copy constructor did not work
+            std::abort();
+
+        if (foo->size() != 0)
+            // default constructor did not work
+            std::abort();
+
+        // the assignment operator for the "wrapper" object should work
+        foo = baz;
+        if (*foo != *baz)
+            // assignment operator did not work
+            std::abort();
+    }
+
+    {
+        typedef Opm::ConditionalStorage<false, std::string> ConditionalFalseString;
+        ConditionalFalseString foo; // default constructor
+        ConditionalFalseString bar("hello"); // construct by value
+        ConditionalFalseString OPM_UNUSED baz(bar); // copy constructor
+
+        EnsureCompileTimeConstant<ConditionalFalseString::condition> hello OPM_UNUSED;
+        if (!std::is_same<typename ConditionalFalseString::type, std::string>::value)
+            // something went wrong with the exported type
+            std::abort();
+
+        if (ConditionalFalseString::condition != false)
+            // the condition is not exported correctly
+            std::abort();
+
+        // the assignment operator for the "wrapper" object should always work
+        baz = foo;
+
+        try {
+            *bar;
+
+            // this is supposed to throw an std::logic_error
+            std::abort();
+        }
+        catch (std::logic_error &) {}
+
+        try {
+            foo->size();
+
+            // this is supposed to throw an std::logic_error
+            std::abort();
+        }
+        catch (std::logic_error &) {}
+    }
+
+    {
+        typedef Opm::ConditionalStorage<true, IAmAnIslandLeaveMeAlone> ConditionalTrueIsland;
+        ConditionalTrueIsland OPM_UNUSED foo(1, 2);
+        // ConditionalTrueIsland OPM_UNUSED bar; // compiler fails because of missing default ctor
+    }
+
+    {
+        typedef Opm::ConditionalStorage<false, IAmAnIslandLeaveMeAlone> ConditionalFalseIsland;
+        ConditionalFalseIsland OPM_UNUSED foo(1, 2);
+        // ConditionalFalseIsland OPM_UNUSED bar; // compiler fails because of missing default ctor
+    }
+
+    return 0;
+}

--- a/tests/test_blackoilfluidstate.cpp
+++ b/tests/test_blackoilfluidstate.cpp
@@ -34,9 +34,7 @@
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/checkFluidSystem.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 int main()
 {

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -60,9 +60,7 @@ namespace ComponentsTest {
 #include <opm/material/components/co2tables.inc>
 }}
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 template <class Scalar, class Evaluation>
 void testAllComponents()

--- a/tests/test_densead.cpp
+++ b/tests/test_densead.cpp
@@ -37,11 +37,9 @@
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <iostream>
 #include <array>

--- a/tests/test_eclblackoilfluidsystem.cpp
+++ b/tests/test_eclblackoilfluidsystem.cpp
@@ -37,17 +37,15 @@
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/densead/Evaluation.hpp>
 
-#include <opm/common/Valgrind.hpp>
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <type_traits>
 #include <cmath>

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -52,9 +52,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 // values of strings based on the first SPE1 test case of opm-data.  note that in the
 // real world it does not make much sense to specify a fluid phase using more than a
@@ -235,9 +233,8 @@ inline void testAll()
     size_t numPvtRegions = pvtwKeyword.size();
 
     if (numPvtRegions != 2)
-        OPM_THROW(std::logic_error,
-                  "The number of PVT regions of the test deck must be 2. (is "
-                  << numPvtRegions << ")");
+        throw std::logic_error("The number of PVT regions of the test deck must be 2. (is "
+                               +std::to_string(numPvtRegions)+")");
 
     //////////
     // constant compressibility water
@@ -254,18 +251,16 @@ inline void testAll()
                                       /*temperature=*/273.15 + 20.0,
                                       /*pressure=*/1e5);
     if (std::abs(tmp - refTmp)  > tolerance)
-        OPM_THROW(std::logic_error,
-                  "The reference water viscosity at region 0 is supposed to be " << refTmp
-                  << ". (is " << tmp << ")");
+        throw std::logic_error("The reference water viscosity at region 0 is supposed to be "+std::to_string(refTmp)
+                               +". (is "+std::to_string(tmp)+")");
 
     refTmp = 1.2e-3;
     tmp = constCompWaterPvt.viscosity(/*regionIdx=*/1,
                                       /*temperature=*/273.15 + 20.0,
                                       /*pressure=*/2e5);
     if (std::abs(tmp - refTmp)  > tolerance)
-        OPM_THROW(std::logic_error,
-                  "The reference water viscosity at region 1 is supposed to be " << refTmp
-                  << ". (is " << tmp << ")");
+        throw std::logic_error("The reference water viscosity at region 1 is supposed to be "+std::to_string(refTmp)
+                               +". (is "+std::to_string(tmp)+")");
 
     //////////
     // the gas and oil PVT classes.

--- a/tests/test_eclmateriallawmanager.cpp
+++ b/tests/test_eclmateriallawmanager.cpp
@@ -43,9 +43,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 // values of strings taken from the SPE1 test case1 of opm-data
 static const char* fam1DeckString =
@@ -450,12 +448,10 @@ inline void testAll()
         materialLawManager.initFromDeck(deck, eclState, compressedToCartesianIdx);
 
         if (materialLawManager.enableEndPointScaling())
-            OPM_THROW(std::logic_error,
-                      "Discrepancy between the deck and the EclMaterialLawManager");
+            throw std::logic_error("Discrepancy between the deck and the EclMaterialLawManager");
 
         if (materialLawManager.enableHysteresis())
-            OPM_THROW(std::logic_error,
-                      "Discrepancy between the deck and the EclMaterialLawManager");
+            throw std::logic_error("Discrepancy between the deck and the EclMaterialLawManager");
 
         {
             const auto fam2Deck = parser.parseString(fam2DeckString, parseContext);
@@ -465,12 +461,10 @@ inline void testAll()
             fam2MaterialLawManager.initFromDeck(fam2Deck, fam2EclState, compressedToCartesianIdx);
 
             if (fam2MaterialLawManager.enableEndPointScaling())
-                OPM_THROW(std::logic_error,
-                          "Discrepancy between the deck and the EclMaterialLawManager");
+                throw std::logic_error("Discrepancy between the deck and the EclMaterialLawManager");
 
             if (fam2MaterialLawManager.enableHysteresis())
-                OPM_THROW(std::logic_error,
-                          "Discrepancy between the deck and the EclMaterialLawManager");
+                throw std::logic_error("Discrepancy between the deck and the EclMaterialLawManager");
 
             const auto hysterDeck = parser.parseString(hysterDeckString, parseContext);
             const Opm::EclipseState hysterEclState(hysterDeck, parseContext);
@@ -479,12 +473,10 @@ inline void testAll()
             hysterMaterialLawManager.initFromDeck(hysterDeck, hysterEclState, compressedToCartesianIdx);
 
             if (hysterMaterialLawManager.enableEndPointScaling())
-                OPM_THROW(std::logic_error,
-                          "Discrepancy between the deck and the EclMaterialLawManager");
+                throw std::logic_error("Discrepancy between the deck and the EclMaterialLawManager");
 
             if (hysterMaterialLawManager.enableHysteresis() != true)
-                OPM_THROW(std::logic_error,
-                          "Discrepancy between the deck and the EclMaterialLawManager");
+                throw std::logic_error("Discrepancy between the deck and the EclMaterialLawManager");
 
 
 
@@ -522,11 +514,9 @@ inline void testAll()
                         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
 
                             if (std::abs(pcFam1[phaseIdx] - pcFam2[phaseIdx]) > 1e-5)
-                                OPM_THROW(std::logic_error,
-                                          "Discrepancy between capillary pressure of family 1 and family 2 keywords");
+                                throw std::logic_error("Discrepancy between capillary pressure of family 1 and family 2 keywords");
                             if (std::abs(krFam1[phaseIdx] - krFam2[phaseIdx]) > 1e-1)
-                                OPM_THROW(std::logic_error,
-                                          "Discrepancy between relative permeabilities of family 1 and family 2 keywords");
+                                throw std::logic_error("Discrepancy between relative permeabilities of family 1 and family 2 keywords");
                         }
 
 
@@ -556,11 +546,9 @@ inline void testAll()
 
                         for (unsigned phasePairIdx = 0; phasePairIdx < 2; ++ phasePairIdx) {
                             if ((pcSwMdc_in[phasePairIdx] - pcSwMdc_out[phasePairIdx]) != 0.0)
-                                OPM_THROW(std::logic_error,
-                                          "Hysteresis parameters did not propagate correctly");
+                                throw std::logic_error("Hysteresis parameters did not propagate correctly");
                             if ((krnSwMdc_in[phasePairIdx] - krnSwMdc_out[phasePairIdx]) != 0.0)
-                                OPM_THROW(std::logic_error,
-                                          "Hysteresis parameters did not propagate correctly");
+                                throw std::logic_error("Hysteresis parameters did not propagate correctly");
 
                         }
                     }
@@ -613,11 +601,9 @@ inline void testAll()
                     for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
 
                         if (std::abs(pcFam1[phaseIdx] - pcFam2[phaseIdx]) > 1e-5)
-                            OPM_THROW(std::logic_error,
-                                      "Discrepancy between capillary pressure of family 1 and family 2 keywords");
+                            throw std::logic_error("Discrepancy between capillary pressure of family 1 and family 2 keywords");
                         if (std::abs(krFam1[phaseIdx] - krFam2[phaseIdx]) > 1e-1)
-                            OPM_THROW(std::logic_error,
-                                      "Discrepancy between relative permeabilities of family 1 and family 2 keywords");
+                            throw std::logic_error("Discrepancy between relative permeabilities of family 1 and family 2 keywords");
                     }
                 }
             }

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -67,11 +67,9 @@
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/components/N2.hpp>
 
-#include <opm/common/Unused.hpp>
+#include <opm/material/common/Unused.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 // this function makes sure that a capillary pressure law adheres to
 // the generic programming interface for such laws. This API _must_ be

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -62,9 +62,7 @@ namespace FluidSystemsTest {
 #include <opm/material/components/co2tables.inc>
 } }
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 // check that the blackoil fluid system implements all non-standard functions
 template <class Evaluation, class FluidSystem>

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -46,9 +46,9 @@
 #include <opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <sstream>
 
 template <class Scalar, class FluidState>
 void checkSame(const FluidState& fsRef, const FluidState& fsFlash)
@@ -64,32 +64,37 @@ void checkSame(const FluidState& fsRef, const FluidState& fsFlash)
         // check the pressures
         error = 1 - fsRef.pressure(phaseIdx)/fsFlash.pressure(phaseIdx);
         if (std::abs(error) > tol) {
-            OPM_THROW(std::runtime_error,
-                      "pressure error phase " << phaseIdx << " is incorrect: "
-                      << fsFlash.pressure(phaseIdx)  << " flash vs "
-                      << fsRef.pressure(phaseIdx) << " reference"
-                      << " error=" << error);
+                std::ostringstream oss;
+                oss << "pressure error phase " << phaseIdx << " is incorrect: "
+                    << fsFlash.pressure(phaseIdx)  << " flash vs "
+                    << fsRef.pressure(phaseIdx) << " reference"
+                    << " error=" << error;
+                throw std::runtime_error(oss.str());
         }
 
         // check the saturations
         error = fsRef.saturation(phaseIdx) - fsFlash.saturation(phaseIdx);
-        if (std::abs(error) > tol)
-            OPM_THROW(std::runtime_error,
-                      "saturation error phase " << phaseIdx << " is incorrect: "
-                      << fsFlash.saturation(phaseIdx) << " flash vs "
-                      << fsRef.saturation(phaseIdx) << " reference"
-                      << " error=" << error);
+        if (std::abs(error) > tol) {
+            std::ostringstream oss;
+            oss << "saturation error phase " << phaseIdx << " is incorrect: "
+                << fsFlash.saturation(phaseIdx) << " flash vs "
+                << fsRef.saturation(phaseIdx) << " reference"
+                << " error=" << error;
+            throw std::runtime_error(oss.str());
+        }
 
         // check the compositions
         for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
             error = fsRef.moleFraction(phaseIdx, compIdx) - fsFlash.moleFraction(phaseIdx, compIdx);
-            if (std::abs(error) > tol)
-                OPM_THROW(std::runtime_error,
-                          "composition error phase " << phaseIdx << ", component " << compIdx
-                          << " is incorrect: "
-                          << fsFlash.moleFraction(phaseIdx, compIdx) << " flash vs "
-                          << fsRef.moleFraction(phaseIdx, compIdx) << " reference"
-                          << " error=" << error);
+            if (std::abs(error) > tol) {
+                std::ostringstream oss;
+                oss << "composition error phase " << phaseIdx << ", component " << compIdx
+                    << " is incorrect: "
+                    << fsFlash.moleFraction(phaseIdx, compIdx) << " flash vs "
+                    << fsRef.moleFraction(phaseIdx, compIdx) << " reference"
+                    << " error=" << error;
+                throw std::runtime_error(oss.str());
+            }
         }
     }
 }

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -45,9 +45,7 @@
 #include <opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 template <class Scalar, class FluidState>
 void checkSame(const FluidState& fsRef, const FluidState& fsFlash)
@@ -63,31 +61,36 @@ void checkSame(const FluidState& fsRef, const FluidState& fsFlash)
         // check the pressures
         error = 1 - fsRef.pressure(phaseIdx)/fsFlash.pressure(phaseIdx);
         if (std::abs(error) > tol) {
-            OPM_THROW(std::runtime_error,
-                      "pressure error for phase " << phaseIdx << " exceeds tolerance"
-                      << " (" << fsFlash.pressure(phaseIdx)  << " flash vs "
-                      << fsRef.pressure(phaseIdx) << " reference,"
-                      << " error=" << error << ")");
+            std::ostringstream oss;
+            oss << "pressure error for phase " << phaseIdx << " exceeds tolerance"
+                << " (" << fsFlash.pressure(phaseIdx)  << " flash vs "
+                << fsRef.pressure(phaseIdx) << " reference,"
+                << " error=" << error << ")";
+            throw std::runtime_error(oss.str());
         }
 
         // check the saturations
         error = fsRef.saturation(phaseIdx) - fsFlash.saturation(phaseIdx);
-        if (std::abs(error) > tol)
-            OPM_THROW(std::runtime_error,
-                      "saturation error for phase " << phaseIdx << " exceeds tolerance"
-                      << " (" << fsFlash.saturation(phaseIdx) << " flash vs "
-                      << fsRef.saturation(phaseIdx) << " reference,"
-                      << " error=" << error << ")");
+        if (std::abs(error) > tol) {
+            std::ostringstream oss;
+            oss << "saturation error for phase " << phaseIdx << " exceeds tolerance"
+                << " (" << fsFlash.saturation(phaseIdx) << " flash vs "
+                << fsRef.saturation(phaseIdx) << " reference,"
+                << " error=" << error << ")";
+            throw std::runtime_error(oss.str());
+        }
 
         // check the compositions
         for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
             error = fsRef.moleFraction(phaseIdx, compIdx) - fsFlash.moleFraction(phaseIdx, compIdx);
-            if (std::abs(error) > tol)
-                OPM_THROW(std::runtime_error,
-                          "composition error phase " << phaseIdx << ", component " << compIdx << " exceeds tolerance"
-                          << " (" << fsFlash.moleFraction(phaseIdx, compIdx) << " flash vs "
-                          << fsRef.moleFraction(phaseIdx, compIdx) << " reference,"
-                          << " error=" << error << ")");
+            if (std::abs(error) > tol) {
+                std::ostringstream oss;
+                oss << "composition error phase " << phaseIdx << ", component " << compIdx << " exceeds tolerance"
+                    << " (" << fsFlash.moleFraction(phaseIdx, compIdx) << " flash vs "
+                    << fsRef.moleFraction(phaseIdx, compIdx) << " reference,"
+                    << " error=" << error << ")";
+                throw std::runtime_error(oss.str());
+            }
         }
     }
 }

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -36,9 +36,7 @@
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 template <class FluidSystem, class FluidState>
 void createSurfaceGasFluidSystem(FluidState& gasFluidState)
@@ -223,8 +221,7 @@ Scalar bringOilToSurface(FluidState& surfaceFluidState, Scalar alpha, const Flui
     ComponentVector tmpMolarities;
     for (int i = 0;; ++i) {
         if (i >= 20)
-            OPM_THROW(Opm::NumericalProblem,
-                       "Newton method did not converge after 20 iterations");
+            throw Opm::NumericalIssue("Newton method did not converge after 20 iterations");
 
         // calculate the deviation from the standard pressure
         tmpMolarities = molarities;

--- a/tests/test_tabulation.cpp
+++ b/tests/test_tabulation.cpp
@@ -34,9 +34,7 @@
 #include <opm/material/components/H2O.hpp>
 #include <opm/material/components/TabulatedComponent.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/parallel/mpihelper.hh>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 extern bool success;
 bool success;


### PR DESCRIPTION
all of these classes have only been used in opm-material and its downstreams in the first place.

this is the `opm-material` part of OPM/opm-common#332