### PR TITLE
Use active vectors

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
@@ -50,7 +50,7 @@
 #include <iostream>
 #include <cassert>
 #include <algorithm>
-
+#include <memory>
 namespace Opm {
 /*!
  * \brief Collects all grid properties which are relevant for end point scaling.
@@ -58,6 +58,33 @@ namespace Opm {
  * This class is used for both, the drainage and the imbibition variants of the ECL
  * keywords.
  */
+
+namespace {
+
+template <typename T>
+std::unique_ptr<std::vector<T>> compressed_copy(const std::vector<T>& global_vector, const std::vector<int>& compressedToCartesianElemIdx) {
+    std::unique_ptr<std::vector<T>> compressed = std::make_unique<std::vector<T>>(compressedToCartesianElemIdx.size());
+
+    for (std::size_t active_index = 0; active_index < compressedToCartesianElemIdx.size(); active_index++) {
+        auto global_index = compressedToCartesianElemIdx[active_index];
+        compressed->operator[](active_index) = global_vector[global_index];
+    }
+
+    return compressed;
+}
+
+
+std::unique_ptr<std::vector<double>> try_get(const Eclipse3DProperties& props, const std::string& keyword, const std::vector<int>& compressedToCartesianElemIdx) {
+    if (props.hasDeckDoubleGridProperty(keyword))
+        return compressed_copy(props.getDoubleGridProperty(keyword).getData(), compressedToCartesianElemIdx);
+
+    return {};
+}
+
+}
+
+
+
 class EclEpsGridProperties
 {
 
@@ -65,118 +92,122 @@ public:
 #if HAVE_ECL_INPUT
 
     EclEpsGridProperties(const Opm::EclipseState& eclState,
-                         bool useImbibition)
+                         bool useImbibition,
+                         const std::vector<int>& compressedToCartesianElemIdx)
     {
         std::string kwPrefix = useImbibition?"I":"";
-        if (useImbibition)
-            global_satnum = &eclState.get3DProperties().getIntGridProperty("IMBNUM").getData();
-        else
-            global_satnum = &eclState.get3DProperties().getIntGridProperty("SATNUM").getData();
+        const auto& ecl3dProps = eclState.get3DProperties();
 
-        retrieveGridPropertyData_(&this->global_swl, eclState, kwPrefix+"SWL");
-        retrieveGridPropertyData_(&this->global_sgl, eclState, kwPrefix+"SGL");
-        retrieveGridPropertyData_(&this->global_swcr, eclState, kwPrefix+"SWCR");
-        retrieveGridPropertyData_(&this->global_sgcr, eclState, kwPrefix+"SGCR");
-        retrieveGridPropertyData_(&this->global_sowcr, eclState, kwPrefix+"SOWCR");
-        retrieveGridPropertyData_(&this->global_sogcr, eclState, kwPrefix+"SOGCR");
-        retrieveGridPropertyData_(&this->global_swu, eclState, kwPrefix+"SWU");
-        retrieveGridPropertyData_(&this->global_sgu, eclState, kwPrefix+"SGU");
-        retrieveGridPropertyData_(&this->global_pcw, eclState, kwPrefix+"PCW");
-        retrieveGridPropertyData_(&this->global_pcg, eclState, kwPrefix+"PCG");
-        retrieveGridPropertyData_(&this->global_krw, eclState, kwPrefix+"KRW");
-        retrieveGridPropertyData_(&this->global_kro, eclState, kwPrefix+"KRO");
-        retrieveGridPropertyData_(&this->global_krg, eclState, kwPrefix+"KRG");
+        if (useImbibition)
+            compressed_satnum = compressed_copy(ecl3dProps.getIntGridProperty("IMBNUM").getData(), compressedToCartesianElemIdx);
+        else
+            compressed_satnum = compressed_copy(ecl3dProps.getIntGridProperty("SATNUM").getData(), compressedToCartesianElemIdx);
+
+        this->compressed_swl = try_get( ecl3dProps, kwPrefix+"SWL", compressedToCartesianElemIdx);
+        this->compressed_sgl = try_get( ecl3dProps, kwPrefix+"SGL", compressedToCartesianElemIdx);
+        this->compressed_swcr = try_get( ecl3dProps, kwPrefix+"SWCR", compressedToCartesianElemIdx);
+        this->compressed_sgcr = try_get( ecl3dProps, kwPrefix+"SGCR", compressedToCartesianElemIdx);
+        this->compressed_sowcr = try_get( ecl3dProps, kwPrefix+"SOWCR", compressedToCartesianElemIdx);
+        this->compressed_sogcr = try_get( ecl3dProps, kwPrefix+"SOGCR", compressedToCartesianElemIdx);
+        this->compressed_swu = try_get( ecl3dProps, kwPrefix+"SWU", compressedToCartesianElemIdx);
+        this->compressed_sgu = try_get( ecl3dProps, kwPrefix+"SGU", compressedToCartesianElemIdx);
+        this->compressed_pcw = try_get( ecl3dProps, kwPrefix+"PCW", compressedToCartesianElemIdx);
+        this->compressed_pcg = try_get( ecl3dProps, kwPrefix+"PCG", compressedToCartesianElemIdx);
+        this->compressed_krw = try_get( ecl3dProps, kwPrefix+"KRW", compressedToCartesianElemIdx);
+        this->compressed_kro = try_get( ecl3dProps, kwPrefix+"KRO", compressedToCartesianElemIdx);
+        this->compressed_krg = try_get( ecl3dProps, kwPrefix+"KRG", compressedToCartesianElemIdx);
 
         // _may_ be needed to calculate the Leverett capillary pressure scaling factor
-        const auto& ecl3dProps = eclState.get3DProperties();
-        this->global_poro = &ecl3dProps.getDoubleGridProperty("PORO").getData();
+        if (ecl3dProps.hasDeckDoubleGridProperty("PORO"))
+            this->compressed_poro = compressed_copy(ecl3dProps.getDoubleGridProperty("PORO").getData(), compressedToCartesianElemIdx);
 
-        if (ecl3dProps.hasDeckDoubleGridProperty("PERMX")) {
-            this->global_permx = &ecl3dProps.getDoubleGridProperty("PERMX").getData();
-            this->global_permy = this->global_permx;
-            this->global_permz = this->global_permx;
-        }
+        this->compressed_permx = compressed_copy(ecl3dProps.getDoubleGridProperty("PERMX").getData(), compressedToCartesianElemIdx);
 
         if (ecl3dProps.hasDeckDoubleGridProperty("PERMY"))
-            this->global_permy = &ecl3dProps.getDoubleGridProperty("PERMY").getData();
+            this->compressed_permy = compressed_copy(ecl3dProps.getDoubleGridProperty("PERMY").getData(), compressedToCartesianElemIdx);
+        else
+            this->compressed_permy = compressed_copy(ecl3dProps.getDoubleGridProperty("PERMX").getData(), compressedToCartesianElemIdx);
 
         if (ecl3dProps.hasDeckDoubleGridProperty("PERMZ"))
-            this->global_permz = &ecl3dProps.getDoubleGridProperty("PERMZ").getData();
+            this->compressed_permz = compressed_copy(ecl3dProps.getDoubleGridProperty("PERMZ").getData(), compressedToCartesianElemIdx);
+        else
+            this->compressed_permz = compressed_copy(ecl3dProps.getDoubleGridProperty("PERMZ").getData(), compressedToCartesianElemIdx);
     }
+
 #endif
 
 
 
-    unsigned satRegion(std::size_t global_index) const {
-        return this->global_satnum->operator[](global_index) - 1;
+    unsigned satRegion(std::size_t active_index) const {
+        return this->compressed_satnum->operator[](active_index) - 1;
     }
 
-    double permx(std::size_t global_index) const {
-        return this->global_permx->operator[](global_index);
+    double permx(std::size_t active_index) const {
+        return this->compressed_permx->operator[](active_index);
     }
 
-    double permy(std::size_t global_index) const {
-        return this->global_permy->operator[](global_index);
+    double permy(std::size_t active_index) const {
+        return this->compressed_permy->operator[](active_index);
     }
 
-    double permz(std::size_t global_index) const {
-        return this->global_permz->operator[](global_index);
+    double permz(std::size_t active_index) const {
+        return this->compressed_permz->operator[](active_index);
     }
 
-    double poro(std::size_t global_index) const {
-        return this->global_poro->operator[](global_index);
+    double poro(std::size_t active_index) const {
+        return this->compressed_poro->operator[](active_index);
     }
 
-    const double * swl(std::size_t global_index) const {
-        return this->satfunc(this->global_swl, global_index);
+    const double * swl(std::size_t active_index) const {
+        return this->satfunc(this->compressed_swl, active_index);
     }
 
-    const double * sgl(std::size_t global_index) const {
-        return this->satfunc(this->global_sgl, global_index);
+    const double * sgl(std::size_t active_index) const {
+        return this->satfunc(this->compressed_sgl, active_index);
     }
 
-    const double * swcr(std::size_t global_index) const {
-        return this->satfunc(this->global_swcr, global_index);
+    const double * swcr(std::size_t active_index) const {
+        return this->satfunc(this->compressed_swcr, active_index);
     }
 
-    const double * sgcr(std::size_t global_index) const {
-        return this->satfunc(this->global_sgcr, global_index);
+    const double * sgcr(std::size_t active_index) const {
+        return this->satfunc(this->compressed_sgcr, active_index);
     }
 
-    const double * sowcr(std::size_t global_index) const {
-        return this->satfunc(this->global_sowcr, global_index);
+    const double * sowcr(std::size_t active_index) const {
+        return this->satfunc(this->compressed_sowcr, active_index);
     }
 
-    const double * sogcr(std::size_t global_index) const {
-        return this->satfunc(this->global_sogcr, global_index);
+    const double * sogcr(std::size_t active_index) const {
+        return this->satfunc(this->compressed_sogcr, active_index);
     }
 
-    const double * swu(std::size_t global_index) const {
-        return this->satfunc(this->global_swu, global_index);
+    const double * swu(std::size_t active_index) const {
+        return this->satfunc(this->compressed_swu, active_index);
     }
 
-    const double * sgu(std::size_t global_index) const {
-        return this->satfunc(this->global_sgu, global_index);
+    const double * sgu(std::size_t active_index) const {
+        return this->satfunc(this->compressed_sgu, active_index);
     }
 
-    const double * pcw(std::size_t global_index) const {
-        return this->satfunc(this->global_pcw, global_index);
+    const double * pcw(std::size_t active_index) const {
+        return this->satfunc(this->compressed_pcw, active_index);
     }
 
-    const double * pcg(std::size_t global_index) const {
-        return this->satfunc(this->global_pcg, global_index);
+    const double * pcg(std::size_t active_index) const {
+        return this->satfunc(this->compressed_pcg, active_index);
     }
 
-    const double * krw(std::size_t global_index) const {
-        return this->satfunc(this->global_krw, global_index);
+    const double * krw(std::size_t active_index) const {
+        return this->satfunc(this->compressed_krw, active_index);
     }
 
-    const double * krg(std::size_t global_index) const {
-        return this->satfunc(this->global_krg, global_index);
+    const double * krg(std::size_t active_index) const {
+        return this->satfunc(this->compressed_krg, active_index);
     }
 
-    const double * kro(std::size_t global_index) const {
-        return this->satfunc(this->global_kro, global_index);
+    const double * kro(std::size_t active_index) const {
+        return this->satfunc(this->compressed_kro, active_index);
     }
 
 
@@ -194,32 +225,32 @@ private:
     }
 #endif
 
-    const double * satfunc(const std::vector<double>* data, std::size_t global_index) const {
+    const double * satfunc(const std::unique_ptr<std::vector<double>>& data, std::size_t active_index) const {
         if (data)
-            return &(data->operator[](global_index));
+            return &(data->operator[](active_index));
         return nullptr;
     }
 
 
-    const std::vector<int>*    global_satnum;
-    const std::vector<double>* global_swl;
-    const std::vector<double>* global_sgl;
-    const std::vector<double>* global_swcr;
-    const std::vector<double>* global_sgcr;
-    const std::vector<double>* global_sowcr;
-    const std::vector<double>* global_sogcr;
-    const std::vector<double>* global_swu;
-    const std::vector<double>* global_sgu;
-    const std::vector<double>* global_pcw;
-    const std::vector<double>* global_pcg;
-    const std::vector<double>* global_krw;
-    const std::vector<double>* global_kro;
-    const std::vector<double>* global_krg;
+    std::unique_ptr<std::vector<int>> compressed_satnum;
+    std::unique_ptr<std::vector<double>> compressed_swl;
+    std::unique_ptr<std::vector<double>> compressed_sgl;
+    std::unique_ptr<std::vector<double>> compressed_swcr;
+    std::unique_ptr<std::vector<double>> compressed_sgcr;
+    std::unique_ptr<std::vector<double>> compressed_sowcr;
+    std::unique_ptr<std::vector<double>> compressed_sogcr;
+    std::unique_ptr<std::vector<double>> compressed_swu;
+    std::unique_ptr<std::vector<double>> compressed_sgu;
+    std::unique_ptr<std::vector<double>> compressed_pcw;
+    std::unique_ptr<std::vector<double>> compressed_pcg;
+    std::unique_ptr<std::vector<double>> compressed_krw;
+    std::unique_ptr<std::vector<double>> compressed_kro;
+    std::unique_ptr<std::vector<double>> compressed_krg;
 
-    const std::vector<double>* global_permx;
-    const std::vector<double>* global_permy;
-    const std::vector<double>* global_permz;
-    const std::vector<double>* global_poro;
+    std::unique_ptr<std::vector<double>> compressed_permx;
+    std::unique_ptr<std::vector<double>> compressed_permy;
+    std::unique_ptr<std::vector<double>> compressed_permz;
+    std::unique_ptr<std::vector<double>> compressed_poro;
 };
 }
 #endif

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -248,26 +248,26 @@ struct EclEpsScalingPointsInfo
      */
     void extractScaled(const Opm::EclipseState& eclState,
                        const EclEpsGridProperties& epsProperties,
-                       unsigned cartesianCellIdx)
+                       unsigned activeIndex)
     {
         // overwrite the unscaled values with the values for the cell if it is
         // explicitly specified by the corresponding keyword.
-        update(Swl,     epsProperties.swl(cartesianCellIdx));
-        update(Sgl,     epsProperties.sgl(cartesianCellIdx));
-        update(Swcr,    epsProperties.swcr(cartesianCellIdx));
-        update(Sgcr,    epsProperties.sgcr(cartesianCellIdx));
+        update(Swl,     epsProperties.swl(activeIndex));
+        update(Sgl,     epsProperties.sgl(activeIndex));
+        update(Swcr,    epsProperties.swcr(activeIndex));
+        update(Sgcr,    epsProperties.sgcr(activeIndex));
 
-        update(Sowcr,   epsProperties.sowcr(cartesianCellIdx));
-        update(Sogcr,   epsProperties.sogcr(cartesianCellIdx));
-        update(Swu,     epsProperties.swu(cartesianCellIdx));
-        update(Sgu,     epsProperties.sgu(cartesianCellIdx));
-        update(maxPcow, epsProperties.pcw(cartesianCellIdx));
-        update(maxPcgo, epsProperties.pcg(cartesianCellIdx));
-        update(maxKrw,  epsProperties.krw(cartesianCellIdx));
-        update(maxKrg,  epsProperties.krg(cartesianCellIdx));
+        update(Sowcr,   epsProperties.sowcr(activeIndex));
+        update(Sogcr,   epsProperties.sogcr(activeIndex));
+        update(Swu,     epsProperties.swu(activeIndex));
+        update(Sgu,     epsProperties.sgu(activeIndex));
+        update(maxPcow, epsProperties.pcw(activeIndex));
+        update(maxPcgo, epsProperties.pcg(activeIndex));
+        update(maxKrw,  epsProperties.krw(activeIndex));
+        update(maxKrg,  epsProperties.krg(activeIndex));
         // quite likely that's wrong!
-        update(maxKrow, epsProperties.kro(cartesianCellIdx));
-        update(maxKrog, epsProperties.kro(cartesianCellIdx));
+        update(maxKrow, epsProperties.kro(activeIndex));
+        update(maxKrog, epsProperties.kro(activeIndex));
 
         // compute the Leverett capillary pressure scaling factors if applicable.  note
         // that this needs to be done using non-SI units to make it correspond to the
@@ -280,19 +280,19 @@ struct EclEpsScalingPointsInfo
 
             Scalar perm;
             if (jfuncDir == Opm::JFunc::Direction::X)
-                perm = epsProperties.permx(cartesianCellIdx);
+                perm = epsProperties.permx(activeIndex);
             else if (jfuncDir == Opm::JFunc::Direction::Y)
-                perm = epsProperties.permy(cartesianCellIdx);
+                perm = epsProperties.permy(activeIndex);
             else if (jfuncDir == Opm::JFunc::Direction::Z)
-                perm = epsProperties.permz(cartesianCellIdx);
+                perm = epsProperties.permz(activeIndex);
             else if (jfuncDir == Opm::JFunc::Direction::XY)
                 // TODO: verify that this really is the arithmetic mean. (the
                 // documentation just says that the "average" should be used, IMO the
                 // harmonic mean would be more appropriate because that's what's usually
                 // applied when calculating the fluxes.)
             {
-                double permx = epsProperties.permx(cartesianCellIdx);
-                double permy = epsProperties.permy(cartesianCellIdx);
+                double permx = epsProperties.permx(activeIndex);
+                double permy = epsProperties.permy(activeIndex);
                 perm = Opm::arithmeticMean(permx, permy);
             } else
                 throw std::runtime_error("Illegal direction indicator for the JFUNC "
@@ -301,7 +301,7 @@ struct EclEpsScalingPointsInfo
             // convert permeability from m^2 to mD
             perm *= 1.01325e15;
 
-            Scalar poro = epsProperties.poro(cartesianCellIdx);
+            Scalar poro = epsProperties.poro(activeIndex);
             Scalar alpha = jfunc.alphaFactor();
             Scalar beta = jfunc.betaFactor();
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -525,43 +525,39 @@ private:
             oilWaterScaledImbPointsVector.resize(numCompressedElems);
         }
 
-        EclEpsGridProperties epsGridProperties(eclState, false);
+        EclEpsGridProperties epsGridProperties(eclState, false, compressedToCartesianElemIdx);
 
         for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
-            unsigned cartElemIdx = static_cast<unsigned>(compressedToCartesianElemIdx[elemIdx]);
             readGasOilScaledPoints_(gasOilScaledInfoVector,
                                     gasOilScaledPointsVector,
                                     gasOilConfig,
                                     eclState,
                                     epsGridProperties,
-                                    elemIdx,
-                                    cartElemIdx);
+                                    elemIdx);
+
             readOilWaterScaledPoints_(oilWaterScaledEpsInfoDrainage_,
                                       oilWaterScaledEpsPointsDrainage,
                                       oilWaterConfig,
                                       eclState,
                                       epsGridProperties,
-                                      elemIdx,
-                                      cartElemIdx);
+                                      elemIdx);
 
             if (enableHysteresis()) {
-                EclEpsGridProperties epsImbGridProperties(eclState, true);
+                EclEpsGridProperties epsImbGridProperties(eclState, true, compressedToCartesianElemIdx);
 
                 readGasOilScaledPoints_(gasOilScaledImbInfoVector,
                                         gasOilScaledImbPointsVector,
                                         gasOilConfig,
                                         eclState,
                                         epsImbGridProperties,
-                                        elemIdx,
-                                        cartElemIdx);
+                                        elemIdx);
 
                 readOilWaterScaledPoints_(oilWaterScaledImbInfoVector,
                                           oilWaterScaledImbPointsVector,
                                           oilWaterConfig,
                                           eclState,
                                           epsImbGridProperties,
-                                          elemIdx,
-                                          cartElemIdx);
+                                          elemIdx);
             }
         }
 
@@ -969,13 +965,12 @@ private:
                                  std::shared_ptr<EclEpsConfig> config,
                                  const Opm::EclipseState& eclState,
                                  const EclEpsGridProperties& epsGridProperties,
-                                 unsigned elemIdx,
-                                 unsigned cartElemIdx)
+                                 unsigned elemIdx)
     {
-        unsigned satRegionIdx = epsGridProperties.satRegion( cartElemIdx );
+        unsigned satRegionIdx = epsGridProperties.satRegion( elemIdx );
 
         destInfo[elemIdx] = std::make_shared<EclEpsScalingPointsInfo<Scalar> >(unscaledEpsInfo_[satRegionIdx]);
-        destInfo[elemIdx]->extractScaled(eclState, epsGridProperties, cartElemIdx);
+        destInfo[elemIdx]->extractScaled(eclState, epsGridProperties, elemIdx);
 
         destPoints[elemIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
         destPoints[elemIdx]->init(*destInfo[elemIdx], *config, EclGasOilSystem);
@@ -987,13 +982,12 @@ private:
                                    std::shared_ptr<EclEpsConfig> config,
                                    const Opm::EclipseState& eclState,
                                    const EclEpsGridProperties& epsGridProperties,
-                                   unsigned elemIdx,
-                                   unsigned cartElemIdx)
+                                   unsigned elemIdx)
     {
-        unsigned satRegionIdx = epsGridProperties.satRegion( cartElemIdx );
+        unsigned satRegionIdx = epsGridProperties.satRegion( elemIdx );
 
         destInfo[elemIdx] = std::make_shared<EclEpsScalingPointsInfo<Scalar> >(unscaledEpsInfo_[satRegionIdx]);
-        destInfo[elemIdx]->extractScaled(eclState, epsGridProperties, cartElemIdx);
+        destInfo[elemIdx]->extractScaled(eclState, epsGridProperties, elemIdx);
 
         destPoints[elemIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
         destPoints[elemIdx]->init(*destInfo[elemIdx], *config, EclOilWaterSystem);


### PR DESCRIPTION
This is on top of #363. 

Store only the active cell elements in the `EclEpsGridProperties`. This is part of the 3D property refactor effot. The aiim is to reduce memory usage - but for this PR there will be a (temporary ..) increase in memory usage.