### PR TITLE
fill value zero for Evaluation(int numDerivatives) of DynamicEvaluation

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -216,7 +216,7 @@ public:
 {% if numDerivs < 0 %}\
     // create a "blank" dynamic evaluation
     explicit Evaluation(int numDerivatives)
-        : data_(1 + numDerivatives)
+        : data_(1 + numDerivatives, 0.0)
     {}
 
     // create a dynamic evaluation which represents a constant function

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -115,7 +115,7 @@ public:
 
     // create a "blank" dynamic evaluation
     explicit Evaluation(int numDerivatives)
-        : data_(1 + numDerivatives)
+        : data_(1 + numDerivatives, 0.0)
     {}
 
     // create a dynamic evaluation which represents a constant function


### PR DESCRIPTION
otherwise, we get some small non-zero values there.

it causes the failure of polymer case for https://github.com/OPM/opm-simulators/pull/1760