### PR TITLE
Machine readable debian/copyright for review

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,13 +1,273 @@
-License: GPL-3+
- This package is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 3 of the License, or
- (at your option) any later version.
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: opm-material
+Upstream-Contact: opm@opm-project.org
+Source: <https://github.com/OPM/opm-material>
+Comment: We use the name "OPM development team", to denote that parts
+     of individual files might be copyright by
+     Dr. Blatt - HPC-Simulation-Software & Services,
+     IWS-LH2 at University of Stuttgart, NORCE, Poware (Andreas Lauser), SINTEF,
+     or TNO.
+Files-Excluded: external
+    redhat
+    debian
+    .git*
+    jenkins
+    .clang-format
+    travis
 
+Files: *
+Copyright: 2013-2021 Equinor ASA
+   2012-2021 OPM development team
+License: GPL-3.0+
+
+Files: debian/*
+Copyright: 2013-2021 Equinor ASA
+   2013-2021 OPM development team
+License: GPL-3.0+
+
+Files: bin/genEvalSpecializations.py
+ opm/material/Constants.hpp
+ opm/material/IdealGas.hpp
+ opm/material/binarycoefficients/Air_Mesitylene.hpp
+ opm/material/binarycoefficients/Air_Xylene.hpp
+ opm/material/binarycoefficients/Brine_CO2.hpp
+ opm/material/binarycoefficients/FullerMethod.hpp
+ opm/material/binarycoefficients/H2O_Air.hpp
+ opm/material/binarycoefficients/H2O_CO2.hpp
+ opm/material/binarycoefficients/H2O_Mesitylene.hpp
+ opm/material/binarycoefficients/H2O_N2.hpp
+ opm/material/binarycoefficients/H2O_Xylene.hpp
+ opm/material/binarycoefficients/HenryIapws.hpp
+ opm/material/checkFluidSystem.hpp
+ opm/material/common/ConditionalStorage.hpp
+ opm/material/common/EnsureFinalized.hpp
+ opm/material/common/Exceptions.hpp
+ opm/material/common/FastSmallVector.hpp
+ opm/material/common/HasMemberGeneratorMacros.hpp
+ opm/material/common/IntervalTabulated2DFunction.hpp
+ opm/material/common/MathToolbox.hpp
+ opm/material/common/Means.hpp
+ opm/material/common/OpmFinal.hpp
+ opm/material/common/PolynomialUtils.hpp
+ opm/material/common/Spline.hpp
+ opm/material/common/Tabulated1DFunction.hpp
+ opm/material/common/TridiagonalMatrix.hpp
+ opm/material/common/UniformTabulated2DFunction.hpp
+ opm/material/common/UniformXTabulated2DFunction.hpp
+ opm/material/common/Valgrind.hpp
+ opm/material/common/quad.hpp
+ opm/material/components/Air.hpp
+ opm/material/components/Brine.hpp
+ opm/material/components/CO2.hpp
+ opm/material/components/Component.hpp
+ opm/material/components/Dnapl.hpp
+ opm/material/components/Lnapl.hpp
+ opm/material/components/Mesitylene.hpp
+ opm/material/components/N2.hpp
+ opm/material/components/NullComponent.hpp
+ opm/material/components/SimpleCO2.hpp
+ opm/material/components/SimpleH2O.hpp
+ opm/material/components/SimpleHuDuanH2O.hpp
+ opm/material/components/TabulatedComponent.hpp
+ opm/material/components/Unit.hpp
+ opm/material/components/Xylene.hpp
+ opm/material/components/iapws/Region1.hpp
+ opm/material/components/iapws/Region2.hpp
+ opm/material/components/iapws/Region4.hpp
+ opm/material/constraintsolvers/CompositionFromFugacities.hpp
+ opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
+ opm/material/constraintsolvers/ImmiscibleFlash.hpp
+ opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
+ opm/material/constraintsolvers/NcpFlash.hpp
+ opm/material/densead/DynamicEvaluation.hpp
+ opm/material/densead/Evaluation.hpp
+ opm/material/densead/Evaluation1.hpp
+ opm/material/densead/Evaluation10.hpp
+ opm/material/densead/Evaluation11.hpp
+ opm/material/densead/Evaluation12.hpp
+ opm/material/densead/Evaluation2.hpp
+ opm/material/densead/Evaluation3.hpp
+ opm/material/densead/Evaluation4.hpp
+ opm/material/densead/Evaluation5.hpp
+ opm/material/densead/Evaluation6.hpp
+ opm/material/densead/Evaluation7.hpp
+ opm/material/densead/Evaluation8.hpp
+ opm/material/densead/Evaluation9.hpp
+ opm/material/densead/EvaluationSpecializations.hpp
+ opm/material/densead/Math.hpp
+ opm/material/eos/PengRobinson.hpp
+ opm/material/eos/PengRobinsonMixture.hpp
+ opm/material/eos/PengRobinsonParams.hpp
+ opm/material/eos/PengRobinsonParamsMixture.hpp
+ opm/material/fluidmatrixinteractions/BrooksCorey.hpp
+ opm/material/fluidmatrixinteractions/BrooksCoreyParams.hpp
+ opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+ opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+ opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
+ opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+ opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+ opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
+ opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+ opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+ opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+ opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+ opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+ opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+ opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+ opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
+ opm/material/fluidmatrixinteractions/EclStone2Material.hpp
+ opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
+ opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+ opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+ opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp
+ opm/material/fluidmatrixinteractions/EffToAbsLawParams.hpp
+ opm/material/fluidmatrixinteractions/LinearMaterial.hpp
+ opm/material/fluidmatrixinteractions/LinearMaterialParams.hpp
+ opm/material/fluidmatrixinteractions/MaterialTraits.hpp
+ opm/material/fluidmatrixinteractions/NullMaterial.hpp
+ opm/material/fluidmatrixinteractions/NullMaterialParams.hpp
+ opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
+ opm/material/fluidmatrixinteractions/ParkerLenhardParams.hpp
+ opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+ opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+ opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp
+ opm/material/fluidmatrixinteractions/RegularizedBrooksCoreyParams.hpp
+ opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp
+ opm/material/fluidmatrixinteractions/RegularizedVanGenuchtenParams.hpp
+ opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
+ opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterialParams.hpp
+ opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
+ opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchtenParams.hpp
+ opm/material/fluidmatrixinteractions/VanGenuchten.hpp
+ opm/material/fluidmatrixinteractions/VanGenuchtenParams.hpp
+ opm/material/fluidstates/BlackOilFluidState.hpp
+ opm/material/fluidstates/CompositionalFluidState.hpp
+ opm/material/fluidstates/FluidStateCompositionModules.hpp
+ opm/material/fluidstates/FluidStateDensityModules.hpp
+ opm/material/fluidstates/FluidStateEnthalpyModules.hpp
+ opm/material/fluidstates/FluidStateFugacityModules.hpp
+ opm/material/fluidstates/FluidStatePressureModules.hpp
+ opm/material/fluidstates/FluidStateSaturationModules.hpp
+ opm/material/fluidstates/FluidStateTemperatureModules.hpp
+ opm/material/fluidstates/FluidStateViscosityModules.hpp
+ opm/material/fluidstates/ImmiscibleFluidState.hpp
+ opm/material/fluidstates/ModularFluidState.hpp
+ opm/material/fluidstates/NonEquilibriumFluidState.hpp
+ opm/material/fluidstates/PressureOverlayFluidState.hpp
+ opm/material/fluidstates/SaturationOverlayFluidState.hpp
+ opm/material/fluidstates/SimpleModularFluidState.hpp
+ opm/material/fluidstates/TemperatureOverlayFluidState.hpp
+ opm/material/fluidsystems/BaseFluidSystem.hpp
+ opm/material/fluidsystems/BlackOilDefaultIndexTraits.hpp
+ opm/material/fluidsystems/BlackOilFluidSystem.hpp
+ opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+ opm/material/fluidsystems/GasPhase.hpp
+ opm/material/fluidsystems/H2OAirFluidSystem.hpp
+ opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+ opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
+ opm/material/fluidsystems/H2ON2FluidSystem.hpp
+ opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+ opm/material/fluidsystems/LiquidPhase.hpp
+ opm/material/fluidsystems/NullParameterCache.hpp
+ opm/material/fluidsystems/ParameterCacheBase.hpp
+ opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
+ opm/material/fluidsystems/Spe5FluidSystem.hpp
+ opm/material/fluidsystems/Spe5ParameterCache.hpp
+ opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
+ opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+ opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+ opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
+ opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+ opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+ opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+ opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+ opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+ opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+ opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+ opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+ opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+ opm/material/fluidsystems/blackoilpvt/SolventPvt.hpp
+ opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+ opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+ opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+ opm/material/thermal/ConstantSolidHeatCapLaw.hpp
+ opm/material/thermal/ConstantSolidHeatCapLawParams.hpp
+ opm/material/thermal/EclHeatcrLaw.hpp
+ opm/material/thermal/EclHeatcrLawParams.hpp
+ opm/material/thermal/EclSolidEnergyLawMultiplexer.hpp
+ opm/material/thermal/EclSolidEnergyLawMultiplexerParams.hpp
+ opm/material/thermal/EclSpecrockLaw.hpp
+ opm/material/thermal/EclSpecrockLawParams.hpp
+ opm/material/thermal/EclThcLaw.hpp
+ opm/material/thermal/EclThcLawParams.hpp
+ opm/material/thermal/EclThconrLaw.hpp
+ opm/material/thermal/EclThconrLawParams.hpp
+ opm/material/thermal/EclThermalConductionLawMultiplexer.hpp
+ opm/material/thermal/EclThermalConductionLawMultiplexerParams.hpp
+ opm/material/thermal/EclThermalLawManager.hpp
+ opm/material/thermal/FluidThermalConductionLaw.hpp
+ opm/material/thermal/FluidThermalConductionLawParams.hpp
+ opm/material/thermal/NullSolidEnergyLaw.hpp
+ opm/material/thermal/NullThermalConductionLaw.hpp
+ opm/material/thermal/SomertonThermalConductionLaw.hpp
+ opm/material/thermal/SomertonThermalConductionLawParams.hpp
+ tests/checkComponent.hpp
+ tests/test_2dtables.cpp
+ tests/test_ConditionalStorage.cpp
+ tests/test_blackoilfluidstate.cpp
+ tests/test_co2brinepvt.cpp
+ tests/test_components.cpp
+ tests/test_densead.cpp
+ tests/test_eclblackoilpvt.cpp
+ tests/test_eclmateriallawmanager.cpp
+ tests/test_fluidmatrixinteractions.cpp
+ tests/test_fluidsystems.cpp
+ tests/test_immiscibleflash.cpp
+ tests/test_ncpflash.cpp
+ tests/test_pengrobinson.cpp
+ tests/test_spline.cpp
+ tests/test_tabulation.cpp
+Copyright: 2013-2020 Equinor ASA
+   2012-2020 OPM development team
+License: GPL-2.0+
+
+Files: opm/material/components/H2O.hpp
+ opm/material/components/iapws/Common.hpp
+Copyright: 2013-2021 Equinor ASA
+   2012-2021 OPM development team
+   2004-2009, John Pye
+License: GPL-2.0+
+
+License: GPL-3.0+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
  This package is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
-
+ .
  You should have received a copy of the GNU General Public License
- along with this program. If not, see <http://www.gnu.org/licenses/>
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU General
+ Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+
+License: GPL-2.0+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU General
+ Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".


### PR DESCRIPTION
This is the version we are proposing for the Debian packages. It is my best attempt from the copyright statements of the individual files without reviewing all individual commits (and confidential/unknown contracts). Please review and propose any (reasonable) changes via PRs to my branch.

To express the uncertainty (and lacking maintenance of the copyright headers in the files), I have added "OPM development team" at some occasions.

Please note that the clearest copyright is probably for opm-grid and opm-simulators.

Also note that embedded external source copies are exclude (as they are not part of Debian packages)

@akva2 Not sure what debhelper version this requires. Hence be careful when merging this for Ubuntu.