### PR TITLE
remove the Opm::FluidSystems namespace

### DIFF
--- a/opm/material/components/CO2.hpp
+++ b/opm/material/components/CO2.hpp
@@ -44,7 +44,7 @@ namespace Opm {
  * Under reservoir conditions, CO2 is typically in supercritical
  * state. These properties can be provided in tabulated form, which is
  * necessary for this component. The template is used by the
- * fluidsystem \c FluidSystems::BrineCO2. If thermodynamic precision
+ * fluidsystem \c BrineCO2FluidSystem. If thermodynamic precision
  * is not a top priority, the much simpler component \c Opm::SimpleCO2 can be
  * used instead
  */

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -22,7 +22,7 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidSystems::BlackOil
+ * \copydoc Opm::BlackOilFluidSystem
  */
 #ifndef OPM_BLACK_OIL_FLUID_SYSTEM_HPP
 #define OPM_BLACK_OIL_FLUID_SYSTEM_HPP
@@ -82,8 +82,6 @@ auto getRv_(typename std::enable_if<HasMember_Rv<FluidState>::value, const Fluid
 
 }
 
-namespace FluidSystems {
-
 /*!
  * \brief A fluid system which uses the black-oil model assumptions to calculate
  *        termodynamically meaningful quantities.
@@ -91,9 +89,9 @@ namespace FluidSystems {
  * \tparam Scalar The type used for scalar floating point values
  */
 template <class Scalar>
-class BlackOil : public BaseFluidSystem<Scalar, BlackOil<Scalar> >
+class BlackOilFluidSystem : public BaseFluidSystem<Scalar, BlackOilFluidSystem<Scalar> >
 {
-    typedef BlackOil ThisType;
+    typedef BlackOilFluidSystem ThisType;
 
 public:
     typedef Opm::GasPvtMultiplexer<Scalar> GasPvt;
@@ -1269,7 +1267,7 @@ private:
 };
 
 template <class Scalar>
-const int BlackOil<Scalar>::phaseToSolventCompIdx_[3] =
+const int BlackOilFluidSystem<Scalar>::phaseToSolventCompIdx_[3] =
 {
     waterCompIdx, // water phase
     oilCompIdx, // oil phase
@@ -1278,7 +1276,7 @@ const int BlackOil<Scalar>::phaseToSolventCompIdx_[3] =
 
 
 template <class Scalar>
-const int BlackOil<Scalar>::phaseToSoluteCompIdx_[3] =
+const int BlackOilFluidSystem<Scalar>::phaseToSoluteCompIdx_[3] =
 {
     -1, // water phase
     gasCompIdx, // oil phase
@@ -1286,52 +1284,52 @@ const int BlackOil<Scalar>::phaseToSoluteCompIdx_[3] =
 };
 
 template <class Scalar>
-unsigned char BlackOil<Scalar>::numActivePhases_;
+unsigned char BlackOilFluidSystem<Scalar>::numActivePhases_;
 
 template <class Scalar>
-bool BlackOil<Scalar>::phaseIsActive_[numPhases];
-
-template <class Scalar>
-Scalar
-BlackOil<Scalar>::surfaceTemperature; // [K]
+bool BlackOilFluidSystem<Scalar>::phaseIsActive_[numPhases];
 
 template <class Scalar>
 Scalar
-BlackOil<Scalar>::surfacePressure; // [Pa]
+BlackOilFluidSystem<Scalar>::surfaceTemperature; // [K]
 
 template <class Scalar>
 Scalar
-BlackOil<Scalar>::reservoirTemperature_;
+BlackOilFluidSystem<Scalar>::surfacePressure; // [Pa]
 
 template <class Scalar>
-bool BlackOil<Scalar>::enableDissolvedGas_;
+Scalar
+BlackOilFluidSystem<Scalar>::reservoirTemperature_;
 
 template <class Scalar>
-bool BlackOil<Scalar>::enableVaporizedOil_;
+bool BlackOilFluidSystem<Scalar>::enableDissolvedGas_;
+
+template <class Scalar>
+bool BlackOilFluidSystem<Scalar>::enableVaporizedOil_;
 
 template <class Scalar>
 std::shared_ptr<OilPvtMultiplexer<Scalar> >
-BlackOil<Scalar>::oilPvt_;
+BlackOilFluidSystem<Scalar>::oilPvt_;
 
 template <class Scalar>
 std::shared_ptr<Opm::GasPvtMultiplexer<Scalar> >
-BlackOil<Scalar>::gasPvt_;
+BlackOilFluidSystem<Scalar>::gasPvt_;
 
 template <class Scalar>
 std::shared_ptr<WaterPvtMultiplexer<Scalar> >
-BlackOil<Scalar>::waterPvt_;
+BlackOilFluidSystem<Scalar>::waterPvt_;
 
 template <class Scalar>
 std::vector<std::array<Scalar, 3> >
-BlackOil<Scalar>::referenceDensity_;
+BlackOilFluidSystem<Scalar>::referenceDensity_;
 
 template <class Scalar>
 std::vector<std::array<Scalar, 3> >
-BlackOil<Scalar>::molarMass_;
+BlackOilFluidSystem<Scalar>::molarMass_;
 
 template <class Scalar>
-bool BlackOil<Scalar>::isInitialized_ = false;
+bool BlackOilFluidSystem<Scalar>::isInitialized_ = false;
 
-}} // namespace Opm, FluidSystems
+} // namespace Opm
 
 #endif

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -23,7 +23,7 @@
 /*!
  * \file
  *
- * \copydoc Opm::FluidSystems::BrineCO2
+ * \copydoc Opm::BrineCO2FluidSystem
  */
 #ifndef OPM_BRINE_CO2_SYSTEM_HPP
 #define OPM_BRINE_CO2_SYSTEM_HPP
@@ -48,7 +48,6 @@
 #include <iostream>
 
 namespace Opm {
-namespace FluidSystems {
 
 /*!
  * \brief A two-phase fluid system with water and CO2.
@@ -58,8 +57,8 @@ namespace FluidSystems {
  * sampling to be supplied as template argument.
  */
 template <class Scalar, class CO2Tables>
-class BrineCO2
-    : public BaseFluidSystem<Scalar, BrineCO2<Scalar, CO2Tables> >
+class BrineCO2FluidSystem
+    : public BaseFluidSystem<Scalar, BrineCO2FluidSystem<Scalar, CO2Tables> >
 {
     typedef Opm::H2O<Scalar> H2O_IAPWS;
     typedef Opm::Brine<Scalar, H2O_IAPWS> Brine_IAPWS;
@@ -602,7 +601,6 @@ private:
     }
 };
 
-} // namespace FluidSystems
 } // namespace Opm
 
 #endif

--- a/opm/material/fluidsystems/H2OAirFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirFluidSystem.hpp
@@ -22,7 +22,7 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidSystems::H2OAir
+ * \copydoc Opm::H2OAirFluidSystem
  */
 #ifndef OPM_H2O_AIR_SYSTEM_HPP
 #define OPM_H2O_AIR_SYSTEM_HPP
@@ -43,7 +43,6 @@
 #include <cassert>
 
 namespace Opm {
-namespace FluidSystems {
 
 /*!
  * \ingroup Fluidsystems
@@ -57,10 +56,10 @@ namespace FluidSystems {
 template <class Scalar,
           //class H2Otype = Opm::SimpleH2O<Scalar>,
           class H2Otype = Opm::TabulatedComponent<Scalar, Opm::H2O<Scalar> >>
-class H2OAir
-    : public BaseFluidSystem<Scalar, H2OAir<Scalar, H2Otype> >
+class H2OAirFluidSystem
+    : public BaseFluidSystem<Scalar, H2OAirFluidSystem<Scalar, H2Otype> >
 {
-    typedef H2OAir<Scalar,H2Otype> ThisType;
+    typedef H2OAirFluidSystem<Scalar,H2Otype> ThisType;
     typedef BaseFluidSystem <Scalar, ThisType> Base;
     typedef Opm::IdealGas<Scalar> IdealGas;
 
@@ -460,8 +459,6 @@ public:
         }
     }
 };
-
-} // namespace FluidSystems
 
 } // namespace Opm
 

--- a/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
@@ -22,7 +22,7 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidSystems::H2OAirMesitylene
+ * \copydoc Opm::H2OAirMesityleneFluidSystem
  */
 #ifndef OPM_H2O_AIR_MESITYLENE_FLUID_SYSTEM_HPP
 #define OPM_H2O_AIR_MESITYLENE_FLUID_SYSTEM_HPP
@@ -45,7 +45,6 @@
 #include <iostream>
 
 namespace Opm {
-namespace FluidSystems {
 
 /*!
  * \ingroup Fluidsystems
@@ -53,10 +52,10 @@ namespace FluidSystems {
  *        water, air and mesitylene (DNAPL) as components.
  */
 template <class Scalar>
-class H2OAirMesitylene
-    : public BaseFluidSystem<Scalar, H2OAirMesitylene<Scalar> >
+class H2OAirMesityleneFluidSystem
+    : public BaseFluidSystem<Scalar, H2OAirMesityleneFluidSystem<Scalar> >
 {
-    typedef H2OAirMesitylene<Scalar> ThisType;
+    typedef H2OAirMesityleneFluidSystem<Scalar> ThisType;
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
     typedef Opm::H2O<Scalar> IapwsH2O;
@@ -469,7 +468,6 @@ public:
         return 0.0143964;
     }
 };
-} // namespace FluidSystems
 } // namespace Opm
 
 #endif

--- a/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
@@ -22,7 +22,7 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidSystems::H2OAirXylene
+ * \copydoc Opm::H2OAirXyleneFluidSystem
  */
 #ifndef OPM_H2O_AIR_XYLENE_FLUID_SYSTEM_HPP
 #define OPM_H2O_AIR_XYLENE_FLUID_SYSTEM_HPP
@@ -41,7 +41,6 @@
 #include "NullParameterCache.hpp"
 
 namespace Opm {
-namespace FluidSystems {
 
 /*!
  * \ingroup Fluidsystems
@@ -49,10 +48,10 @@ namespace FluidSystems {
  *        water, air and NAPL (contaminant) as components.
  */
 template <class Scalar>
-class H2OAirXylene
-    : public BaseFluidSystem<Scalar, H2OAirXylene<Scalar> >
+class H2OAirXyleneFluidSystem
+    : public BaseFluidSystem<Scalar, H2OAirXyleneFluidSystem<Scalar> >
 {
-    typedef H2OAirXylene<Scalar> ThisType;
+    typedef H2OAirXyleneFluidSystem<Scalar> ThisType;
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
 public:
@@ -417,7 +416,7 @@ private:
     static LhsEval NAPLPhaseDensity_(const LhsEval& T, const LhsEval& pn)
     { return NAPL::liquidDensity(T, pn); }
 };
-} // namespace FluidSystems
+
 } // namespace Opm
 
 #endif

--- a/opm/material/fluidsystems/H2ON2FluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2FluidSystem.hpp
@@ -22,7 +22,7 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidSystems::H2ON2
+ * \copydoc Opm::H2ON2FluidSystem
  */
 #ifndef OPM_H2O_N2_FLUID_SYSTEM_HPP
 #define OPM_H2O_N2_FLUID_SYSTEM_HPP
@@ -44,7 +44,6 @@
 #include <cassert>
 
 namespace Opm {
-namespace FluidSystems {
 
 /*!
  * \ingroup Fluidsystems
@@ -52,10 +51,10 @@ namespace FluidSystems {
  * \brief A two-phase fluid system with water and nitrogen as components.
  */
 template <class Scalar>
-class H2ON2
-    : public BaseFluidSystem<Scalar, H2ON2<Scalar> >
+class H2ON2FluidSystem
+    : public BaseFluidSystem<Scalar, H2ON2FluidSystem<Scalar> >
 {
-    typedef H2ON2<Scalar> ThisType;
+    typedef H2ON2FluidSystem<Scalar> ThisType;
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
     // convenience typedefs
@@ -485,8 +484,6 @@ public:
         return XAlphaH2O*c_pH2O + XAlphaN2*c_pN2;
     }
 };
-
-} // namespace FluidSystems
 
 } // namespace Opm
 

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -22,7 +22,7 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidSystems::H2ON2LiquidPhase
+ * \copydoc Opm::H2ON2LiquidPhaseFluidSystem
  */
 #ifndef OPM_H2O_N2_LIQUIDPHASE_FLUID_SYSTEM_HPP
 #define OPM_H2O_N2_LIQUIDPHASE_FLUID_SYSTEM_HPP
@@ -44,7 +44,6 @@
 #include <cassert>
 
 namespace Opm {
-namespace FluidSystems {
 
 /*!
  * \ingroup Fluidsystems
@@ -53,10 +52,10 @@ namespace FluidSystems {
  *        components.
  */
 template <class Scalar>
-class H2ON2LiquidPhase
-    : public BaseFluidSystem<Scalar, H2ON2LiquidPhase<Scalar> >
+class H2ON2LiquidPhaseFluidSystem
+    : public BaseFluidSystem<Scalar, H2ON2LiquidPhaseFluidSystem<Scalar> >
 {
-    typedef H2ON2LiquidPhase<Scalar> ThisType;
+    typedef H2ON2LiquidPhaseFluidSystem<Scalar> ThisType;
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
     // convenience typedefs
@@ -368,8 +367,6 @@ public:
         return H2O::liquidHeatCapacity(T, p);
     }
 };
-
-} // namespace FluidSystems
 
 } // namespace Opm
 

--- a/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
@@ -22,7 +22,7 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidSystems::SinglePhase
+ * \copydoc Opm::SinglePhaseFluidSystem
  */
 #ifndef OPM_SINGLE_PHASE_FLUIDSYSTEM_HPP
 #define OPM_SINGLE_PHASE_FLUIDSYSTEM_HPP
@@ -43,7 +43,6 @@
 #include <cassert>
 
 namespace Opm {
-namespace FluidSystems {
 
 /*!
  * \ingroup Fluidsystems
@@ -55,10 +54,10 @@ namespace FluidSystems {
  * Opm::GasPhase<Component> may be used.
  */
 template <class Scalar, class Fluid>
-class SinglePhase
-    : public BaseFluidSystem<Scalar, SinglePhase<Scalar, Fluid> >
+class SinglePhaseFluidSystem
+    : public BaseFluidSystem<Scalar, SinglePhaseFluidSystem<Scalar, Fluid> >
 {
-    typedef SinglePhase<Scalar, Fluid> ThisType;
+    typedef SinglePhaseFluidSystem<Scalar, Fluid> ThisType;
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
 public:
@@ -269,6 +268,6 @@ public:
     }
 };
 
-}} // namespace Opm, FluidSystems
+} // namespace Opm
 
 #endif

--- a/opm/material/fluidsystems/Spe5FluidSystem.hpp
+++ b/opm/material/fluidsystems/Spe5FluidSystem.hpp
@@ -22,7 +22,7 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidSystems::Spe5
+ * \copydoc Opm::Spe5FluidSystem
  */
 #ifndef OPM_SPE5_FLUID_SYSTEM_HPP
 #define OPM_SPE5_FLUID_SYSTEM_HPP
@@ -36,7 +36,7 @@
 #include <opm/material/common/Spline.hpp>
 
 namespace Opm {
-namespace FluidSystems {
+
 /*!
  * \ingroup Fluidsystems
  * \brief The fluid system for the oil, gas and water phases of the
@@ -52,10 +52,10 @@ namespace FluidSystems {
  * Reservoir Simulation, 1987
  */
 template <class Scalar>
-class Spe5
-    : public BaseFluidSystem<Scalar, Spe5<Scalar> >
+class Spe5FluidSystem
+    : public BaseFluidSystem<Scalar, Spe5FluidSystem<Scalar> >
 {
-    typedef Opm::FluidSystems::Spe5<Scalar> ThisType;
+    typedef Opm::Spe5FluidSystem<Scalar> ThisType;
 
     typedef typename Opm::PengRobinsonMixture<Scalar, ThisType> PengRobinsonMixture;
     typedef typename Opm::PengRobinson<Scalar> PengRobinson;
@@ -438,9 +438,8 @@ protected:
 };
 
 template <class Scalar>
-const Scalar Spe5<Scalar>::R = Opm::Constants<Scalar>::R;
+const Scalar Spe5FluidSystem<Scalar>::R = Opm::Constants<Scalar>::R;
 
-} // namespace FluidSystems
 } // namespace Opm
 
 #endif

--- a/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
+++ b/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
@@ -22,7 +22,7 @@
 */
 /*!
  * \file
- * \copydoc Opm::FluidSystems::TwoPhaseImmiscible
+ * \copydoc Opm::TwoPhaseImmiscibleFluidSystem
  */
 #ifndef OPM_TWO_PHASE_IMMISCIBLE_FLUID_SYSTEM_HPP
 #define OPM_TWO_PHASE_IMMISCIBLE_FLUID_SYSTEM_HPP
@@ -38,7 +38,6 @@
 #include "NullParameterCache.hpp"
 
 namespace Opm {
-namespace FluidSystems {
 
 /*!
  * \ingroup Fluidsystems
@@ -54,14 +53,14 @@ namespace FluidSystems {
  * systems without compositional effects.
  */
 template <class Scalar, class WettingPhase, class NonwettingPhase>
-class TwoPhaseImmiscible
-    : public BaseFluidSystem<Scalar, TwoPhaseImmiscible<Scalar, WettingPhase, NonwettingPhase> >
+class TwoPhaseImmiscibleFluidSystem
+    : public BaseFluidSystem<Scalar, TwoPhaseImmiscibleFluidSystem<Scalar, WettingPhase, NonwettingPhase> >
 {
     // do not try to instanciate this class, it has only static members!
-    TwoPhaseImmiscible()
+    TwoPhaseImmiscibleFluidSystem()
     {}
 
-    typedef TwoPhaseImmiscible<Scalar, WettingPhase, NonwettingPhase> ThisType;
+    typedef TwoPhaseImmiscibleFluidSystem<Scalar, WettingPhase, NonwettingPhase> ThisType;
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
 public:
@@ -314,8 +313,6 @@ public:
         return NonwettingPhase::heatCapacity(temperature, pressure);
     }
 };
-
-} // namespace FluidSystems
 
 } // namespace Opm
 

--- a/tests/test_blackoilfluidstate.cpp
+++ b/tests/test_blackoilfluidstate.cpp
@@ -41,7 +41,7 @@ int main()
     {
         typedef double Scalar;
         typedef double Evaluation;
-        typedef typename Opm::FluidSystems::BlackOil<Scalar> FluidSystem;
+        typedef typename Opm::BlackOilFluidSystem<Scalar> FluidSystem;
         typedef Opm::BlackOilFluidState<Scalar, FluidSystem> FluidState;
 
         FluidState fs;
@@ -51,7 +51,7 @@ int main()
     {
         typedef float Scalar;
         typedef float Evaluation;
-        typedef typename Opm::FluidSystems::BlackOil<Scalar> FluidSystem;
+        typedef typename Opm::BlackOilFluidSystem<Scalar> FluidSystem;
         typedef Opm::BlackOilFluidState<Scalar, FluidSystem> FluidState;
 
         FluidState fs;
@@ -61,7 +61,7 @@ int main()
     {
         typedef float Scalar;
         typedef Opm::DenseAd::Evaluation<Scalar, 2> Evaluation;
-        typedef typename Opm::FluidSystems::BlackOil<Scalar> FluidSystem;
+        typedef typename Opm::BlackOilFluidSystem<Scalar> FluidSystem;
         typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
 
         FluidState fs;

--- a/tests/test_eclblackoilfluidsystem.cpp
+++ b/tests/test_eclblackoilfluidsystem.cpp
@@ -615,7 +615,7 @@ inline void testAll()
     // for fluid systems are already tested by the generic test for all fluidsystems.
 
     typedef typename Opm::MathToolbox<Evaluation>::Scalar Scalar;
-    typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
 
     static constexpr int numPhases = FluidSystem::numPhases;
 

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -266,8 +266,8 @@ inline void testAll()
     typedef Opm::LiquidPhase<Scalar, H2O> Liquid;
     typedef Opm::GasPhase<Scalar, N2> Gas;
 
-    typedef Opm::FluidSystems::TwoPhaseImmiscible<Scalar, Liquid, Gas> TwoPFluidSystem;
-    typedef Opm::FluidSystems::BlackOil<Scalar> ThreePFluidSystem;
+    typedef Opm::TwoPhaseImmiscibleFluidSystem<Scalar, Liquid, Gas> TwoPFluidSystem;
+    typedef Opm::BlackOilFluidSystem<Scalar> ThreePFluidSystem;
 
     typedef Opm::TwoPhaseMaterialTraits<Scalar,
                                         TwoPFluidSystem::wettingPhaseIdx,

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -164,7 +164,7 @@ void ensureBlackoilApi()
 template <class Scalar>
 void testAllFluidStates()
 {
-    typedef Opm::FluidSystems::H2ON2<Scalar> FluidSystem;
+    typedef Opm::H2ON2FluidSystem<Scalar> FluidSystem;
 
     // SimpleModularFluidState
     {   Opm::SimpleModularFluidState<Scalar,
@@ -233,7 +233,7 @@ void testAllFluidSystems()
 
     // black-oil
     {
-        typedef Opm::FluidSystems::BlackOil<Scalar> FluidSystem;
+        typedef Opm::BlackOilFluidSystem<Scalar> FluidSystem;
         if (false) checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>();
 
         typedef Opm::DenseAd::Evaluation<Scalar, 1> BlackoilDummyEval;
@@ -242,45 +242,45 @@ void testAllFluidSystems()
     }
 
     // Brine -- CO2
-    {   typedef Opm::FluidSystems::BrineCO2<Scalar, Opm::FluidSystemsTest::CO2Tables> FluidSystem;
+    {   typedef Opm::BrineCO2FluidSystem<Scalar, Opm::FluidSystemsTest::CO2Tables> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- N2
-    {   typedef Opm::FluidSystems::H2ON2<Scalar> FluidSystem;
+    {   typedef Opm::H2ON2FluidSystem<Scalar> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- N2 -- liquid phase
-    {   typedef Opm::FluidSystems::H2ON2LiquidPhase<Scalar> FluidSystem;
+    {   typedef Opm::H2ON2LiquidPhaseFluidSystem<Scalar> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- Air
     {   typedef Opm::SimpleH2O<Scalar> H2O;
-        typedef Opm::FluidSystems::H2OAir<Scalar, H2O> FluidSystem;
+        typedef Opm::H2OAirFluidSystem<Scalar, H2O> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- Air -- Mesitylene
-    {   typedef Opm::FluidSystems::H2OAirMesitylene<Scalar> FluidSystem;
+    {   typedef Opm::H2OAirMesityleneFluidSystem<Scalar> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- Air -- Xylene
-    {   typedef Opm::FluidSystems::H2OAirXylene<Scalar> FluidSystem;
+    {   typedef Opm::H2OAirXyleneFluidSystem<Scalar> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // 2p-immiscible
-    {   typedef Opm::FluidSystems::TwoPhaseImmiscible<Scalar, Liquid, Liquid> FluidSystem;
+    {   typedef Opm::TwoPhaseImmiscibleFluidSystem<Scalar, Liquid, Liquid> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
-    {   typedef Opm::FluidSystems::TwoPhaseImmiscible<Scalar, Liquid, Gas> FluidSystem;
+    {   typedef Opm::TwoPhaseImmiscibleFluidSystem<Scalar, Liquid, Gas> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
-    {  typedef Opm::FluidSystems::TwoPhaseImmiscible<Scalar, Gas, Liquid> FluidSystem;
+    {  typedef Opm::TwoPhaseImmiscibleFluidSystem<Scalar, Gas, Liquid> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // 1p
-    {   typedef Opm::FluidSystems::SinglePhase<Scalar, Liquid> FluidSystem;
+    {   typedef Opm::SinglePhaseFluidSystem<Scalar, Liquid> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
-    {   typedef Opm::FluidSystems::SinglePhase<Scalar, Gas> FluidSystem;
+    {   typedef Opm::SinglePhaseFluidSystem<Scalar, Gas> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 }
 

--- a/tests/test_immiscibleflash.cpp
+++ b/tests/test_immiscibleflash.cpp
@@ -165,7 +165,7 @@ void completeReferenceFluidState(FluidState& fs,
 template <class Scalar>
 inline void testAll()
 {
-    typedef Opm::FluidSystems::H2ON2<Scalar> FluidSystem;
+    typedef Opm::H2ON2FluidSystem<Scalar> FluidSystem;
     typedef Opm::ImmiscibleFluidState<Scalar, FluidSystem> ImmiscibleFluidState;
 
     enum { numPhases = FluidSystem::numPhases };

--- a/tests/test_ncpflash.cpp
+++ b/tests/test_ncpflash.cpp
@@ -167,7 +167,7 @@ void completeReferenceFluidState(FluidState& fs,
 template <class Scalar>
 inline void testAll()
 {
-    typedef Opm::FluidSystems::H2ON2<Scalar> FluidSystem;
+    typedef Opm::H2ON2FluidSystem<Scalar> FluidSystem;
     typedef Opm::CompositionalFluidState<Scalar, FluidSystem> CompositionalFluidState;
 
     enum { numPhases = FluidSystem::numPhases };

--- a/tests/test_pengrobinson.cpp
+++ b/tests/test_pengrobinson.cpp
@@ -292,7 +292,7 @@ void printResult(const RawTable& rawTable,
 template <class Scalar>
 inline void testAll()
 {
-    typedef Opm::FluidSystems::Spe5<Scalar> FluidSystem;
+    typedef Opm::Spe5FluidSystem<Scalar> FluidSystem;
 
     enum {
         numPhases = FluidSystem::numPhases,


### PR DESCRIPTION
this has mildly annoyed me for quite some time, and finally managed to bring myself to changing it: The Opm::FluidSystems namespace is pretty useless because the number of classes contained within it is quite small and mismatch between the naming convention of the file names the actual classes is somewhat confusing IMO. Thus, this patch changes the naming of fluid systems from `Opm::FluidSystems::Foo` to`Opm::FooFluidSystem`.

(also, flat hierarchies currently seem to be popular with the cool people!?)

this patch requires some simple mop-ups for `ewoms` and `opm-simulators`.