### PR TITLE
fixed: explicitly add boost::filesystem to prereqs

### DIFF
--- a/opm-material-prereqs.cmake
+++ b/opm-material-prereqs.cmake
@@ -20,6 +20,7 @@ set (opm-material_DEPS
   "dune-common REQUIRED"
   # valgrind client requests
   "Valgrind"
+  "Boost COMPONENTS filesystem"
   )
 
 find_package_deps(opm-material)


### PR DESCRIPTION
required due to used headers from opm-common