### PR TITLE
Grid Properties: Include FieldPropsManager

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
@@ -31,6 +31,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>


### PR DESCRIPTION
We use the manager internally (for instance in the `try_get()` helper function) and therefore need a declaration in scope.