### PR TITLE
make it work with the latest dune master

### DIFF
--- a/opm/material/common/quad.hpp
+++ b/opm/material/common/quad.hpp
@@ -29,7 +29,10 @@
 #if !defined OPM_COMMON_QUAD_HPP && HAVE_QUAD
 #define OPM_COMMON_QUAD_HPP
 
+#include <opm/material/common/Unused.hpp>
+
 #include <cmath>
+#include <complex>
 #include <string>
 #include <stdexcept>
 #include <limits>
@@ -258,6 +261,18 @@ inline std::istream& operator>>(std::istream& is, quad& val)
     val = tmp;
     return ret;
 }
+
+inline quad real(quad val)
+{ return val; }
+
+inline quad real(const std::complex<quad>& val)
+{ return val.real(); }
+
+inline quad imag(quad val OPM_UNUSED)
+{ return 0.0; }
+
+inline quad imag(const std::complex<quad>& val)
+{ return val.imag(); }
 
 inline quad abs(quad val)
 { return (val < 0) ? -val : val; }

--- a/opm/material/constraintsolvers/CompositionFromFugacities.hpp
+++ b/opm/material/constraintsolvers/CompositionFromFugacities.hpp
@@ -89,8 +89,6 @@ public:
             return;
         }
 
-        //Dune::FMatrixPrecision<Scalar>::set_singular_limit(1e-25);
-
         // save initial composition in case something goes wrong
         Dune::FieldVector<Evaluation, numComponents> xInit;
         for (unsigned i = 0; i < numComponents; ++i) {

--- a/opm/material/constraintsolvers/ImmiscibleFlash.hpp
+++ b/opm/material/constraintsolvers/ImmiscibleFlash.hpp
@@ -36,6 +36,7 @@
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
+#include <dune/common/version.hh>
 
 #include <limits>
 #include <iostream>
@@ -143,7 +144,9 @@ public:
         typedef Dune::FieldVector<FlashEval, numEq> FlashDefectVector;
         typedef Opm::ImmiscibleFluidState<FlashEval, FluidSystem> FlashFluidState;
 
+#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,7)
         Dune::FMatrixPrecision<InputEval>::set_singular_limit(1e-35);
+#endif
 
         if (tolerance <= 0)
             tolerance = std::min<Scalar>(1e-5,

--- a/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
+++ b/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
@@ -34,6 +34,7 @@
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
+#include <dune/common/version.hh>
 
 namespace Opm {
 
@@ -250,8 +251,10 @@ public:
 
         // solve for all mole fractions
         try {
+#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,7)
             static constexpr Scalar eps = std::numeric_limits<Scalar>::min()*1000.0;
             Dune::FMatrixPrecision<Scalar>::set_singular_limit(eps);
+#endif
             M.solve(x, b);
         }
         catch (const Dune::FMatrixError& e) {

--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -39,6 +39,7 @@
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
+#include <dune/common/version.hh>
 
 #include <limits>
 #include <iostream>
@@ -161,7 +162,9 @@ public:
         typedef Dune::FieldVector<FlashEval, numEq> FlashDefectVector;
         typedef Opm::CompositionalFluidState<FlashEval, FluidSystem, /*energy=*/false> FlashFluidState;
 
+#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,7)
         Dune::FMatrixPrecision<InputEval>::set_singular_limit(1e-35);
+#endif
 
         if (tolerance <= 0)
             tolerance = std::min<Scalar>(1e-3,


### PR DESCRIPTION
`Dune::set_singularity_limit()` has been removed there and `std::real()` gets used by the dense matrix-vector code (this causes trouble if `quad` is selected as scalar type)