### PR TITLE
fixed: remove boost::filesystem from prereqs

### DIFF
--- a/opm-material-prereqs.cmake
+++ b/opm-material-prereqs.cmake
@@ -17,7 +17,6 @@ set (opm-material_DEPS
   "dune-common REQUIRED"
   # valgrind client requests
   "Valgrind"
-  "Boost COMPONENTS filesystem"
   )
 
 find_package_deps(opm-material)


### PR DESCRIPTION
This was forgotten during switch to std::filesystem.