### PR TITLE
Add phaseIsActive(unsigned int) to base fluid system (returning true).

### DIFF
--- a/opm/material/fluidsystems/BaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/BaseFluidSystem.hpp
@@ -274,6 +274,13 @@ public:
     {
         throw std::runtime_error("Not implemented: The fluid system '"+Dune::className<Implementation>()+"'  does not provide a heatCapacity() method!");
     }
+
+
+    //! \brief Returns whether a fluid phase is active
+    static unsigned phaseIsActive(unsigned /*phaseIdx*/)
+    {
+        return true;
+    }
 };
 
 } // namespace Opm


### PR DESCRIPTION
This promotes the feature from being a special function for the black oil fluid system to being in theory available for all. The need for this arose in downstream code.