### PR TITLE
simplify the implementation of VAPPARS

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -500,19 +500,15 @@ public:
                                              const Evaluation& /*temperature*/,
                                              const Evaluation& pressure,
                                              const Evaluation& oilSaturation,
-                                             Evaluation maxOilSaturation) const
+                                             const Evaluation& maxOilSaturation) const
     {
         Evaluation tmp =
             saturatedGasDissolutionFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true);
 
         // apply the vaporization parameters for the gas phase (cf. the Eclipse VAPPARS
         // keyword)
-        maxOilSaturation = Opm::min(maxOilSaturation, Scalar(1.0));
-        if (vapPar2_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
-            static const Scalar eps = 0.001;
-            const Evaluation& So = Opm::max(oilSaturation, eps);
-            tmp *= Opm::max(1e-3, Opm::pow(So/maxOilSaturation, vapPar2_));
-        }
+        if (vapPar2_ > 0.0 && oilSaturation < maxOilSaturation)
+            tmp *= Opm::max(1e-3, Opm::pow(oilSaturation/maxOilSaturation, vapPar2_));
 
         return tmp;
     }

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -521,19 +521,15 @@ public:
                                               const Evaluation& /*temperature*/,
                                               const Evaluation& pressure,
                                               const Evaluation& oilSaturation,
-                                              Evaluation maxOilSaturation) const
+                                              const Evaluation& maxOilSaturation) const
     {
         Evaluation tmp =
             saturatedOilVaporizationFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true);
 
         // apply the vaporization parameters for the gas phase (cf. the Eclipse VAPPARS
         // keyword)
-        maxOilSaturation = Opm::min(maxOilSaturation, Scalar(1.0));
-        if (vapPar1_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
-            static const Scalar eps = 0.001;
-            const Evaluation& So = Opm::max(oilSaturation, eps);
-            tmp *= Opm::max(1e-3, Opm::pow(So/maxOilSaturation, vapPar1_));
-        }
+        if (oilSaturation < maxOilSaturation)
+            tmp *= Opm::max(1e-3, Opm::pow(oilSaturation/maxOilSaturation, vapPar1_));
 
         return tmp;
     }


### PR DESCRIPTION
besides making this code quite a bit less convoluted, `ebos` is approximately 10% faster on Norne while producing indistinguishable results.