### PR TITLE
add libpython3-dev to debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: build-essential, debhelper (>= 9),
                libdune-common-dev, libdune-istl-dev, cmake, bc,
                git, zlib1g-dev, libtool, doxygen,
                texlive-latex-extra, texlive-latex-recommended, ghostscript,
-               mpi-default-dev, mpi-default-bin
+               mpi-default-dev, mpi-default-bin, libpython3-dev
 Standards-Version: 3.9.2
 Section: libs
 Homepage: http://opm-project.org


### PR DESCRIPTION
needed since we now build embedded python support
in opm-common

Sorry for being late with this, so much going on atm (quarantine for my teenager, toddler at home, ..)