### PR TITLE
Enable onephase

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -448,10 +448,11 @@ private:
             + (oilEnabled?1:0)
             + (waterEnabled?1:0);
 
-        if (numEnabled < 2)
-            throw std::runtime_error("At least two fluid phases must be enabled. (Is: "+std::to_string(numEnabled)+")");
-
-        if (numEnabled == 2) {
+        if (numEnabled == 0) {
+            throw std::runtime_error("At least one fluid phase must be enabled. (Is: "+std::to_string(numEnabled)+")");
+        } else if (numEnabled == 1) {
+            threePhaseApproach_ = Opm::EclMultiplexerApproach::EclOnePhaseApproach;
+        } else if ( numEnabled == 2) {
             threePhaseApproach_ = Opm::EclTwoPhaseApproach;
             if (!gasEnabled)
                 twoPhaseApproach_ = Opm::EclTwoPhaseOilWater;
@@ -1049,6 +1050,11 @@ private:
             realParams.setOilWaterParams(oilWaterParams);
             realParams.setApproach(twoPhaseApproach_);
             realParams.finalize();
+            break;
+        }
+
+        case EclOnePhaseApproach: {
+            // Nothing to do, no parameters.
             break;
         }
         }

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -155,6 +155,10 @@ public:
                                                  params.template getRealParams<EclTwoPhaseApproach>(),
                                                  fluidState);
             break;
+
+        case EclOnePhaseApproach:
+            values[0] = 0.0;
+            break;
         }
     }
 
@@ -187,6 +191,10 @@ public:
         case EclTwoPhaseApproach:
             TwoPhaseMaterial::oilWaterHysteresisParams(pcSwMdc, krnSwMdc,
                                      params.template getRealParams<EclTwoPhaseApproach>());
+            break;
+
+        case EclOnePhaseApproach:
+            // Do nothing.
             break;
         }
     }
@@ -221,6 +229,10 @@ public:
             TwoPhaseMaterial::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc,
                                      params.template getRealParams<EclTwoPhaseApproach>());
             break;
+
+        case EclOnePhaseApproach:
+            // Do nothing.
+            break;
         }
     }
 
@@ -254,6 +266,10 @@ public:
             TwoPhaseMaterial::gasOilHysteresisParams(pcSwMdc, krnSwMdc,
                                      params.template getRealParams<EclTwoPhaseApproach>());
             break;
+
+        case EclOnePhaseApproach:
+            // Do nothing.
+            break;
         }
     }
 
@@ -286,6 +302,10 @@ public:
         case EclTwoPhaseApproach:
             TwoPhaseMaterial::setGasOilHysteresisParams(pcSwMdc, krnSwMdc,
                                      params.template getRealParams<EclTwoPhaseApproach>());
+            break;
+
+        case EclOnePhaseApproach:
+            // Do nothing.
             break;
         }
     }
@@ -407,7 +427,16 @@ public:
                                                      params.template getRealParams<EclTwoPhaseApproach>(),
                                                      fluidState);
             break;
+
+        case EclOnePhaseApproach:
+            values[0] = 1.0;
+            break;
+
+        default:
+            throw std::logic_error("Not implemented: relativePermeabilities() option for unknown EclMultiplexerApproach (="
+                                   + std::to_string(params.approach()) + ")");
         }
+        
     }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -44,7 +44,8 @@ enum EclMultiplexerApproach {
     EclDefaultApproach,
     EclStone1Approach,
     EclStone2Approach,
-    EclTwoPhaseApproach
+    EclTwoPhaseApproach,
+    EclOnePhaseApproach
 };
 
 /*!
@@ -124,6 +125,10 @@ public:
 
         case EclTwoPhaseApproach:
             realParams_ = ParamPointerType(new TwoPhaseParams, Deleter< TwoPhaseParams > () );
+            break;
+
+        case EclOnePhaseApproach:
+            // Do nothing, no parameters.
             break;
         }
     }

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -199,7 +199,7 @@ public:
         setReservoirTemperature(eclState.getTableManager().rtemp());
 
         // this fluidsystem only supports two or three phases
-        assert(numActivePhases_ >= 2 && numActivePhases_ <= 3);
+        assert(numActivePhases_ >= 1 && numActivePhases_ <= 3);
 
         setEnableDissolvedGas(deck.hasKeyword("DISGAS"));
         setEnableVaporizedOil(deck.hasKeyword("VAPOIL"));

--- a/opm/material/thermal/EclThconrLaw.hpp
+++ b/opm/material/thermal/EclThconrLaw.hpp
@@ -57,11 +57,14 @@ public:
     {
         // THCONR + THCONSF approach.
         Scalar lambdaRef = params.referenceTotalThermalConductivity();
-        Scalar alpha = params.dTotalThermalConductivity_dSg();
-
         static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
-        const Evaluation& Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
-        return lambdaRef*(1.0 - alpha*Sg);
+        if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+            Scalar alpha = params.dTotalThermalConductivity_dSg();
+            const Evaluation& Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+            return lambdaRef*(1.0 - alpha*Sg);
+        } else {
+            return lambdaRef;
+        }
     }
 };
 } // namespace Opm


### PR DESCRIPTION
This builds on and replaces #336. Essentially it takes into account what my review comments would have been.

The changes I have made compared to #336 are:
 - Fix whitespace nitpicks.
 - Improve an exception message.
 - Add switch cases for EclOnePhaseApproach to silence compiler warnings, thereby making explicit the "for one-phase, do nothing" cases.

For the thermalConductivity() function I think the proposed fix is fine, it calls no methods not already called and is a simple improvement, so I think any larger refactoring of that is out of scope for this.

With that, I think this should be ready to merge when green. 