### PR TITLE
Reorganize EclMaterialLawManager

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -148,7 +148,7 @@ public:
                 stoneEtas[satRegionIdx] = deck.getKeyword("STONE1EX").getRecord(satRegionIdx).getItem(0).getSIDouble(0);
         }
 
-        initParamsForElements_(eclState, compressedToCartesianElemIdx, satnumRegionArray_, imbnumRegionArray_);
+        initParamsForElements_(eclState, compressedToCartesianElemIdx);
     }
 
     /*!
@@ -465,9 +465,7 @@ private:
     }
 
     void initParamsForElements_(const EclipseState& eclState,
-                                const std::vector<int>& compressedToCartesianElemIdx,
-                                const std::vector<int>& satnumRegionArray,
-                                const std::vector<int>& imbnumRegionArray)
+                                const std::vector<int>& compressedToCartesianElemIdx)
     {
         // get the number of saturation regions
         const size_t numSatRegions = eclState.runspec().tabdims().getNumSatTables();
@@ -580,10 +578,10 @@ private:
             oilWaterImbParams.resize(numCompressedElems);
         }
 
-        assert(numCompressedElems == satnumRegionArray.size());
-        assert(!enableHysteresis() || numCompressedElems == imbnumRegionArray.size());
+        assert(numCompressedElems == satnumRegionArray_.size());
+        assert(!enableHysteresis() || numCompressedElems == imbnumRegionArray_.size());
         for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
-            unsigned satRegionIdx = static_cast<unsigned>(satnumRegionArray[elemIdx]);
+            unsigned satRegionIdx = static_cast<unsigned>(satnumRegionArray_[elemIdx]);
 
             gasOilParams[elemIdx] = std::make_shared<GasOilTwoPhaseHystParams>();
             oilWaterParams[elemIdx] = std::make_shared<OilWaterTwoPhaseHystParams>();
@@ -618,7 +616,7 @@ private:
             }
 
             if (enableHysteresis()) {
-                unsigned imbRegionIdx = imbnumRegionArray[elemIdx];
+                unsigned imbRegionIdx = imbnumRegionArray_[elemIdx];
 
                 if (hasGas && hasOil) {
                     auto gasOilImbParamsHyst = std::make_shared<GasOilEpsTwoPhaseParams>();
@@ -658,7 +656,7 @@ private:
         materialLawParams_.resize(numCompressedElems);
         for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
             materialLawParams_[elemIdx] = std::make_shared<MaterialLawParams>();
-            unsigned satRegionIdx = static_cast<unsigned>(satnumRegionArray[elemIdx]);
+            unsigned satRegionIdx = static_cast<unsigned>(satnumRegionArray_[elemIdx]);
 
             initThreePhaseParams_(eclState,
                                   *materialLawParams_[elemIdx],

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -117,8 +117,7 @@ public:
     {}
 
     void initFromDeck(const Opm::Deck& deck,
-                      const Opm::EclipseState& eclState,
-                      const std::vector<int>& compressedToCartesianElemIdx)
+                      const Opm::EclipseState& eclState)
     {
         // get the number of saturation regions and the number of cells in the deck
         const size_t numSatRegions = eclState.runspec().tabdims().getNumSatTables();
@@ -147,8 +146,6 @@ public:
             if (!stoneEtas.empty())
                 stoneEtas[satRegionIdx] = deck.getKeyword("STONE1EX").getRecord(satRegionIdx).getItem(0).getSIDouble(0);
         }
-
-        initParamsForElements(eclState, compressedToCartesianElemIdx);
     }
 
     void initParamsForElements(const EclipseState& eclState,

--- a/tests/test_eclmateriallawmanager.cpp
+++ b/tests/test_eclmateriallawmanager.cpp
@@ -453,7 +453,8 @@ inline void testAll()
             compressedToCartesianIdx[i] = static_cast<int>(i);
 
         MaterialLawManager materialLawManager;
-        materialLawManager.initFromDeck(deck, eclState, compressedToCartesianIdx);
+        materialLawManager.initFromDeck(deck, eclState);
+        materialLawManager.initParamsForElements(eclState, compressedToCartesianIdx);
 
         if (materialLawManager.enableEndPointScaling())
             throw std::logic_error("Discrepancy between the deck and the EclMaterialLawManager");
@@ -466,7 +467,8 @@ inline void testAll()
             const Opm::EclipseState fam2EclState(fam2Deck);
 
             Opm::EclMaterialLawManager<MaterialTraits> fam2MaterialLawManager;
-            fam2MaterialLawManager.initFromDeck(fam2Deck, fam2EclState, compressedToCartesianIdx);
+            fam2MaterialLawManager.initFromDeck(fam2Deck, fam2EclState);
+            fam2MaterialLawManager.initParamsForElements(fam2EclState, compressedToCartesianIdx);
 
             if (fam2MaterialLawManager.enableEndPointScaling())
                 throw std::logic_error("Discrepancy between the deck and the EclMaterialLawManager");
@@ -478,7 +480,8 @@ inline void testAll()
             const Opm::EclipseState hysterEclState(hysterDeck);
 
             Opm::EclMaterialLawManager<MaterialTraits> hysterMaterialLawManager;
-            hysterMaterialLawManager.initFromDeck(hysterDeck, hysterEclState, compressedToCartesianIdx);
+            hysterMaterialLawManager.initFromDeck(hysterDeck, hysterEclState);
+            hysterMaterialLawManager.initParamsForElements(hysterEclState, compressedToCartesianIdx);
 
             if (hysterMaterialLawManager.enableEndPointScaling())
                 throw std::logic_error("Discrepancy between the deck and the EclMaterialLawManager");
@@ -570,13 +573,15 @@ inline void testAll()
             const Opm::EclipseState fam1EclState(fam1Deck);
 
             MaterialLawManager fam1materialLawManager;
-            fam1materialLawManager.initFromDeck(fam1Deck, fam1EclState, compressedToCartesianIdx);
+            fam1materialLawManager.initFromDeck(fam1Deck, fam1EclState);
+            fam1materialLawManager.initParamsForElements(fam1EclState, compressedToCartesianIdx);
 
             const auto fam2Deck = parser.parseString(fam2DeckStringGasOil);
             const Opm::EclipseState fam2EclState(fam2Deck);
 
             Opm::EclMaterialLawManager<MaterialTraits> fam2MaterialLawManager;
-            fam2MaterialLawManager.initFromDeck(fam2Deck, fam2EclState, compressedToCartesianIdx);
+            fam2MaterialLawManager.initFromDeck(fam2Deck, fam2EclState);
+            fam2MaterialLawManager.initParamsForElements(fam2EclState, compressedToCartesianIdx);
 
             for (unsigned elemIdx = 0; elemIdx < n; ++ elemIdx) {
                 for (int i = 0; i < 100; ++ i) {


### PR DESCRIPTION
This is some preparatory changes for aiding setup without deck access.

The only change of behavior is supposed to be the requirement for a separate call to initParamsForElements for users.