### PR TITLE
make the water PVT salt dependent

### DIFF
--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -76,6 +76,18 @@ LhsEval getInvB_(typename std::enable_if<!HasMember_invB<FluidState>::value,
         /FluidSystem::referenceDensity(phaseIdx, pvtRegionIdx);
 }
 
+OPM_GENERATE_HAS_MEMBER(saltConcentration, ) // Creates 'HasMember_saltConcentration<T>'.
+
+template <class FluidState>
+unsigned getSaltConcentration_(typename std::enable_if<HasMember_saltConcentration<FluidState>::value,
+                                                    const FluidState&>::type fluidState)
+{ return fluidState.saltConcentration(); }
+
+template <class FluidState>
+unsigned getSaltConcentration_(typename std::enable_if<!HasMember_saltConcentration<FluidState>::value,
+                                                    const FluidState&>::type fluidState OPM_UNUSED)
+{ return 0; }
+
 /*!
  * \brief Implements a "tailor-made" fluid state class for the black-oil model.
  *

--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -79,14 +79,14 @@ LhsEval getInvB_(typename std::enable_if<!HasMember_invB<FluidState>::value,
 OPM_GENERATE_HAS_MEMBER(saltConcentration, ) // Creates 'HasMember_saltConcentration<T>'.
 
 template <class FluidState>
-unsigned getSaltConcentration_(typename std::enable_if<HasMember_saltConcentration<FluidState>::value,
+auto getSaltConcentration_(typename std::enable_if<HasMember_saltConcentration<FluidState>::value,
                                                     const FluidState&>::type fluidState)
 { return fluidState.saltConcentration(); }
 
 template <class FluidState>
-unsigned getSaltConcentration_(typename std::enable_if<!HasMember_saltConcentration<FluidState>::value,
+auto getSaltConcentration_(typename std::enable_if<!HasMember_saltConcentration<FluidState>::value,
                                                     const FluidState&>::type fluidState OPM_UNUSED)
-{ return 0; }
+{ return 0.0; }
 
 /*!
  * \brief Implements a "tailor-made" fluid state class for the black-oil model.

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -603,6 +603,7 @@ public:
 
         const LhsEval& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
         const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& saltConcentration = Opm::BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
 
         switch (phaseIdx) {
         case oilPhaseIdx: {
@@ -643,7 +644,7 @@ public:
         case waterPhaseIdx:
             return
                 referenceDensity(waterPhaseIdx, regionIdx)
-                * waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p);
+                * waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, saltConcentration);
         }
 
         throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
@@ -731,6 +732,7 @@ public:
 
         const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
         const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& saltConcentration = Opm::decay<LhsEval>(fluidState.saltConcentration());
 
         switch (phaseIdx) {
         case oilPhaseIdx: {
@@ -764,7 +766,7 @@ public:
             return gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv);
         }
         case waterPhaseIdx:
-            return waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p);
+            return waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, saltConcentration);
         default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
     }
@@ -786,11 +788,12 @@ public:
 
         const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
         const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& saltConcentration = Opm::decay<LhsEval>(fluidState.saltConcentration());
 
         switch (phaseIdx) {
         case oilPhaseIdx: return oilPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
         case gasPhaseIdx: return gasPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
-        case waterPhaseIdx: return waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p);
+        case waterPhaseIdx: return waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, saltConcentration);
         default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
     }
@@ -928,6 +931,7 @@ public:
 
         const LhsEval& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
         const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& saltConcentration = Opm::BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
 
         switch (phaseIdx) {
         case oilPhaseIdx: {
@@ -965,7 +969,7 @@ public:
         case waterPhaseIdx:
             // since water is always assumed to be immiscible in the black-oil model,
             // there is no "saturated water"
-            return waterPvt_->viscosity(regionIdx, T, p);
+            return waterPvt_->viscosity(regionIdx, T, p, saltConcentration);
         }
 
         throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -157,20 +157,6 @@ public:
     template <class Evaluation>
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& temperature,
-                         const Evaluation& pressure) const
-    {
-       // assert(realWaterPvt_ != ConstantCompressibilityBrinePvt );
-        const Evaluation saltconcentration = 0.0;
-        OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, saltconcentration));
-        return 0;
-    }
-
-    /*!
-     * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
-     */
-    template <class Evaluation>
-    Evaluation viscosity(unsigned regionIdx,
-                         const Evaluation& temperature,
                          const Evaluation& pressure,
                          const Evaluation& saltconcentration) const
     {
@@ -187,19 +173,6 @@ public:
                                             const Evaluation& pressure,
                                             const Evaluation& saltconcentration) const
     {   OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactor(regionIdx, temperature, pressure, saltconcentration));
-        return 0;
-    }
-
-    /*!
-     * \brief Returns the formation volume factor [-] of the fluid phase.
-     */
-    template <class Evaluation>
-    Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
-                                            const Evaluation& temperature,
-                                            const Evaluation& pressure) const
-    {
-        const Evaluation saltconcentration = 0.0;
-        OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactor(regionIdx, temperature, pressure, saltconcentration));
         return 0;
     }
 

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -139,6 +139,7 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
     while (0) {
         Evaluation temperature = 273.15 + 20.0;
         Evaluation pressure = 1e5;
+        Evaluation saltconcentration = 0.0;
         Evaluation Rs = 0.0;
         Evaluation Rv = 0.0;
         Evaluation So = 0.5;
@@ -150,10 +151,12 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         /////
         tmp = waterPvt.viscosity(/*regionIdx=*/0,
                                  temperature,
-                                 pressure);
+                                 pressure,
+                                 saltconcentration);
         tmp = waterPvt.inverseFormationVolumeFactor(/*regionIdx=*/0,
                                                     temperature,
-                                                    pressure);
+                                                    pressure,
+                                                    saltconcentration);
 
         /////
         // oil PVT API

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -53,6 +53,7 @@
 #include <opm/material/fluidstates/NonEquilibriumFluidState.hpp>
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
 #include <opm/material/fluidstates/SimpleModularFluidState.hpp>
+#include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
 // include the tables for CO2 which are delivered with opm-material by default
 #include <opm/material/common/UniformTabulated2DFunction.hpp>
@@ -83,7 +84,7 @@ void ensureBlackoilApi()
 #endif
 
         typedef typename FluidSystem::Scalar Scalar;
-        typedef Opm::CompositionalFluidState<Evaluation, FluidSystem> FluidState;
+        typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
         FluidState fluidState;
         Evaluation XoG = 0.0;
         Evaluation XgO = 0.0;


### PR DESCRIPTION
The PVTWSALT was implemented but the salt concentration was never passed to the PVT model. I have removed the interface that allows for not passing the salt concentration to assure the salt concentration is always passed to the model. This should only affect the brine specialization. 