### PR TITLE
SPECROCK thermal law: rename internal variables

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -152,7 +152,8 @@ public:
                     Scalar T0 = temperatureColumn[i];
                     Scalar T1 = temperatureColumn[i + 1];
                     Scalar m = (c_v1 - c_v0)/(T1 - T0);
-                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c_v0*(T1 - T0);
+                    Scalar c = c_v0 - m*T0;
+                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c*(T1 - T0);
                     u += deltaU;
                 }
 

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -151,10 +151,7 @@ public:
                     Scalar c_v1 = cvGasColumn[i + 1];
                     Scalar T0 = temperatureColumn[i];
                     Scalar T1 = temperatureColumn[i + 1];
-                    Scalar m = (c_v1 - c_v0)/(T1 - T0);
-                    Scalar c = c_v0 - m*T0;
-                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c*(T1 - T0);
-                    u += deltaU;
+                    u += 0.5*(c_v0 + c_v1)*(T1 - T0);
                 }
 
                 internalEnergyCurves_[regionIdx].setXYContainers(temperatureColumn.vectorCopy(), uSamples);

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -147,12 +147,12 @@ public:
 
                     // integrate to the heat capacity from the current sampling point to the next
                     // one. this leads to a quadratic polynomial.
-                    Scalar h0 = cvGasColumn[i];
-                    Scalar h1 = cvGasColumn[i + 1];
+                    Scalar c_v0 = cvGasColumn[i];
+                    Scalar c_v1 = cvGasColumn[i + 1];
                     Scalar T0 = temperatureColumn[i];
                     Scalar T1 = temperatureColumn[i + 1];
-                    Scalar m = (h1 - h0)/(T1 - T0);
-                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + h0*(T1 - T0);
+                    Scalar m = (c_v1 - c_v0)/(T1 - T0);
+                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c_v0*(T1 - T0);
                     u += deltaU;
                 }
 

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -163,7 +163,8 @@ public:
                     Scalar T0 = temperatureColumn[i];
                     Scalar T1 = temperatureColumn[i + 1];
                     Scalar m = (c_v1 - c_v0)/(T1 - T0);
-                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c_v0*(T1 - T0);
+                    Scalar c = c_v0 - m*T0;
+                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c*(T1 - T0);
                     u += deltaU;
                 }
 

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -162,10 +162,7 @@ public:
                     Scalar c_v1 = cvOilColumn[i + 1];
                     Scalar T0 = temperatureColumn[i];
                     Scalar T1 = temperatureColumn[i + 1];
-                    Scalar m = (c_v1 - c_v0)/(T1 - T0);
-                    Scalar c = c_v0 - m*T0;
-                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c*(T1 - T0);
-                    u += deltaU;
+                    u += 0.5*(c_v0 + c_v1)*(T1 - T0);
                 }
 
                 internalEnergyCurves_[regionIdx].setXYContainers(temperatureColumn.vectorCopy(), uSamples);

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -158,12 +158,12 @@ public:
 
                     // integrate to the heat capacity from the current sampling point to the next
                     // one. this leads to a quadratic polynomial.
-                    Scalar h0 = cvOilColumn[i];
-                    Scalar h1 = cvOilColumn[i + 1];
+                    Scalar c_v0 = cvOilColumn[i];
+                    Scalar c_v1 = cvOilColumn[i + 1];
                     Scalar T0 = temperatureColumn[i];
                     Scalar T1 = temperatureColumn[i + 1];
-                    Scalar m = (h1 - h0)/(T1 - T0);
-                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + h0*(T1 - T0);
+                    Scalar m = (c_v1 - c_v0)/(T1 - T0);
+                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c_v0*(T1 - T0);
                     u += deltaU;
                 }
 

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -144,12 +144,12 @@ public:
 
                     // integrate to the heat capacity from the current sampling point to the next
                     // one. this leads to a quadratic polynomial.
-                    Scalar h0 = cvWaterColumn[i];
-                    Scalar h1 = cvWaterColumn[i + 1];
+                    Scalar c_v0 = cvWaterColumn[i];
+                    Scalar c_v1 = cvWaterColumn[i + 1];
                     Scalar T0 = temperatureColumn[i];
                     Scalar T1 = temperatureColumn[i + 1];
-                    Scalar m = (h1 - h0)/(T1 - T0);
-                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + h0*(T1 - T0);
+                    Scalar m = (c_v1 - c_v0)/(T1 - T0);
+                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c_v0*(T1 - T0);
                     u += deltaU;
                 }
 

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -149,7 +149,8 @@ public:
                     Scalar T0 = temperatureColumn[i];
                     Scalar T1 = temperatureColumn[i + 1];
                     Scalar m = (c_v1 - c_v0)/(T1 - T0);
-                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c_v0*(T1 - T0);
+                    Scalar c = c_v0 - m*T0;
+                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c*(T1 - T0);
                     u += deltaU;
                 }
 

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -148,10 +148,7 @@ public:
                     Scalar c_v1 = cvWaterColumn[i + 1];
                     Scalar T0 = temperatureColumn[i];
                     Scalar T1 = temperatureColumn[i + 1];
-                    Scalar m = (c_v1 - c_v0)/(T1 - T0);
-                    Scalar c = c_v0 - m*T0;
-                    Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c*(T1 - T0);
-                    u += deltaU;
+                    u += 0.5*(c_v0 + c_v1)*(T1 - T0);
                 }
 
                 internalEnergyCurves_[regionIdx].setXYContainers(temperatureColumn.vectorCopy(), uSamples);

--- a/opm/material/thermal/EclSpecrockLawParams.hpp
+++ b/opm/material/thermal/EclSpecrockLawParams.hpp
@@ -77,10 +77,7 @@ public:
             Scalar c_v1 = heatCapacity[i + 1];
             Scalar T0 = temperature[i];
             Scalar T1 = temperature[i + 1];
-            Scalar m = (c_v1 - c_v0)/(T1 - T0);
-            Scalar c = c_v0 - m*T0;
-            Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c*(T1 - T0);
-            curU += deltaU;
+            curU += 0.5*(c_v0 + c_v1)*(T1 - T0);
         }
 
         internalEnergyFunction_.setXYContainers(T, u);

--- a/opm/material/thermal/EclSpecrockLawParams.hpp
+++ b/opm/material/thermal/EclSpecrockLawParams.hpp
@@ -78,7 +78,8 @@ public:
             Scalar T0 = temperature[i];
             Scalar T1 = temperature[i + 1];
             Scalar m = (c_v1 - c_v0)/(T1 - T0);
-            Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c_v0*(T1 - T0);
+            Scalar c = c_v0 - m*T0;
+            Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c*(T1 - T0);
             curU += deltaU;
         }
 

--- a/opm/material/thermal/EclSpecrockLawParams.hpp
+++ b/opm/material/thermal/EclSpecrockLawParams.hpp
@@ -61,8 +61,9 @@ public:
 
         // integrate the heat capacity to compute the internal energy
         Scalar curU = temperature[0]*heatCapacity[0];
-        std::vector<Scalar> T(temperature.size());
-        std::vector<Scalar> u(heatCapacity.size());
+        unsigned n = temperature.size();
+        std::vector<Scalar> T(n);
+        std::vector<Scalar> u(n);
         for (unsigned i = 0; i < temperature.size(); ++ i) {
             T[i] = temperature[i];
             u[i] = curU;
@@ -72,12 +73,12 @@ public:
 
             // integrate to the heat capacity from the current sampling point to the next
             // one. this leads to a quadratic polynomial.
-            Scalar u0 = heatCapacity[i];
-            Scalar u1 = heatCapacity[i + 1];
+            Scalar c_v0 = heatCapacity[i];
+            Scalar c_v1 = heatCapacity[i + 1];
             Scalar T0 = temperature[i];
             Scalar T1 = temperature[i + 1];
-            Scalar m = (u1 - u0)/(T1 - T0);
-            Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + u0*(T1 - T0);
+            Scalar m = (c_v1 - c_v0)/(T1 - T0);
+            Scalar deltaU = 0.5*m*(T1*T1 - T0*T0) + c_v0*(T1 - T0);
             curU += deltaU;
         }
 


### PR DESCRIPTION
using `u` for heat capacitis is very confusing because the variables can easily be mistaken for the internal energy.