### PR TITLE
Silence unused argument warning for DynamicEvaluation.

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -395,7 +395,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    static Evaluation createConstant(const RhsValueType& value OPM_UNUSED)
     {
         throw std::logic_error("Dynamically-sized evaluation objects require to specify the number of derivatives.");
     }

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -212,7 +212,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    static Evaluation createConstant(const RhsValueType& value OPM_UNUSED)
     {
         throw std::logic_error("Dynamically-sized evaluation objects require to specify the number of derivatives.");
     }


### PR DESCRIPTION
I consider this trivial enough to self-merge when green.