### PR TITLE
unify the creation of evalutions

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -412,7 +412,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -313,15 +313,50 @@ public:
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
 {% if numDerivs < 0 %}\
     template <class RhsValueType>
+    static Evaluation createVariable(const RhsValueType& value OPM_UNUSED, int varPos OPM_UNUSED)
+    {
+        throw std::logic_error("Dynamically sized evaluations require that the number of "
+                               "derivatives is specified when creating an evaluation");
+    }
+
+    template <class RhsValueType>
     static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
         return Evaluation(nVars, value, varPos);
     }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(x.size(), value, varPos);
+    }
 {% else %}\
     template <class RhsValueType>
     static Evaluation createVariable(const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != {{numDerivs}})
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with {{numDerivs}} derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -338,11 +373,46 @@ public:
     {
         return Evaluation(nVars, value);
     }
-{% else %}\
+
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        throw std::logic_error("Dynamically-sized evaluation objects require to specify the number of derivatives.");
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    {
+        return Evaluation(x.size(), value);
+    }
+{% else %}\
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != {{numDerivs}})
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with {{numDerivs}} derivatives");
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/common/MathToolbox.hpp
+++ b/opm/material/common/MathToolbox.hpp
@@ -113,14 +113,51 @@ public:
     { return value; }
 
     /*!
+     * \brief Given a scalar value, return an evaluation of a constant function that
+     *        features a given number of derivatives
+     *
+     * For this toolbox, an evaluation is the value, so this method is the identity
+     * function. In general, this returns an evaluation object for which all derivatives
+     * are zero.
+     */
+    static Scalar createConstant(unsigned numDerivatives, Scalar value)
+    {
+        if (numDerivatives != 0)
+            throw std::logic_error("Plain floating point objects cannot represent any derivatives");
+        return value;
+    }
+
+    /*!
+     * \brief Given a scalar value, return an evaluation of a constant function that is
+     *        compatible to a "template" variable.
+     *
+     * For this toolbox, an evaluation is the value, so this method is the identity
+     * function. In general, this returns an evaluation object for which all derivatives
+     * are zero.
+     */
+    static Scalar createConstant(Scalar x OPM_UNUSED, Scalar value)
+    { return value; }
+
+    /*!
      * \brief Given a scalar value, return an evaluation of a linear function.
      *
      * i.e., Create an evaluation which represents f(x) = x and the derivatives with
      * regard to x. For scalars (which do not consider derivatives), this method does
      * nothing.
      */
-    static Scalar createVariable(Scalar value, unsigned /*varIdx*/)
-    { return value; }
+    static Scalar createVariable(Scalar value OPM_UNUSED, unsigned varIdx OPM_UNUSED)
+    { throw std::logic_error("Plain floating point objects cannot represent variables"); }
+
+    /*!
+     * \brief Given a scalar value, return an evaluation of a linear function that is
+     *        compatible with a "template" evaluation.
+     *
+     * i.e., Create an evaluation which represents f(x) = x and the derivatives with
+     * regard to x. For scalars (which do not consider derivatives), this method does
+     * nothing.
+     */
+    static Scalar createVariable(Scalar x OPM_UNUSED, Scalar value OPM_UNUSED, unsigned varIdx OPM_UNUSED)
+    { throw std::logic_error("Plain floating point objects cannot represent variables"); }
 
     /*!
      * \brief Given a function evaluation, constrain it to its value (if necessary).
@@ -248,6 +285,22 @@ Evaluation blank(const Evaluation& x)
 template <class Evaluation, class Scalar>
 Evaluation constant(const Scalar& value)
 { return Opm::MathToolbox<Evaluation>::createConstant(value); }
+
+template <class Evaluation, class Scalar>
+Evaluation constant(unsigned numDeriv, const Scalar& value)
+{ return Opm::MathToolbox<Evaluation>::createConstant(numDeriv, value); }
+
+template <class Evaluation, class Scalar>
+Evaluation constant(const Evaluation& x, const Scalar& value)
+{ return Opm::MathToolbox<Evaluation>::createConstant(x, value); }
+
+template <class Evaluation, class Scalar>
+Evaluation variable(unsigned numDeriv, const Scalar& value, unsigned idx)
+{ return Opm::MathToolbox<Evaluation>::createVariable(numDeriv, value, idx); }
+
+template <class Evaluation, class Scalar>
+Evaluation variable(const Evaluation& x, const Scalar& value, unsigned idx)
+{ return Opm::MathToolbox<Evaluation>::createVariable(x, value, idx); }
 
 template <class Evaluation, class Scalar>
 Evaluation variable(const Scalar& value, unsigned idx)

--- a/opm/material/common/MathToolbox.hpp
+++ b/opm/material/common/MathToolbox.hpp
@@ -37,6 +37,7 @@
 #include <cmath>
 #include <algorithm>
 #include <type_traits>
+#include <stdexcept>
 
 namespace Opm {
 /*

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -170,11 +170,26 @@ public:
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
+    static Evaluation createVariable(const RhsValueType& value OPM_UNUSED, int varPos OPM_UNUSED)
+    {
+        throw std::logic_error("Dynamically sized evaluations require that the number of "
+                               "derivatives is specified when creating an evaluation");
+    }
+
+    template <class RhsValueType>
     static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
         return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(x.size(), value, varPos);
     }
 
 
@@ -184,6 +199,22 @@ public:
     static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         return Evaluation(nVars, value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const RhsValueType& value)
+    {
+        throw std::logic_error("Dynamically-sized evaluation objects require to specify the number of derivatives.");
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    {
+        return Evaluation(x.size(), value);
     }
 
     // print the value and the derivatives of the function evaluation

--- a/opm/material/densead/Evaluation.hpp
+++ b/opm/material/densead/Evaluation.hpp
@@ -205,7 +205,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation.hpp
+++ b/opm/material/densead/Evaluation.hpp
@@ -162,11 +162,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 0)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 0 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 0)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 0 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation1.hpp
+++ b/opm/material/densead/Evaluation1.hpp
@@ -196,7 +196,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation1.hpp
+++ b/opm/material/densead/Evaluation1.hpp
@@ -153,11 +153,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 1)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 1 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 1)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 1 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation10.hpp
+++ b/opm/material/densead/Evaluation10.hpp
@@ -205,7 +205,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation10.hpp
+++ b/opm/material/densead/Evaluation10.hpp
@@ -162,11 +162,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 10)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 10 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 10)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 10 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation11.hpp
+++ b/opm/material/densead/Evaluation11.hpp
@@ -206,7 +206,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation11.hpp
+++ b/opm/material/densead/Evaluation11.hpp
@@ -163,11 +163,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 11)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 11 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 11)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 11 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation12.hpp
+++ b/opm/material/densead/Evaluation12.hpp
@@ -164,11 +164,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 12)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 12 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 12)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 12 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation12.hpp
+++ b/opm/material/densead/Evaluation12.hpp
@@ -207,7 +207,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation2.hpp
+++ b/opm/material/densead/Evaluation2.hpp
@@ -197,7 +197,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation2.hpp
+++ b/opm/material/densead/Evaluation2.hpp
@@ -154,11 +154,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 2)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 2 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 2)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 2 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation3.hpp
+++ b/opm/material/densead/Evaluation3.hpp
@@ -155,11 +155,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 3)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 3 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 3)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 3 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation3.hpp
+++ b/opm/material/densead/Evaluation3.hpp
@@ -198,7 +198,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation4.hpp
+++ b/opm/material/densead/Evaluation4.hpp
@@ -156,11 +156,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 4)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 4 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 4)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 4 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation4.hpp
+++ b/opm/material/densead/Evaluation4.hpp
@@ -199,7 +199,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation5.hpp
+++ b/opm/material/densead/Evaluation5.hpp
@@ -200,7 +200,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation5.hpp
+++ b/opm/material/densead/Evaluation5.hpp
@@ -157,11 +157,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 5)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 5 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 5)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 5 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation6.hpp
+++ b/opm/material/densead/Evaluation6.hpp
@@ -201,7 +201,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation6.hpp
+++ b/opm/material/densead/Evaluation6.hpp
@@ -158,11 +158,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 6)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 6 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 6)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 6 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation7.hpp
+++ b/opm/material/densead/Evaluation7.hpp
@@ -202,7 +202,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation7.hpp
+++ b/opm/material/densead/Evaluation7.hpp
@@ -159,11 +159,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 7)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 7 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 7)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 7 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation8.hpp
+++ b/opm/material/densead/Evaluation8.hpp
@@ -203,7 +203,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation8.hpp
+++ b/opm/material/densead/Evaluation8.hpp
@@ -160,11 +160,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 8)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 8 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 8)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 8 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation9.hpp
+++ b/opm/material/densead/Evaluation9.hpp
@@ -161,11 +161,50 @@ public:
         return Evaluation(value, varPos);
     }
 
+    template <class RhsValueType>
+    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    {
+        if (nVars != 9)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 9 derivatives");
+
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(nVars, value, varPos);
+    }
+
+    template <class RhsValueType>
+    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    {
+        // copy function value and set all derivatives to 0, except for the variable
+        // which is represented by the value (which is set to 1.0)
+        return Evaluation(value, varPos);
+    }
+
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    {
+        if (nVars != 9)
+            throw std::logic_error("This statically-sized evaluation can only represent objects"
+                                   " with 9 derivatives");
+        return Evaluation(value);
+    }
 
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
     static Evaluation createConstant(const RhsValueType& value)
+    {
+        return Evaluation(value);
+    }
+
+    // "evaluate" a constant function (i.e. a function that does not depend on the set of
+    // relevant variables, f(x) = c).
+    template <class RhsValueType>
+    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Evaluation9.hpp
+++ b/opm/material/densead/Evaluation9.hpp
@@ -204,7 +204,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    static Evaluation createConstant(const Evaluation& x OPM_UNUSED, const RhsValueType& value)
     {
         return Evaluation(value);
     }

--- a/opm/material/densead/Math.hpp
+++ b/opm/material/densead/Math.hpp
@@ -443,6 +443,12 @@ public:
     static Evaluation createConstant(ValueType value)
     { return Evaluation::createConstant(value); }
 
+    static Evaluation createConstant(unsigned numDeriv, const ValueType value)
+    { return Evaluation::createConstant(numDeriv, value); }
+
+    static Evaluation createConstant(const Evaluation& x, const ValueType value)
+    { return Evaluation::createConstant(x, value); }
+
     static Evaluation createVariable(ValueType value, int varIdx)
     { return Evaluation::createVariable(value, varIdx); }
 


### PR DESCRIPTION
This is a IMO better solution for the problem which #339 aims to fix: To create a constant, there are now always the three functions

```
Opm::constant<Eval>(value);
Opm::constant<Eval>(numDeriv, value);
Opm::constant<Eval>(x, value); // with 'x' being the 'template' of the returned value
```

If a given call does not make sense, an exception is thrown:

- Plain floating point objects like `float`, `double` or `quad`  complain if the specified number of derivatives is not zero.
- Statically sized evaluations throw if the specified number of derivatives of passed to the function is not equal to their static size.
- Dynamically sized evaluations complain if the number of derivatives cannot be determined.

The third variant of `Opm::constant()` works unconditionally. The `Opm::variable()` helpers are modified analogously.