### PR TITLE
Mixing energy

### DIFF
--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -322,9 +322,11 @@ public:
      */
     Scalar internalEnergy(unsigned phaseIdx OPM_UNUSED) const
     {
-        //double ent_fac=0.0;
-        double ent_fac=1.0;
-        return (*enthalpy_)[phaseIdx] - ent_fac*pressure(phaseIdx)/density(phaseIdx);
+        //double entFac=0.0;
+        double entFac=1.0;
+        // this may be setting which for entFac =1 make this probably E100 compatible
+        // however this has to be consitent with call to enthalpy
+        return (*enthalpy_)[phaseIdx] - entFac*pressure(phaseIdx)/density(phaseIdx);
     }
 
     //////

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -1030,13 +1030,9 @@ public:
         assert(0 <= regionIdx && regionIdx <= numRegions());
 
         const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        //const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        //double ent_fac=0;
-        double ent_fac = 1.0;
+        double entFac = 1.0;
         return energy<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx)
-                + ent_fac*p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
-
-        //return energy;
+                + entFac*p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
     }
 
     /*!


### PR DESCRIPTION
Modifications to make energy module for black oil to not only gennerate termperature due to the entalpy/work term. This is physical since we assume the energy density only depend on temperature. It is introduced energy density on each phase depending on the phases. 