### PR TITLE
Extrapolate oil viscosity temperature factor for undersaturated case

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -265,7 +265,7 @@ public:
             return isothermalMu;
 
         // compute the viscosity deviation due to temperature
-        const auto& muOilvisct = oilvisctCurves_[regionIdx].eval(temperature);
+        const auto& muOilvisct = oilvisctCurves_[regionIdx].eval(temperature, /*extrapolate=*/true);
         return muOilvisct/viscRef_[regionIdx]*isothermalMu;
     }
 
@@ -282,7 +282,7 @@ public:
             return isothermalMu;
 
         // compute the viscosity deviation due to temperature
-        const auto& muOilvisct = oilvisctCurves_[regionIdx].eval(temperature, true);
+        const auto& muOilvisct = oilvisctCurves_[regionIdx].eval(temperature, /*extrapolate=*/true);
         return muOilvisct/viscRef_[regionIdx]*isothermalMu;
     }
 


### PR DESCRIPTION
The linear extrapolation for oil viscosity temperature factor for the undersatured case is missing. 

