### PR TITLE
adding createConstantOne and createConstantZero to Evaluations

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -310,6 +310,24 @@ public:
     { return Evaluation(); }
 {% endif %}\
 
+    // create an Evaluation with value and all the derivatives to be zero
+{% if numDerivs < 0 %}\
+    static Evaluation createConstantZero(const Evaluation& x)
+    { return Evaluation(x.size(), 0.0); }
+{% else %}\
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+{% endif %}\
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+{% if numDerivs < 0 %}\
+    static Evaluation createConstantOne(const Evaluation& x)
+    { return Evaluation(x.size(), 1.); }
+{% else %}\
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+{% endif %}\
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
 {% if numDerivs < 0 %}\
     template <class RhsValueType>

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -168,6 +168,14 @@ public:
     static Evaluation createBlank(const Evaluation& x)
     { return Evaluation(x.size()); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x)
+    { return Evaluation(x.size(), 0.0); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x)
+    { return Evaluation(x.size(), 1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation.hpp
+++ b/opm/material/densead/Evaluation.hpp
@@ -153,6 +153,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation1.hpp
+++ b/opm/material/densead/Evaluation1.hpp
@@ -144,6 +144,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation10.hpp
+++ b/opm/material/densead/Evaluation10.hpp
@@ -153,6 +153,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation11.hpp
+++ b/opm/material/densead/Evaluation11.hpp
@@ -154,6 +154,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation12.hpp
+++ b/opm/material/densead/Evaluation12.hpp
@@ -155,6 +155,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation2.hpp
+++ b/opm/material/densead/Evaluation2.hpp
@@ -145,6 +145,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation3.hpp
+++ b/opm/material/densead/Evaluation3.hpp
@@ -146,6 +146,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation4.hpp
+++ b/opm/material/densead/Evaluation4.hpp
@@ -147,6 +147,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation5.hpp
+++ b/opm/material/densead/Evaluation5.hpp
@@ -148,6 +148,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation6.hpp
+++ b/opm/material/densead/Evaluation6.hpp
@@ -149,6 +149,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation7.hpp
+++ b/opm/material/densead/Evaluation7.hpp
@@ -150,6 +150,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation8.hpp
+++ b/opm/material/densead/Evaluation8.hpp
@@ -151,6 +151,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Evaluation9.hpp
+++ b/opm/material/densead/Evaluation9.hpp
@@ -152,6 +152,14 @@ public:
     static Evaluation createBlank(const Evaluation& x OPM_UNUSED)
     { return Evaluation(); }
 
+    // create an Evaluation with value and all the derivatives to be zero
+    static Evaluation createConstantZero(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(0.); }
+
+    // create an Evaluation with value to be one and all the derivatives to be zero
+    static Evaluation createConstantOne(const Evaluation& x OPM_UNUSED)
+    { return Evaluation(1.); }
+
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)

--- a/opm/material/densead/Math.hpp
+++ b/opm/material/densead/Math.hpp
@@ -440,6 +440,12 @@ public:
     static Evaluation createBlank(const Evaluation& x)
     { return Evaluation::createBlank(x); }
 
+    static Evaluation createConstantZero(const Evaluation& x)
+    { return Evaluation::createConstantZero(x); }
+
+    static Evaluation createConstantOne(const Evaluation& x)
+    { return Evaluation::createConstantOne(x); }
+
     static Evaluation createConstant(ValueType value)
     { return Evaluation::createConstant(value); }
 


### PR DESCRIPTION
following the discussion from https://github.com/OPM/opm-material/pull/338 . 

`createConstantOne()` and `createConstantZero()` are introduced to create more well defined behavoir than `createBlank()`. 