### PR TITLE
Do not check for kr curves for water single-phase

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -184,7 +184,9 @@ struct EclEpsScalingPointsInfo
             Swcr = 0.0;
             bool family1 = (!sgofTables.empty() || !slgofTables.empty());
             bool family2 = !sgfnTables.empty() && !sof2Tables.empty();
-            if (family1) {
+            if (!hasOil) {
+                return;
+            } else if (family1) {
                 if (!sgofTables.empty())
                     extractUnscaledSgof_(sgofTables.getTable<SgofTable>(satRegionIdx));
                 else {
@@ -206,7 +208,9 @@ struct EclEpsScalingPointsInfo
             Sgcr = 0.0;
             bool family1 = !swofTables.empty();
             bool family2 = !swfnTables.empty() && !sof2Tables.empty();
-            if (family1) {
+            if (!hasOil) {
+                return;
+            } else if (family1) {
                 extractUnscaledSwof_(swofTables.getTable<SwofTable>(satRegionIdx));
             } else if (family2) {
                 extractUnscaledSwfn_(swfnTables.getTable<SwfnTable>(satRegionIdx));

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -178,15 +178,15 @@ struct EclEpsScalingPointsInfo
         bool hasGas = eclState.runspec().phases().active(Phase::GAS);
         bool hasOil = eclState.runspec().phases().active(Phase::OIL);
 
-        if (!hasWater) {
+        if (int(hasWater) + int(hasGas) + int(hasOil) == 1) {
+            return;
+        } else if (!hasWater) {
             Swl = 0.0;
             Swu = 0.0;
             Swcr = 0.0;
             bool family1 = (!sgofTables.empty() || !slgofTables.empty());
             bool family2 = !sgfnTables.empty() && !sof2Tables.empty();
-            if (!hasOil) {
-                return;
-            } else if (family1) {
+            if (family1) {
                 if (!sgofTables.empty())
                     extractUnscaledSgof_(sgofTables.getTable<SgofTable>(satRegionIdx));
                 else {
@@ -201,16 +201,13 @@ struct EclEpsScalingPointsInfo
                 throw std::domain_error("No valid saturation keyword family specified");
             }
             return;
-        }
-        else if (!hasGas) {
+        } else if (!hasGas) {
             Sgl = 0.0;
             Sgu = 0.0;
             Sgcr = 0.0;
             bool family1 = !swofTables.empty();
             bool family2 = !swfnTables.empty() && !sof2Tables.empty();
-            if (!hasOil) {
-                return;
-            } else if (family1) {
+            if (family1) {
                 extractUnscaledSwof_(swofTables.getTable<SwofTable>(satRegionIdx));
             } else if (family2) {
                 extractUnscaledSwfn_(swfnTables.getTable<SwfnTable>(satRegionIdx));


### PR DESCRIPTION
This fix remove the need of dummy relative permeability curves, so we can run flow_onephase and flow_onephase_energy with exactly input file as commercial simulator. 