### PR TITLE
Don't Index Out of Bounds

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -181,7 +181,7 @@ public:
         initBegin(numRegions);
 
         numActivePhases_ = 0;
-        std::fill(&phaseIsActive_[0], &phaseIsActive_[numPhases], false);
+        std::fill_n(&phaseIsActive_[0], numPhases, false);
 
         if (deck.hasKeyword("OIL")) {
             phaseIsActive_[oilPhaseIdx] = true;
@@ -268,7 +268,7 @@ public:
         setReservoirTemperature(surfaceTemperature);
 
         numActivePhases_ = numPhases;
-        std::fill(&phaseIsActive_[0], &phaseIsActive_[numPhases], true);
+        std::fill_n(&phaseIsActive_[0], numPhases, true);
 
         resizeArrays_(numPvtRegions);
     }


### PR DESCRIPTION
The `phaseIsActive_` array has size `numPhases`.  We must not form the expression `phaseIsActive_[numPhases]`.  Switch to using `fill_n()` in place of `fill()` lest we have to write
```C++
std::fill(&phaseIsActive_[0], &phaseIsActive_[0] + numPhases, v)
```