### PR TITLE
Adaptations neededed for gas-water system

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -241,15 +241,17 @@ public:
             this->enableKrwScaling_ = hasKR("W") || this->enableThreePointKrwScaling();
             this->enablePcScaling_  = hasPC("W") || fp.has_double("SWATINIT");
         }
-        else {
-            assert(twoPhaseSystemType == EclGasOilSystem);
-
+        else if (twoPhaseSystemType == EclGasOilSystem) {
             this->setEnableThreePointKrwScaling(hasKR("ORG"));
             this->setEnableThreePointKrnScaling(hasKR("GR"));
 
             this->enableKrnScaling_ = hasKR("G") || this->enableThreePointKrnScaling();
             this->enableKrwScaling_ = hasKR("O") || this->enableThreePointKrwScaling();
             this->enablePcScaling_  = hasPC("G");
+        }
+        else {
+            assert(twoPhaseSystemType == EclGasWaterSystem);
+            //TODO enable endpoint scaling for gaswater system
         }
 
         if (enablePcScaling_ && enableLeverettScaling_) {

--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -49,6 +49,7 @@ namespace Opm {
 enum EclTwoPhaseSystemType {
     EclGasOilSystem,
     EclOilWaterSystem,
+    EclGasWaterSystem
 };
 
 /*!

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -344,7 +344,7 @@ public:
             maxKrn_ = epsInfo.maxKrow;
         }
         else {
-            assert(epsSystemType == EclGasOilSystem);
+            assert((epsSystemType == EclGasOilSystem) ||(epsSystemType == EclGasWaterSystem) );
 
             // saturation scaling for capillary pressure
             saturationPcPoints_[0] = 1.0 - epsInfo.Swl - epsInfo.Sgu;

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -952,7 +952,6 @@ private:
                                         const Opm::EclipseState& eclState,
                                         unsigned satRegionIdx)
     {
-        //if (!hasGas || !hasWater)
         if (hasOil)
             // we don't read anything if oil is present
             return;
@@ -1030,7 +1029,6 @@ private:
                                      const Opm::EclipseState& /* eclState */,
                                      unsigned satRegionIdx)
     {
-        //if (!hasGas || !hasWater)
         if (hasOil)
             // we don't read anything if oil phase is active
             return;

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -367,7 +367,7 @@ public:
                                                            EclOilWaterSystem);
             }
 
-            if (hasGas && hasWater) {
+            if (hasGas && hasWater && !hasOil) {
                 auto gasWaterDrainParams = std::make_shared<GasWaterEpsTwoPhaseParams>();
                 gasWaterDrainParams->setConfig(gasWaterConfig);
                 gasWaterDrainParams->setUnscaledPoints(gasWaterUnscaledPointsVector_[satRegionIdx]);
@@ -410,7 +410,7 @@ public:
                                                                  EclGasOilSystem);
                 }
 
-                if (hasGas && hasWater) {
+                if (hasGas && hasWater && !hasOil) {
                     auto gasWaterImbParamsHyst = std::make_shared<GasWaterEpsTwoPhaseParams>();
                     gasWaterImbParamsHyst->setConfig(gasWaterConfig);
                     gasWaterImbParamsHyst->setUnscaledPoints(gasWaterUnscaledPointsVector_[imbRegionIdx]);
@@ -430,7 +430,7 @@ public:
             if (hasOil && hasWater)
                 oilWaterParams[elemIdx]->finalize();
 
-            if (hasGas && hasWater)
+            if (hasGas && hasWater && !hasOil)
                 gasWaterParams[elemIdx]->finalize();
         }
 
@@ -952,8 +952,9 @@ private:
                                         const Opm::EclipseState& eclState,
                                         unsigned satRegionIdx)
     {
-        if (!hasGas || !hasWater)
-            // we don't read anything if either the gas or the water phase is not active
+        //if (!hasGas || !hasWater)
+        if (hasOil)
+            // we don't read anything if oil is present
             return;
 
         dest[satRegionIdx] = std::make_shared<GasWaterEffectiveTwoPhaseParams>();
@@ -1029,8 +1030,9 @@ private:
                                      const Opm::EclipseState& /* eclState */,
                                      unsigned satRegionIdx)
     {
-        if (!hasGas || !hasWater)
-            // we don't read anything if either the water or the oil phase is not active
+        //if (!hasGas || !hasWater)
+        if (hasOil)
+            // we don't read anything if oil phase is active
             return;
 
         dest[satRegionIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -960,6 +960,9 @@ private:
 
         auto& effParams = *dest[satRegionIdx];
 
+        const auto tolcrit = eclState.runspec().saturationFunctionControls()
+            .minimumRelpermMobilityThreshold();
+
         const auto& tableManager = eclState.getTableManager();
 
         switch (eclState.runspec().saturationFunctionControls().family()) {
@@ -977,10 +980,10 @@ private:
 
             std::vector<double> SwColumn = swfnTable.getColumn("SW").vectorCopy();
             
-            effParams.setKrwSamples(SwColumn, swfnTable.getColumn("KRW").vectorCopy());
-            effParams.setKrnSamples(SwColumn, sgfnTable.getColumn("KRG").vectorCopy());
+            effParams.setKrwSamples(SwColumn, normalizeKrValues_(tolcrit, swfnTable.getColumn("KRW")));
+            effParams.setKrnSamples(SwColumn, normalizeKrValues_(tolcrit, sgfnTable.getColumn("KRG")));
             //Capillary pressure is read from SWFN. 
-            //For gas-water system the capillary pressure column valeas are set to 0 in SGFN
+            //For gas-water system the capillary pressure column values are set to 0 in SGFN
             effParams.setPcnwSamples(SwColumn, swfnTable.getColumn("PCOW").vectorCopy());
             effParams.finalize();
                        

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -968,8 +968,7 @@ private:
         switch (eclState.runspec().saturationFunctionControls().family()) {
         case SatFuncControls::KeywordFamily::Family_I:
         {
-            // No Family I applicable in this case
-            break;
+            throw std::domain_error("Saturation keyword family I is not applicable for a gas-water system");
         }
 
         case SatFuncControls::KeywordFamily::Family_II:

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -952,8 +952,8 @@ private:
                                         const Opm::EclipseState& eclState,
                                         unsigned satRegionIdx)
     {
-        if (hasOil)
-            // we don't read anything if oil is present
+        if (!hasGas || !hasWater || hasOil)
+            // we don't read anything if either the gas or the water phase is not active or if oil is present
             return;
 
         dest[satRegionIdx] = std::make_shared<GasWaterEffectiveTwoPhaseParams>();

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -49,19 +49,22 @@ namespace Opm {
 template <class TraitsT,
           class GasOilMaterialLawT,
           class OilWaterMaterialLawT,
+          class GasWaterMaterialLawT,
           class ParamsT = EclMultiplexerMaterialParams<TraitsT,
                                                        GasOilMaterialLawT,
-                                                       OilWaterMaterialLawT> >
+                                                       OilWaterMaterialLawT,
+                                                       GasWaterMaterialLawT> >
 class EclMultiplexerMaterial : public TraitsT
 {
 public:
     typedef GasOilMaterialLawT GasOilMaterialLaw;
     typedef OilWaterMaterialLawT OilWaterMaterialLaw;
+    typedef GasWaterMaterialLawT GasWaterMaterialLaw;
 
     typedef Opm::EclStone1Material<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw> Stone1Material;
     typedef Opm::EclStone2Material<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw> Stone2Material;
     typedef Opm::EclDefaultMaterial<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw> DefaultMaterial;
-    typedef Opm::EclTwoPhaseMaterial<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw> TwoPhaseMaterial;
+    typedef Opm::EclTwoPhaseMaterial<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw, GasWaterMaterialLaw> TwoPhaseMaterial;
 
     // some safety checks
     static_assert(TraitsT::numPhases == 3,
@@ -72,6 +75,9 @@ public:
                   "pressure law must be two!");
     static_assert(OilWaterMaterialLaw::numPhases == 2,
                   "The number of phases considered by the oil-water capillary "
+                  "pressure law must be two!");
+    static_assert(GasWaterMaterialLaw::numPhases == 2,
+                  "The number of phases considered by the gas-water capillary "
                   "pressure law must be two!");
     static_assert(std::is_same<typename GasOilMaterialLaw::Scalar,
                                typename OilWaterMaterialLaw::Scalar>::value,

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -55,7 +55,7 @@ enum class EclMultiplexerApproach {
  * Essentially, this class just stores parameter object for the "nested" material law and
  * provides some methods to convert to it.
  */
-template<class Traits, class GasOilMaterialLawT, class OilWaterMaterialLawT>
+template<class Traits, class GasOilMaterialLawT, class OilWaterMaterialLawT, class GasWaterMaterialLawT>
 class EclMultiplexerMaterialParams : public Traits, public EnsureFinalized
 {
     typedef typename Traits::Scalar Scalar;
@@ -64,7 +64,7 @@ class EclMultiplexerMaterialParams : public Traits, public EnsureFinalized
     typedef Opm::EclStone1Material<Traits, GasOilMaterialLawT, OilWaterMaterialLawT> Stone1Material;
     typedef Opm::EclStone2Material<Traits, GasOilMaterialLawT, OilWaterMaterialLawT> Stone2Material;
     typedef Opm::EclDefaultMaterial<Traits, GasOilMaterialLawT, OilWaterMaterialLawT> DefaultMaterial;
-    typedef Opm::EclTwoPhaseMaterial<Traits, GasOilMaterialLawT, OilWaterMaterialLawT> TwoPhaseMaterial;
+    typedef Opm::EclTwoPhaseMaterial<Traits, GasOilMaterialLawT, OilWaterMaterialLawT, GasWaterMaterialLawT> TwoPhaseMaterial;
 
     typedef typename Stone1Material::Params Stone1Params;
     typedef typename Stone2Material::Params Stone2Params;

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
@@ -47,7 +47,7 @@ enum class EclTwoPhaseApproach {
  * Essentially, this class just stores the two parameter objects for
  * the twophase capillary pressure laws.
  */
-template<class Traits, class GasOilParamsT, class OilWaterParamsT>
+template<class Traits, class GasOilParamsT, class OilWaterParamsT, class GasWaterParamsT>
 class EclTwoPhaseMaterialParams : public EnsureFinalized
 {
     typedef typename Traits::Scalar Scalar;
@@ -58,6 +58,7 @@ public:
 
     typedef GasOilParamsT GasOilParams;
     typedef OilWaterParamsT OilWaterParams;
+    typedef GasWaterParamsT GasWaterParams;
 
     /*!
      * \brief The default constructor.
@@ -108,11 +109,30 @@ public:
     void setOilWaterParams(std::shared_ptr<OilWaterParams> val)
     { oilWaterParams_ = val; }
 
+  /*!
+     * \brief The parameter object for the gas-water twophase law.
+     */
+    const GasWaterParams& gasWaterParams() const
+    { EnsureFinalized::check(); return *gasWaterParams_; }
+
+    /*!
+     * \brief The parameter object for the gas-water twophase law.
+     */
+    GasWaterParams& gasWaterParams()
+    { EnsureFinalized::check(); return *gasWaterParams_; }
+
+    /*!
+     * \brief Set the parameter object for the gas-water twophase law.
+     */
+    void setGasWaterParams(std::shared_ptr<GasWaterParams> val)
+    { gasWaterParams_ = val; }
+    
 private:
     EclTwoPhaseApproach approach_;
 
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;
+    std::shared_ptr<GasWaterParams> gasWaterParams_;
 };
 } // namespace Opm
 

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -341,7 +341,8 @@ inline void testAll()
         typedef Opm::BrooksCorey<TwoPhaseTraits> TwoPhaseMaterial;
         typedef Opm::EclTwoPhaseMaterial<ThreePhaseTraits,
                                          /*GasOilMaterial=*/TwoPhaseMaterial,
-                                         /*OilWaterMaterial=*/TwoPhaseMaterial> MaterialLaw;
+                                         /*OilWaterMaterial=*/TwoPhaseMaterial,
+                                         /*GasWaterMaterial=*/TwoPhaseMaterial> MaterialLaw;
         testGenericApi<MaterialLaw, ThreePhaseFluidState>();
         testThreePhaseApi<MaterialLaw, ThreePhaseFluidState>();
         //testThreePhaseSatApi<MaterialLaw, ThreePhaseFluidState>();
@@ -350,7 +351,8 @@ inline void testAll()
         typedef Opm::BrooksCorey<TwoPhaseTraits> TwoPhaseMaterial;
         typedef Opm::EclMultiplexerMaterial<ThreePhaseTraits,
                                             /*GasOilMaterial=*/TwoPhaseMaterial,
-                                            /*OilWaterMaterial=*/TwoPhaseMaterial> MaterialLaw;
+                                            /*OilWaterMaterial=*/TwoPhaseMaterial,
+                                            /*GasWaterMaterial=*/TwoPhaseMaterial> MaterialLaw;
         testGenericApi<MaterialLaw, ThreePhaseFluidState>();
         testThreePhaseApi<MaterialLaw, ThreePhaseFluidState>();
         //testThreePhaseSatApi<MaterialLaw, ThreePhaseFluidState>();


### PR DESCRIPTION
Material laws needed for two-phase water-gas system.
Further work is required and ongoing on opm-models  and opm-simulators. 

