### PR TITLE
add missing internal energy function in CO2-Brine module

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -124,11 +124,11 @@ public:
      */
     template <class Evaluation>
     Evaluation internalEnergy(unsigned regionIdx OPM_UNUSED,
-                        const Evaluation& temperature OPM_UNUSED,
-                        const Evaluation& pressure OPM_UNUSED,
+                        const Evaluation& temperature,
+                        const Evaluation& pressure,
                         const Evaluation& Rv OPM_UNUSED) const
     {
-        throw std::runtime_error("Requested the enthalpy of gas but the thermal option is not enabled");
+        return CO2::gasInternalEnergy(temperature, pressure);
     }
 
     /*!


### PR DESCRIPTION
The liquidEnthalpyBrineCO2_ function is copied from the BrineCo2FluidSystem.hh. i.e. the PR is more or a less trivial. 
I have tested this in combination with Flow using the CO2STOR option with THERMAL and energyEnabled.  