### PR TITLE
Explicitly Prevent Negative 3-p Kro Values in Stone 2 Model

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
@@ -362,7 +362,7 @@ public:
         const Evaluation krg = GasOilMaterialLaw::twoPhaseSatKrn(params.gasOilParams(), 1 - Swco - Sg);
         const Evaluation krog = GasOilMaterialLaw::twoPhaseSatKrw(params.gasOilParams(), 1 - Swco - Sg);
 
-        return krocw * ((krow/krocw + krw) * (krog/krocw + krg) - krw - krg);
+        return Opm::max(krocw * ((krow/krocw + krw) * (krog/krocw + krg) - krw - krg), Evaluation{0});
     }
 
     /*!


### PR DESCRIPTION
This makes the material balance equations converge more smoothly in corner cases and makes a real field case run at all.