### PR TITLE
black oil PVT: make the maximum oil saturation a evaluation

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -144,14 +144,14 @@ public:
         void setRegionIndex(unsigned val)
         { regionIdx_ = val; }
 
-        const Scalar maxOilSat() const
+        const Evaluation& maxOilSat() const
         { return maxOilSat_; }
 
-        void setMaxOilSat(Scalar val)
+        void setMaxOilSat(const Evaluation& val)
         { maxOilSat_ = val; }
 
     private:
-        Scalar maxOilSat_;
+        Evaluation maxOilSat_;
         unsigned regionIdx_;
     };
 
@@ -1000,7 +1000,7 @@ public:
     static LhsEval saturatedDissolutionFactor(const FluidState& fluidState,
                                               unsigned phaseIdx,
                                               unsigned regionIdx,
-                                              Scalar maxOilSaturation)
+                                              const LhsEval& maxOilSaturation)
     {
         assert(0 <= phaseIdx && phaseIdx <= numPhases);
         assert(0 <= regionIdx && regionIdx <= numRegions());

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -250,7 +250,7 @@ public:
                                              const Evaluation& /*temperature*/,
                                              const Evaluation& /*pressure*/,
                                              const Evaluation& /*oilSaturation*/,
-                                             Scalar /*maxOilSaturation*/) const
+                                             const Evaluation& /*maxOilSaturation*/) const
     { return 0.0; /* this is dead oil! */ }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -239,7 +239,7 @@ public:
                                              const Evaluation& /*temperature*/,
                                              const Evaluation& /*pressure*/,
                                              const Evaluation& /*oilSaturation*/,
-                                             Scalar /*maxOilSaturation*/) const
+                                             const Evaluation& /*maxOilSaturation*/) const
     { return 0.0; /* this is dead oil! */ }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -266,7 +266,7 @@ public:
                                               const Evaluation& /*temperature*/,
                                               const Evaluation& /*pressure*/,
                                               const Evaluation& /*oilSaturation*/,
-                                              Scalar /*maxOilSaturation*/) const
+                                              const Evaluation& /*maxOilSaturation*/) const
     { return 0.0; /* this is dry gas! */ }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -228,7 +228,7 @@ public:
                                               const Evaluation& temperature,
                                               const Evaluation& pressure,
                                               const Evaluation& oilSaturation,
-                                              Scalar maxOilSaturation) const
+                                              const Evaluation& maxOilSaturation) const
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilVaporizationFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation)); return 0; }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -328,7 +328,7 @@ public:
                                               const Evaluation& temperature,
                                               const Evaluation& pressure,
                                               const Evaluation& oilSaturation,
-                                              Scalar maxOilSaturation) const
+                                              const Evaluation& maxOilSaturation) const
     { return isothermalPvt_->saturatedOilVaporizationFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation); }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -28,8 +28,8 @@
 #define OPM_LIVE_OIL_PVT_HPP
 
 #include <opm/material/Constants.hpp>
-
 #include <opm/material/common/OpmFinal.hpp>
+#include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/UniformXTabulated2DFunction.hpp>
 #include <opm/material/common/Tabulated1DFunction.hpp>
 
@@ -500,14 +500,14 @@ public:
                                              const Evaluation& /*temperature*/,
                                              const Evaluation& pressure,
                                              const Evaluation& oilSaturation,
-                                             Scalar maxOilSaturation) const
+                                             Evaluation maxOilSaturation) const
     {
         Evaluation tmp =
             saturatedGasDissolutionFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true);
 
         // apply the vaporization parameters for the gas phase (cf. the Eclipse VAPPARS
         // keyword)
-        maxOilSaturation = std::min(maxOilSaturation, Scalar(1.0));
+        maxOilSaturation = Opm::min(maxOilSaturation, Scalar(1.0));
         if (vapPar2_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
             static const Scalar eps = 0.001;
             const Evaluation& So = Opm::max(oilSaturation, eps);

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -215,7 +215,7 @@ public:
                                              const Evaluation& temperature,
                                              const Evaluation& pressure,
                                              const Evaluation& oilSaturation,
-                                             Scalar maxOilSaturation) const
+                                             const Evaluation& maxOilSaturation) const
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasDissolutionFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation)); return 0; }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -335,7 +335,7 @@ public:
                                              const Evaluation& temperature,
                                              const Evaluation& pressure,
                                              const Evaluation& oilSaturation,
-                                             Scalar maxOilSaturation) const
+                                             const Evaluation& maxOilSaturation) const
     { return isothermalPvt_->saturatedGasDissolutionFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation); }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -28,6 +28,7 @@
 #define OPM_WET_GAS_PVT_HPP
 
 #include <opm/material/Constants.hpp>
+#include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/OpmFinal.hpp>
 #include <opm/material/common/UniformXTabulated2DFunction.hpp>
 #include <opm/material/common/Tabulated1DFunction.hpp>
@@ -520,14 +521,14 @@ public:
                                               const Evaluation& /*temperature*/,
                                               const Evaluation& pressure,
                                               const Evaluation& oilSaturation,
-                                              Scalar maxOilSaturation) const
+                                              Evaluation maxOilSaturation) const
     {
         Evaluation tmp =
             saturatedOilVaporizationFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true);
 
         // apply the vaporization parameters for the gas phase (cf. the Eclipse VAPPARS
         // keyword)
-        maxOilSaturation = std::min(maxOilSaturation, Scalar(1.0));
+        maxOilSaturation = Opm::min(maxOilSaturation, Scalar(1.0));
         if (vapPar1_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
             static const Scalar eps = 0.001;
             const Evaluation& So = Opm::max(oilSaturation, eps);

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -132,8 +132,6 @@ static const char* deckString1 =
 template <class Evaluation, class OilPvt, class GasPvt, class WaterPvt>
 void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& waterPvt)
 {
-    typedef typename Opm::MathToolbox<Evaluation> Toolbox;
-
     // we don't want to run this, we just want to make sure that it compiles
     while (0) {
         Evaluation temperature = 273.15 + 20.0;
@@ -141,7 +139,7 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         Evaluation Rs = 0.0;
         Evaluation Rv = 0.0;
         Evaluation So = 0.5;
-        typename Toolbox::Scalar maxSo = 1.0;
+        Evaluation maxSo = 1.0;
         Evaluation tmp;
 
         /////


### PR DESCRIPTION
the maximum oil saturation *can* depend on the most current solution, so it needs to include derivatives. Note that this fix should not change the converged solution, only the convergence behaviour, i.e., if changes in the results are encountered, these are likely only numerical noise.
