### PR TITLE
added: OPM_UNUSED_NOMPI

### DIFF
--- a/opm/material/common/Unused.hpp
+++ b/opm/material/common/Unused.hpp
@@ -40,4 +40,10 @@
 #define OPM_OPTIM_UNUSED
 #endif
 
+#ifdef HAVE_MPI
+#define OPM_UNUSED_NOMPI
+#else
+#define OPM_UNUSED_NOMPI OPM_UNUSED
+#endif
+
 #endif


### PR DESCRIPTION
for suppressing unused variable warnings when a variable
is unused if compiled without MPI