### PR TITLE
Use temporary global properties when accesing FieldPropsManager

### DIFF
--- a/opm/material/thermal/EclThermalLawManager.hpp
+++ b/opm/material/thermal/EclThermalLawManager.hpp
@@ -196,10 +196,15 @@ private:
         // initialize the element index -> SATNUM index mapping
 #ifdef ENABLE_3DPROPS_TESTING
         const auto& fp = eclState.fieldProps();
-        const auto& satnum = fp.get<int>("SATNUM");
-        elemToSatnumIdx_.resize(satnum.size());
-        for (std::size_t i = 0; i < satnum.size(); i++)
-            elemToSatnumIdx_[i] = satnum[i] - 1;
+        const std::vector<int>& satnumData = fp.get_global<int>("SATNUM");
+        elemToSatnumIdx_.resize(compressedToCartesianElemIdx.size());
+        for (unsigned elemIdx = 0; elemIdx < compressedToCartesianElemIdx.size(); ++ elemIdx) {
+            unsigned cartesianElemIdx = compressedToCartesianElemIdx[elemIdx];
+
+            // satnumData contains Fortran-style indices, i.e., they start with 1 instead
+            // of 0!
+            elemToSatnumIdx_[elemIdx] = satnumData[cartesianElemIdx] - 1;
+        }
 #else
         const auto& props = eclState.get3DProperties();
         const std::vector<int>& satnumData = props.getIntGridProperty("SATNUM").getData();


### PR DESCRIPTION
This comment:

There are essentially three levels of cells:

    1. The global cartesian set of cells.
    2. The set of cells which are active in the simulation.
    3. The set of cells which are active on one particular MPI process.

The original 3D implementation worked at level 1, whereas the new implementation works at level 2. In both opm-material and opm-simulators there are numerous mappings 1 → 3, at this point I have misunderstood and thought that the properties from the new container were immediately ready for use in the simulator. That is unfortunately not the case. The datastructure used in the new container should be quite well suited for the 2 → 3 conversion, but for now I have opted to go through the global vectors and then reuse the existing 1 → 3 code.

Sums up what this PR is all about.
