### PR TITLE
Implement KRWR Vertical Scaling

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
@@ -99,8 +99,12 @@ public:
         this->compressed_pcw = try_get( fp, kwPrefix+"PCW");
         this->compressed_pcg = try_get( fp, kwPrefix+"PCG");
         this->compressed_krw = try_get( fp, kwPrefix+"KRW");
+        this->compressed_krwr = try_get( fp, kwPrefix+"KRWR");
         this->compressed_kro = try_get( fp, kwPrefix+"KRO");
+        this->compressed_krorg = try_get( fp, kwPrefix+"KRORG");
+        this->compressed_krorw = try_get( fp, kwPrefix+"KRORW");
         this->compressed_krg = try_get( fp, kwPrefix+"KRG");
+        this->compressed_krgr = try_get( fp, kwPrefix+"KRGR");
 
         // _may_ be needed to calculate the Leverett capillary pressure scaling factor
         if (fp.has_double("PORO"))
@@ -185,14 +189,29 @@ public:
         return this->satfunc(this->compressed_krw, active_index);
     }
 
+    const double * krwr(std::size_t active_index) const {
+        return this->satfunc(this->compressed_krwr, active_index);
+    }
+
     const double * krg(std::size_t active_index) const {
         return this->satfunc(this->compressed_krg, active_index);
+    }
+
+    const double * krgr(std::size_t active_index) const {
+        return this->satfunc(this->compressed_krgr, active_index);
     }
 
     const double * kro(std::size_t active_index) const {
         return this->satfunc(this->compressed_kro, active_index);
     }
 
+    const double * krorg(std::size_t active_index) const {
+        return this->satfunc(this->compressed_krorg, active_index);
+    }
+
+    const double * krorw(std::size_t active_index) const {
+        return this->satfunc(this->compressed_krorw, active_index);
+    }
 
 private:
     const double *
@@ -215,8 +234,12 @@ private:
     std::vector<double> compressed_pcw;
     std::vector<double> compressed_pcg;
     std::vector<double> compressed_krw;
+    std::vector<double> compressed_krwr;
     std::vector<double> compressed_kro;
+    std::vector<double> compressed_krorg;
+    std::vector<double> compressed_krorw;
     std::vector<double> compressed_krg;
+    std::vector<double> compressed_krgr;
 
     std::vector<double> compressed_permx;
     std::vector<double> compressed_permy;

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -83,6 +83,12 @@ struct EclEpsScalingPointsInfo
     Scalar pcowLeverettFactor;
     Scalar pcgoLeverettFactor;
 
+    // Scaled relative permeabilities at residual displacing saturation
+    Scalar Krwr;  // water
+    Scalar Krgr;  // gas
+    Scalar Krorw; // oil in water-oil system
+    Scalar Krorg; // oil in gas-oil system
+
     // maximum relative permabilities
     Scalar maxKrw; // maximum relative permability of water
     Scalar maxKrow; // maximum relative permability of oil in the oil-water system
@@ -103,6 +109,10 @@ struct EclEpsScalingPointsInfo
                maxPcgo == data.maxPcgo &&
                pcowLeverettFactor == data.pcowLeverettFactor &&
                pcgoLeverettFactor == data.pcgoLeverettFactor &&
+               Krwr == data.Krwr &&
+               Krgr == data.Krgr &&
+               Krorw == data.Krorw &&
+               Krorg == data.Krorg &&
                maxKrw == data.maxKrw &&
                maxKrow == data.maxKrow &&
                maxKrog == data.maxKrog &&
@@ -123,6 +133,10 @@ struct EclEpsScalingPointsInfo
                   << "    maxPcgo: " << maxPcgo << '\n'
                   << "    pcowLeverettFactor: " << pcowLeverettFactor << '\n'
                   << "    pcgoLeverettFactor: " << pcgoLeverettFactor << '\n'
+                  << "    Krwr: " << Krwr << '\n'
+                  << "    Krgr: " << Krgr << '\n'
+                  << "    Krorw: " << Krorw << '\n'
+                  << "    Krorg: " << Krorg << '\n'
                   << "    maxKrw: " << maxKrw << '\n'
                   << "    maxKrg: " << maxKrg << '\n'
                   << "    maxKrow: " << maxKrow << '\n'
@@ -163,6 +177,11 @@ struct EclEpsScalingPointsInfo
         this->pcowLeverettFactor = 1.0;
         this->pcgoLeverettFactor = 1.0;
 
+        this->Krwr    = rfunc.krw.r [satRegionIdx];
+        this->Krgr    = rfunc.krg.r [satRegionIdx];
+        this->Krorw   = rfunc.kro.rw[satRegionIdx];
+        this->Krorg   = rfunc.kro.rg[satRegionIdx];
+
         this->maxKrw  = rfunc.krw.max[satRegionIdx];
         this->maxKrow = rfunc.kro.max[satRegionIdx];
         this->maxKrog = rfunc.kro.max[satRegionIdx];
@@ -196,6 +215,12 @@ struct EclEpsScalingPointsInfo
         update(Sgu,     epsProperties.sgu(activeIndex));
         update(maxPcow, epsProperties.pcw(activeIndex));
         update(maxPcgo, epsProperties.pcg(activeIndex));
+
+        update(this->Krwr,  epsProperties.krwr(activeIndex));
+        update(this->Krgr,  epsProperties.krgr(activeIndex));
+        update(this->Krorw, epsProperties.krorw(activeIndex));
+        update(this->Krorg, epsProperties.krorg(activeIndex));
+
         update(maxKrw,  epsProperties.krw(activeIndex));
         update(maxKrg,  epsProperties.krg(activeIndex));
         update(maxKrow, epsProperties.kro(activeIndex));
@@ -316,6 +341,10 @@ public:
                 maxPcnwOrLeverettFactor_ = epsInfo.pcowLeverettFactor;
             else
                 maxPcnwOrLeverettFactor_ = epsInfo.maxPcow;
+
+            Krwr_   = epsInfo.Krwr;
+            Krnr_   = epsInfo.Krorw;
+
             maxKrw_ = epsInfo.maxKrw;
             maxKrn_ = epsInfo.maxKrow;
         }
@@ -343,6 +372,9 @@ public:
                 maxPcnwOrLeverettFactor_ = epsInfo.pcgoLeverettFactor;
             else
                 maxPcnwOrLeverettFactor_ = epsInfo.maxPcgo;
+
+            Krwr_   = epsInfo.Krorg;
+            Krnr_   = epsInfo.Krgr;
 
             maxKrw_ = epsInfo.maxKrog;
             maxKrn_ = epsInfo.maxKrg;
@@ -410,6 +442,20 @@ public:
     { return maxPcnwOrLeverettFactor_; }
 
     /*!
+     * \brief Set wetting-phase relative permeability at residual saturation
+     * of non-wetting phase.
+     */
+    void setKrwr(Scalar value)
+    { this->Krwr_ = value; }
+
+    /*!
+     * \brief Returns wetting-phase relative permeability at residual
+     * saturation of non-wetting phase.
+     */
+    Scalar krwr() const
+    { return this->Krwr_; }
+
+    /*!
      * \brief Sets the maximum wetting phase relative permeability
      */
     void setMaxKrw(Scalar value)
@@ -420,6 +466,20 @@ public:
      */
     Scalar maxKrw() const
     { return maxKrw_; }
+
+    /*!
+     * \brief Set non-wetting phase relative permeability at residual
+     * saturation of wetting phase.
+     */
+    void setKrnr(Scalar value)
+    { this->Krnr_ = value; }
+
+    /*!
+     * \brief Returns non-wetting phase relative permeability at residual
+     * saturation of wetting phase.
+     */
+    Scalar krnr() const
+    { return this->Krnr_; }
 
     /*!
      * \brief Sets the maximum wetting phase relative permeability
@@ -447,8 +507,16 @@ private:
     // Maximum wetting phase relative permability value.
     Scalar maxKrw_;
 
+    // Scaled wetting phase relative permeability value at residual
+    // saturation of non-wetting phase.
+    Scalar Krwr_;
+
     // Maximum non-wetting phase relative permability value
     Scalar maxKrn_;
+
+    // Scaled non-wetting phase relative permeability value at residual
+    // saturation of wetting phase.
+    Scalar Krnr_;
 
     // The the points used for saturation ("x-axis") scaling of capillary pressure
     std::array<Scalar, 3> saturationPcPoints_;

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -198,7 +198,6 @@ struct EclEpsScalingPointsInfo
         update(maxPcgo, epsProperties.pcg(activeIndex));
         update(maxKrw,  epsProperties.krw(activeIndex));
         update(maxKrg,  epsProperties.krg(activeIndex));
-        // quite likely that's wrong!
         update(maxKrow, epsProperties.kro(activeIndex));
         update(maxKrog, epsProperties.kro(activeIndex));
 
@@ -298,32 +297,20 @@ public:
         if (epsSystemType == EclOilWaterSystem) {
             // saturation scaling for capillary pressure
             saturationPcPoints_[0] = epsInfo.Swl;
-            saturationPcPoints_[1] = epsInfo.Swu;
+            saturationPcPoints_[2] = saturationPcPoints_[1] = epsInfo.Swu;
 
             // krw saturation scaling endpoints
-            if (config.enableThreePointKrSatScaling()) {
-                saturationKrwPoints_[0] = epsInfo.Swcr;
-                saturationKrwPoints_[1] = 1.0 - epsInfo.Sowcr - epsInfo.Sgl;
-                saturationKrwPoints_[2] = epsInfo.Swu;
-            }
-            else {
-                saturationKrwPoints_[0] = epsInfo.Swcr;
-                saturationKrwPoints_[1] = epsInfo.Swu;
-            }
+            saturationKrwPoints_[0] = epsInfo.Swcr;
+            saturationKrwPoints_[1] = 1.0 - epsInfo.Sowcr - epsInfo.Sgl;
+            saturationKrwPoints_[2] = epsInfo.Swu;
 
             // krn saturation scaling endpoints (with the non-wetting phase being oil).
             // because opm-material specifies non-wetting phase relperms in terms of the
             // wetting phase saturations, the code here uses 1 minus the values specified
             // by the Eclipse TD and the order of the scaling points is reversed
-            if (config.enableThreePointKrSatScaling()) {
-                saturationKrnPoints_[2] = 1.0 - epsInfo.Sowcr;
-                saturationKrnPoints_[1] = epsInfo.Swcr + epsInfo.Sgl;
-                saturationKrnPoints_[0] = epsInfo.Swl + epsInfo.Sgl;
-            }
-            else {
-                saturationKrnPoints_[1] = 1 - epsInfo.Sowcr;
-                saturationKrnPoints_[0] = epsInfo.Swl + epsInfo.Sgl;
-            }
+            saturationKrnPoints_[2] = 1.0 - epsInfo.Sowcr;
+            saturationKrnPoints_[1] = epsInfo.Swcr + epsInfo.Sgl;
+            saturationKrnPoints_[0] = epsInfo.Swl + epsInfo.Sgl;
 
             if (config.enableLeverettScaling())
                 maxPcnwOrLeverettFactor_ = epsInfo.pcowLeverettFactor;
@@ -337,32 +324,20 @@ public:
 
             // saturation scaling for capillary pressure
             saturationPcPoints_[0] = 1.0 - epsInfo.Sgu;
-            saturationPcPoints_[1] = 1.0 - epsInfo.Sgl;
+            saturationPcPoints_[2] = saturationPcPoints_[1] = 1.0 - epsInfo.Sgl;
 
             // krw saturation scaling endpoints
-            if (config.enableThreePointKrSatScaling()) {
-                saturationKrwPoints_[0] = epsInfo.Sogcr;
-                saturationKrwPoints_[1] = 1 - epsInfo.Sgcr - epsInfo.Swl;
-                saturationKrwPoints_[2] = 1 - epsInfo.Swl - epsInfo.Sgl;
-            }
-            else {
-                saturationKrwPoints_[0] = epsInfo.Sogcr;
-                saturationKrwPoints_[1] = 1 - epsInfo.Swl - epsInfo.Sgl;
-            }
+            saturationKrwPoints_[0] = epsInfo.Sogcr;
+            saturationKrwPoints_[1] = 1 - epsInfo.Sgcr - epsInfo.Swl;
+            saturationKrwPoints_[2] = 1 - epsInfo.Swl - epsInfo.Sgl;
 
             // krn saturation scaling endpoints (with the non-wetting phase being gas).
             // because opm-material specifies non-wetting phase relperms in terms of the
             // wetting phase saturations, the code here uses 1 minus the values specified
             // by the Eclipse TD and the order of the scaling points is reversed
-            if (config.enableThreePointKrSatScaling()) {
-                saturationKrnPoints_[2] = 1.0 - epsInfo.Sgcr;
-                saturationKrnPoints_[1] = epsInfo.Sogcr + epsInfo.Swl;
-                saturationKrnPoints_[0] = 1.0 - epsInfo.Sgu;
-            }
-            else {
-                saturationKrnPoints_[1] = 1.0 - epsInfo.Sgcr;
-                saturationKrnPoints_[0] = 1.0 - epsInfo.Sgu;
-            }
+            saturationKrnPoints_[2] = 1.0 - epsInfo.Sgcr;
+            saturationKrnPoints_[1] = epsInfo.Sogcr + epsInfo.Swl;
+            saturationKrnPoints_[0] = 1.0 - epsInfo.Sgu;
 
             if (config.enableLeverettScaling())
                 maxPcnwOrLeverettFactor_ = epsInfo.pcgoLeverettFactor;
@@ -383,7 +358,7 @@ public:
     /*!
      * \brief Returns the points used for capillary pressure saturation scaling
      */
-    const std::array<Scalar, 2>& saturationPcPoints() const
+    const std::array<Scalar, 3>& saturationPcPoints() const
     { return saturationPcPoints_; }
 
     /*!
@@ -466,17 +441,17 @@ public:
     }
 
 private:
-    // The the points used for the "y-axis" scaling of capillary pressure
+    // Points used for vertical scaling of capillary pressure
     Scalar maxPcnwOrLeverettFactor_;
 
-    // The the points used for the "y-axis" scaling of wetting phase relative permability
+    // Maximum wetting phase relative permability value.
     Scalar maxKrw_;
 
-    // The the points used for the "y-axis" scaling of non-wetting phase relative permability
+    // Maximum non-wetting phase relative permability value
     Scalar maxKrn_;
 
     // The the points used for saturation ("x-axis") scaling of capillary pressure
-    std::array<Scalar, 2> saturationPcPoints_;
+    std::array<Scalar, 3> saturationPcPoints_;
 
     // The the points used for saturation ("x-axis") scaling of wetting phase relative permeability
     std::array<Scalar, 3> saturationKrwPoints_;


### PR DESCRIPTION
This PR adds support for scaling of the relative permeability value for water at the residual saturation of the displacing (non-wetting) phase.  We use pure vertical scaling in the left interval `[SWL, SR]`, and a linear/affine function in the right interval `[SR, SWU]`.