### PR TITLE
Add support for diffusion in the blackoil fluid system

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -267,11 +267,8 @@ public:
                 assert(diffCoeffTable.size() == numRegions);
                 for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
                     const auto& diffCoeffTable = diffCoeffTables[regionIdx];
-                    // if molar weights are not provided in the deck we use the default values
-                    if(diffCoeffTable.oil_mw > 0)
-                        molarMass_[regionIdx][oilCompIdx] = diffCoeffTable.oil_mw;
-                    if(diffCoeffTable.gas_mw > 0)
-                        molarMass_[regionIdx][gasCompIdx] = diffCoeffTable.gas_mw;
+                    molarMass_[regionIdx][oilCompIdx] = diffCoeffTable.oil_mw;
+                    molarMass_[regionIdx][gasCompIdx] = diffCoeffTable.gas_mw;
                     setDiffusionCoefficient(diffCoeffTable.gas_in_gas, gasCompIdx, gasPhaseIdx, regionIdx);
                     setDiffusionCoefficient(diffCoeffTable.oil_in_gas, oilCompIdx, gasPhaseIdx, regionIdx);
                     setDiffusionCoefficient(diffCoeffTable.gas_in_oil, gasCompIdx, oilPhaseIdx, regionIdx);

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -1274,6 +1274,26 @@ public:
         return canonicalToActivePhaseIdx_[phaseIdx];
     }
 
+    /*!
+     * \copydoc BaseFluidSystem::diffusionCoefficient
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
+    static LhsEval diffusionCoefficient(const FluidState& fluidState,
+                                        const ParameterCache<ParamCacheEval>& /*paramCache*/,
+                                        unsigned phaseIdx,
+                                        unsigned compIdx)
+    {
+        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+
+        switch (phaseIdx) {
+        case oilPhaseIdx: return oilPvt().diffusionCoefficient(T, p, compIdx);
+        case gasPhaseIdx: return gasPvt().diffusionCoefficient(T, p, compIdx);
+        case waterPhaseIdx: return 0.0;
+        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        }
+    }
+
 private:
     static void resizeArrays_(size_t numRegions)
     {

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -264,7 +264,7 @@ public:
                 // if diffusion coefficient table is empty we relay on the PVT model to
                 // to give us the coefficients.
                 diffusionCoefficients_.resize(numRegions,{0,0,0,0,0,0,0,0,0});
-                assert(diffCoeffTable.size() == numRegions);
+                assert(diffCoeffTables.size() == numRegions);
                 for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
                     const auto& diffCoeffTable = diffCoeffTables[regionIdx];
                     molarMass_[regionIdx][oilCompIdx] = diffCoeffTable.oil_mw;

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -282,7 +282,15 @@ public:
                                     const Evaluation& pressure,
                                     unsigned /*compIdx*/) const
     {
-        return BinaryCoeffBrineCO2::liquidDiffCoeff(temperature, pressure);
+        //Diffusion coefficient of CO2 in pure water according to (McLachlan and Danckwerts, 1972)
+        const Evaluation log_D_H20 = -4.1764 + 712.52 / temperature - 2.5907e5 / (temperature*temperature);
+
+        //Diffusion coefficient of CO2 in the brine phase modified following (Ratcliff and Holdcroft,1963 and Al-Rawajfeh, 2004)
+        const Evaluation& mu_H20 = H2O::liquidViscosity(temperature, pressure); // Water viscosity
+        const Evaluation& mu_Brine = Brine::liquidViscosity(temperature, pressure); // Brine viscosity
+        const Evaluation log_D_Brine = log_D_H20 - 0.87*Opm::log10(mu_Brine / mu_H20);
+
+        return Opm::pow(Evaluation(10), log_D_Brine) * 1e-4; // convert from cm2/s to m2/s
     }
 
 private:

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -57,8 +57,6 @@ template <class Scalar>
 class BrineCo2Pvt
 {
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
-    typedef Opm::SimpleHuDuanH2O<Scalar> H2O;
-    typedef Opm::Brine<Scalar, H2O> Brine;
 
     //typedef Opm::H2O<Scalar> H2O_IAPWS;
     //typedef Opm::Brine<Scalar, H2O_IAPWS> Brine_IAPWS;
@@ -68,9 +66,12 @@ class BrineCo2Pvt
     //typedef H2O_Tabulated H2O;
     //typedef Brine_Tabulated Brine;
 
-    typedef Opm::CO2<Scalar, CO2Tables> CO2;
 
 public:
+    typedef Opm::SimpleHuDuanH2O<Scalar> H2O;
+    typedef Opm::Brine<Scalar, H2O> Brine;
+    typedef Opm::CO2<Scalar, CO2Tables> CO2;
+
     typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
 
     //! The binary coefficients for brine and CO2 used by this fluid system
@@ -380,8 +381,8 @@ private:
     LhsEval convertXoGToxoG_(const LhsEval& XoG) const
     {
         Scalar M_CO2 = CO2::molarMass();
-        Scalar M_H2O = H2O::molarMass();
-        return XoG*M_H2O / (M_CO2*(1 - XoG) + XoG*M_H2O);
+        Scalar M_Brine = Brine::molarMass();
+        return XoG*M_Brine / (M_CO2*(1 - XoG) + XoG*M_Brine);
     }
 
 
@@ -392,9 +393,9 @@ private:
     LhsEval convertxoGToXoG(const LhsEval& xoG) const
     {
         Scalar M_CO2 = CO2::molarMass();
-        Scalar M_H2O = H2O::molarMass();
+        Scalar M_Brine = Brine::molarMass();
 
-        return xoG*M_CO2 / (xoG*(M_CO2 - M_H2O) + M_H2O);
+        return xoG*M_CO2 / (xoG*(M_CO2 - M_Brine) + M_Brine);
     }
 
 

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -276,6 +276,14 @@ public:
                 brineReferenceDensity_ == data.brineReferenceDensity_;
     }
 
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& temperature,
+                                    const Evaluation& pressure,
+                                    unsigned /*compIdx*/) const
+    {
+        return BinaryCoeffBrineCO2::liquidDiffCoeff(temperature, pressure);
+    }
+
 private:
     std::vector<Scalar> brineReferenceDensity_;
     std::vector<Scalar> co2ReferenceDensity_;

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -272,6 +272,14 @@ public:
                                   const Evaluation& /*Rs*/) const
     { return 0.0; /* this is dead oil, so there isn't any meaningful saturation pressure! */ }
 
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& /*temperature*/,
+                                    const Evaluation& /*pressure*/,
+                                    unsigned /*compIdx*/) const
+    {
+        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+    }
+
     const Scalar oilReferenceDensity(unsigned regionIdx) const
     { return oilReferenceDensity_[regionIdx]; }
 

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -278,6 +278,14 @@ public:
                                         const Evaluation& /*pressure*/) const
     { return 0.0; /* this is dead oil! */ }
 
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& /*temperature*/,
+                                    const Evaluation& /*pressure*/,
+                                    unsigned /*compIdx*/) const
+    {
+        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+    }
+
     const Scalar oilReferenceDensity(unsigned regionIdx) const
     { return oilReferenceDensity_[regionIdx]; }
 

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -288,6 +288,14 @@ public:
                                               const Evaluation& /*pressure*/) const
     { return 0.0; /* this is dry gas! */ }
 
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& /*temperature*/,
+                                    const Evaluation& /*pressure*/,
+                                    unsigned /*compIdx*/) const
+    {
+        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+    }
+
     const Scalar gasReferenceDensity(unsigned regionIdx) const
     { return gasReferenceDensity_[regionIdx]; }
 

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -273,6 +273,17 @@ public:
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturationPressure(regionIdx, temperature, Rv)); return 0; }
 
     /*!
+     * \copydoc BaseFluidSystem::diffusionCoefficient
+     */
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& temperature,
+                                    const Evaluation& pressure,
+                                    unsigned compIdx) const
+    {
+      OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.diffusionCoefficient(temperature, pressure, compIdx)); return 0;
+    }
+
+    /*!
      * \brief Returns the concrete approach for calculating the PVT relations.
      *
      * (This is only determined at runtime.)

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -367,6 +367,13 @@ public:
                                   const Evaluation& pressure) const
     { return isothermalPvt_->saturationPressure(regionIdx, temperature, pressure); }
 
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& temperature,
+                                    const Evaluation& pressure,
+                                    unsigned compIdx) const
+    {
+        return isothermalPvt_->diffusionCoefficient(temperature, pressure, compIdx);
+    }
     const IsothermalPvt* isoThermalPvt() const
     { return isothermalPvt_; }
 

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -602,6 +602,13 @@ public:
         throw NumericalIssue(errlog.str());
     }
 
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& /*temperature*/,
+                                    const Evaluation& /*pressure*/,
+                                    unsigned /*compIdx*/) const
+    {
+        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+    }
     const Scalar gasReferenceDensity(unsigned regionIdx) const
     { return gasReferenceDensity_[regionIdx]; }
 

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -266,6 +266,17 @@ public:
                                   const Evaluation& Rs) const
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.saturationPressure(regionIdx, temperature, Rs)); return 0; }
 
+    /*!
+     * \copydoc BaseFluidSystem::diffusionCoefficient
+     */
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& temperature,
+                                    const Evaluation& pressure,
+                                    unsigned compIdx) const
+    {
+      OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.diffusionCoefficient(temperature, pressure, compIdx)); return 0;
+    }
+
     void setApproach(OilPvtApproach appr)
     {
         switch (appr) {

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -377,6 +377,14 @@ public:
                                   const Evaluation& pressure) const
     { return isothermalPvt_->saturationPressure(regionIdx, temperature, pressure); }
 
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& temperature,
+                                    const Evaluation& pressure,
+                                    unsigned compIdx) const
+    {
+        return isothermalPvt_->diffusionCoefficient(temperature, pressure, compIdx);
+    }
+
     const IsothermalPvt* isoThermalPvt() const
     { return isothermalPvt_; }
 

--- a/opm/material/fluidsystems/blackoilpvt/SolventPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/SolventPvt.hpp
@@ -189,6 +189,14 @@ public:
         return invBg/invMugBg;
     }
 
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& /*temperature*/,
+                                    const Evaluation& /*pressure*/,
+                                    unsigned /*compIdx*/) const
+    {
+        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+    }
+
     /*!
      * \brief Return the reference density the solvent phase for a given PVT region
      */

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -628,6 +628,14 @@ public:
         throw NumericalIssue(errlog.str());
     }
 
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& /*temperature*/,
+                                    const Evaluation& /*pressure*/,
+                                    unsigned /*compIdx*/) const
+    {
+        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+    }
+
     const Scalar gasReferenceDensity(unsigned regionIdx) const
     { return gasReferenceDensity_[regionIdx]; }
 


### PR DESCRIPTION
Diffusion coefficients and molar weights are defaulted for the co2-brine module for standard blackoil they must be provided by DIFFC. 

This PR depends on OPM/opm-common#2224
