### PR TITLE
changed: use std::array instead of C arrays

### DIFF
--- a/opm/material/fluidstates/FluidStateCompositionModules.hpp
+++ b/opm/material/fluidstates/FluidStateCompositionModules.hpp
@@ -34,6 +34,7 @@
 #include <opm/material/common/Exceptions.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 
 namespace Opm {
@@ -165,9 +166,9 @@ protected:
     const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
-    Scalar moleFraction_[numPhases][numComponents];
-    Scalar averageMolarMass_[numPhases];
-    Scalar sumMoleFractions_[numPhases];
+    std::array<std::array<Scalar,numComponents>,numPhases> moleFraction_;
+    std::array<Scalar,numPhases> averageMolarMass_;
+    std::array<Scalar,numPhases> sumMoleFractions_;
 };
 
 /*!


### PR DESCRIPTION
Motivation is killing the strange warning https://ci.opm-project.org/job/opm-grid-PR-builder/98/gcc/category.1111378089/source.a94ef8ce-8af6-47bf-a546-59f5906b8663/#69