### PR TITLE
Extract creation of EclEpsGridProperties out of loop

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -542,9 +542,11 @@ private:
                                       epsGridProperties,
                                       elemIdx);
 
-            if (enableHysteresis()) {
-                EclEpsGridProperties epsImbGridProperties(eclState, true, compressedToCartesianElemIdx);
+        }
 
+        if (enableHysteresis()) {
+            EclEpsGridProperties epsImbGridProperties(eclState, true, compressedToCartesianElemIdx);
+            for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
                 readGasOilScaledPoints_(gasOilScaledImbInfoVector,
                                         gasOilScaledImbPointsVector,
                                         gasOilConfig,


### PR DESCRIPTION
Creation of `EclEpsGridProperties` object was done for every cell in the case of hysterisis. Hard work! 