### PR TITLE
fix some GCC 8 warnings

### DIFF
--- a/opm/material/constraintsolvers/CompositionFromFugacities.hpp
+++ b/opm/material/constraintsolvers/CompositionFromFugacities.hpp
@@ -130,7 +130,7 @@ public:
             // Solve J*x = b
             x = 0.0;
             try { J.solve(x, b); }
-            catch (Dune::FMatrixError e)
+            catch (const Dune::FMatrixError& e)
             { throw Opm::NumericalIssue(e.what()); }
 
             //std::cout << "original delta: " << x << "\n";

--- a/opm/material/constraintsolvers/ImmiscibleFlash.hpp
+++ b/opm/material/constraintsolvers/ImmiscibleFlash.hpp
@@ -202,7 +202,7 @@ public:
             deltaX = 0;
 
             try { J.solve(deltaX, b); }
-            catch (Dune::FMatrixError e) {
+            catch (const Dune::FMatrixError& e) {
                 throw Opm::NumericalIssue(e.what());
             }
             Valgrind::CheckDefined(deltaX);


### PR DESCRIPTION
the warnings about catching a polymorphic type by value. I agree that this should not be done.