### PR TITLE
fixed: do not use Opm:: prefix within Opm namespace part 2

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -898,12 +898,12 @@ using DynamicEvaluation = Evaluation<Scalar, DynamicSize, staticSize>;
 {% if numDerivs < 0 %}\
 
 template <class Scalar, unsigned staticSize>
-Opm::DenseAd::Evaluation<Scalar, -1, staticSize> constant(int numDerivatives, const Scalar& value)
-{ return Opm::DenseAd::Evaluation<Scalar, -1, staticSize>::createConstant(numDerivatives, value); }
+DenseAd::Evaluation<Scalar, -1, staticSize> constant(int numDerivatives, const Scalar& value)
+{ return DenseAd::Evaluation<Scalar, -1, staticSize>::createConstant(numDerivatives, value); }
 
 template <class Scalar, unsigned staticSize>
-Opm::DenseAd::Evaluation<Scalar, -1, staticSize> variable(int numDerivatives, const Scalar& value, unsigned idx)
-{ return Opm::DenseAd::Evaluation<Scalar, -1, staticSize>::createVariable(numDerivatives, value, idx); }
+DenseAd::Evaluation<Scalar, -1, staticSize> variable(int numDerivatives, const Scalar& value, unsigned idx)
+{ return DenseAd::Evaluation<Scalar, -1, staticSize>::createVariable(numDerivatives, value, idx); }
 
 {% endif %}\
 } // namespace Opm

--- a/opm/material/IdealGas.hpp
+++ b/opm/material/IdealGas.hpp
@@ -70,7 +70,7 @@ public:
 };
 
 template <class Scalar>
-const Scalar IdealGas<Scalar>::R = Opm::Constants<Scalar>::R;
+const Scalar IdealGas<Scalar>::R = Constants<Scalar>::R;
 
 } // namespace Opm
 

--- a/opm/material/binarycoefficients/Air_Mesitylene.hpp
+++ b/opm/material/binarycoefficients/Air_Mesitylene.hpp
@@ -58,13 +58,13 @@ public:
     template <class Evaluation>
     static Evaluation gasDiffCoeff(Evaluation temperature, Evaluation pressure)
     {
-        typedef Opm::Air<double> Air;
-        typedef Opm::Mesitylene<double> Mesitylene;
+        typedef Air<double> Air;
+        typedef Mesitylene<double> Mesitylene;
 
-        temperature = Opm::max(temperature, 1e-9); // regularization
-        temperature = Opm::min(temperature, 500.0); // regularization
-        pressure = Opm::max(pressure, 0.0); // regularization
-        pressure = Opm::min(pressure, 1e8); // regularization
+        temperature = max(temperature, 1e-9); // regularization
+        temperature = min(temperature, 500.0); // regularization
+        pressure = max(pressure, 0.0); // regularization
+        pressure = min(pressure, 1e8); // regularization
 
         const double M_m = 1e3*Mesitylene::molarMass(); // [g/mol] molecular weight of mesitylene
         const double M_a = 1e3*Air::molarMass(); // [g/mol] molecular weight of air
@@ -78,13 +78,13 @@ public:
         const double T_scal_am = std::sqrt(T_scal_a*T_scal_m);
 
         Evaluation T_star = temperature/T_scal_am;
-        T_star = Opm::max(T_star, 1e-5); // regularization
+        T_star = max(T_star, 1e-5); // regularization
 
-        const Evaluation Omega = 1.06036/Opm::pow(T_star, 0.1561) + 0.193/Opm::exp(T_star*0.47635)
-            + 1.03587/Opm::exp(T_star*1.52996) + 1.76474/Opm::exp(T_star*3.89411);
+        const Evaluation Omega = 1.06036/pow(T_star, 0.1561) + 0.193/exp(T_star*0.47635)
+            + 1.03587/exp(T_star*1.52996) + 1.76474/exp(T_star*3.89411);
         const double B_ = 0.00217 - 0.0005*std::sqrt(1.0/M_a + 1.0/M_m);
         const double Mr = (M_a + M_m)/(M_a*M_m);
-        const Evaluation D_am = (B_*Opm::pow(temperature, 1.5) * std::sqrt(Mr))
+        const Evaluation D_am = (B_*pow(temperature, 1.5) * std::sqrt(Mr))
                            /(1e-5*pressure*std::pow(sigma_am, 2.0) * Omega); // [cm^2/s]
 
         return 1e-4*D_am; // [m^2/s]

--- a/opm/material/binarycoefficients/Air_Xylene.hpp
+++ b/opm/material/binarycoefficients/Air_Xylene.hpp
@@ -56,13 +56,13 @@ public:
     template <class Evaluation>
     static Evaluation gasDiffCoeff(Evaluation temperature, Evaluation pressure)
     {
-        typedef Opm::Air<double> Air;
-        typedef Opm::Xylene<double> Xylene;
+        typedef Air<double> Air;
+        typedef Xylene<double> Xylene;
 
-        temperature = Opm::max(temperature, 1e-9); // regularization
-        temperature = Opm::min(temperature, 500.0); // regularization
-        pressure = Opm::max(pressure, 0.0); // regularization
-        pressure = Opm::min(pressure, 1e8); // regularization
+        temperature = max(temperature, 1e-9); // regularization
+        temperature = min(temperature, 500.0); // regularization
+        pressure = max(pressure, 0.0); // regularization
+        pressure = min(pressure, 1e8); // regularization
 
         const double M_x = 1e3*Xylene::molarMass(); // [g/mol] molecular weight of xylene
         const double M_a = 1e3*Air::molarMass(); // [g/mol] molecular weight of air
@@ -75,14 +75,14 @@ public:
         const double T_scal_x = 1.15*Tb_x;
         const double T_scal_ax = std::sqrt(T_scal_a*T_scal_x);
 
-        const Evaluation& T_star = Opm::max(temperature/T_scal_ax, 1e-5);
+        const Evaluation& T_star = max(temperature/T_scal_ax, 1e-5);
 
-        const Evaluation& Omega = 1.06036/Opm::pow(T_star, 0.1561) + 0.193/Opm::exp(T_star*0.47635)
-            + 1.03587/Opm::exp(T_star*1.52996) + 1.76474/Opm::exp(T_star*3.89411);
+        const Evaluation& Omega = 1.06036/pow(T_star, 0.1561) + 0.193/exp(T_star*0.47635)
+            + 1.03587/exp(T_star*1.52996) + 1.76474/exp(T_star*3.89411);
         const double B_ = 0.00217 - 0.0005*std::sqrt(1.0/M_a + 1.0/M_x);
         const double Mr = (M_a + M_x)/(M_a*M_x);
         return 1e-4
-            *(B_*Opm::pow(temperature,1.5)*std::sqrt(Mr))
+            *(B_*pow(temperature,1.5)*std::sqrt(Mr))
             /(1e-5*pressure*std::pow(sigma_ax, 2.0)*Omega);
     }
 

--- a/opm/material/binarycoefficients/Brine_CO2.hpp
+++ b/opm/material/binarycoefficients/Brine_CO2.hpp
@@ -39,7 +39,7 @@ namespace BinaryCoeff {
  */
 template<class Scalar, class H2O, class CO2, bool verbose = true>
 class Brine_CO2 {
-    typedef Opm::IdealGas<Scalar> IdealGas;
+    typedef ::Opm::IdealGas<Scalar> IdealGas;
     static const int liquidPhaseIdx = 0; // index of the liquid phase
     static const int gasPhaseIdx = 1; // index of the gas phase
 
@@ -158,20 +158,20 @@ public:
         Scalar R = IdealGas::R * 10.; // ideal gas constant with unit bar cm^3 /(K mol)
         Evaluation lnPhiCO2;
 
-        lnPhiCO2 = Opm::log(V / (V - b_CO2));
+        lnPhiCO2 = log(V / (V - b_CO2));
         lnPhiCO2 += b_CO2 / (V - b_CO2);
-        lnPhiCO2 -= 2 * a_CO2 / (R * Opm::pow(temperature, 1.5) * b_CO2) * log((V + b_CO2) / V);
+        lnPhiCO2 -= 2 * a_CO2 / (R * pow(temperature, 1.5) * b_CO2) * log((V + b_CO2) / V);
         lnPhiCO2 +=
             a_CO2 * b_CO2
             / (R
-               * Opm::pow(temperature, 1.5)
+               * pow(temperature, 1.5)
                * b_CO2
                * b_CO2)
-            * (Opm::log((V + b_CO2) / V)
+            * (log((V + b_CO2) / V)
                - b_CO2 / (V + b_CO2));
-        lnPhiCO2 -= Opm::log(pg_bar * V / (R * temperature));
+        lnPhiCO2 -= log(pg_bar * V / (R * temperature));
 
-        return Opm::exp(lnPhiCO2); // fugacity coefficient of CO2
+        return exp(lnPhiCO2); // fugacity coefficient of CO2
     }
 
     /*!
@@ -195,13 +195,13 @@ public:
         Evaluation lnPhiH2O;
 
         lnPhiH2O =
-            Opm::log(V/(V - b_CO2))
+            log(V/(V - b_CO2))
             + b_H2O/(V - b_CO2) - 2*a_CO2_H2O
-            / (R*Opm::pow(temperature, 1.5)*b_CO2)*Opm::log((V + b_CO2)/V)
-            + a_CO2*b_H2O/(R*Opm::pow(temperature, 1.5)*b_CO2*b_CO2)
-            *(Opm::log((V + b_CO2)/V) - b_CO2/(V + b_CO2))
-            - Opm::log(pg_bar*V/(R*temperature));
-        return Opm::exp(lnPhiH2O); // fugacity coefficient of H2O
+            / (R*pow(temperature, 1.5)*b_CO2)*log((V + b_CO2)/V)
+            + a_CO2*b_H2O/(R*pow(temperature, 1.5)*b_CO2*b_CO2)
+            *(log((V + b_CO2)/V) - b_CO2/(V + b_CO2))
+            - log(pg_bar*V/(R*temperature));
+        return exp(lnPhiH2O); // fugacity coefficient of H2O
     }
 
 private:
@@ -267,7 +267,7 @@ private:
         const Evaluation& xi = computeXi_(temperature, pg); // Xi_{CO2-Na+-Cl-}
         const Evaluation& lnGammaStar =
             2*molalityNaCl*lambda + xi*molalityNaCl*molalityNaCl;
-        return Opm::exp(lnGammaStar);
+        return exp(lnGammaStar);
     }
 
     /*!
@@ -287,7 +287,7 @@ private:
         const Evaluation& k0_H2O = equilibriumConstantH2O_(temperature); // equilibrium constant for H2O at 1 bar
         const Evaluation& phi_H2O = fugacityCoefficientH2O(temperature, pg); // fugacity coefficient of H2O for the water-CO2 system
         const Evaluation& pg_bar = pg / 1.e5;
-        return k0_H2O/(phi_H2O*pg_bar)*Opm::exp(deltaP*v_av_H2O/(R*temperature));
+        return k0_H2O/(phi_H2O*pg_bar)*exp(deltaP*v_av_H2O/(R*temperature));
     }
 
     /*!
@@ -307,7 +307,7 @@ private:
         const Evaluation& k0_CO2 = equilibriumConstantCO2_(temperature); // equilibrium constant for CO2 at 1 bar
         const Evaluation& phi_CO2 = fugacityCoefficientCO2(temperature, pg); // fugacity coefficient of CO2 for the water-CO2 system
         const Evaluation& pg_bar = pg / 1.e5;
-        return phi_CO2*pg_bar/(55.508*k0_CO2)*Opm::exp(-(deltaP*v_av_CO2)/(R*temperature));
+        return phi_CO2*pg_bar/(55.508*k0_CO2)*exp(-(deltaP*v_av_CO2)/(R*temperature));
     }
 
     /*!
@@ -330,7 +330,7 @@ private:
             + c[2]/temperature
             + c[3]*pg_bar/temperature
             + c[4]*pg_bar/(630.0 - temperature)
-            + c[5]*temperature*Opm::log(pg_bar);
+            + c[5]*temperature*log(pg_bar);
     }
 
     /*!
@@ -362,7 +362,7 @@ private:
         Evaluation temperatureCelcius = temperature - 273.15;
         static const Scalar c[3] = { 1.189, 1.304e-2, -5.446e-5 };
         Evaluation logk0_CO2 = c[0] + temperatureCelcius*(c[1] + temperatureCelcius*c[2]);
-        Evaluation k0_CO2 = Opm::pow(10.0, logk0_CO2);
+        Evaluation k0_CO2 = pow(10.0, logk0_CO2);
         return k0_CO2;
     }
 
@@ -379,7 +379,7 @@ private:
         static const Scalar c[4] = { -2.209, 3.097e-2, -1.098e-4, 2.048e-7 };
         Evaluation logk0_H2O =
             c[0] + temperatureCelcius*(c[1] + temperatureCelcius*(c[2] + temperatureCelcius*c[3]));
-        return Opm::pow(10.0, logk0_H2O);
+        return pow(10.0, logk0_H2O);
     }
 
 };

--- a/opm/material/binarycoefficients/FullerMethod.hpp
+++ b/opm/material/binarycoefficients/FullerMethod.hpp
@@ -59,11 +59,11 @@ inline Evaluation fullerMethod(const Scalar* M, // molar masses [g/mol]
                                const Evaluation& pressure) // [Pa]
 {
     // "effective" molar mass in [g/m^3]
-    Scalar Mab = Opm::harmonicMean(M[0], M[1]);
+    Scalar Mab = harmonicMean(M[0], M[1]);
 
     // Fuller's method
     const Evaluation& tmp = std::pow(SigmaNu[0], 1./3) + std::pow(SigmaNu[1], 1./3);
-    return 1e-4 * (143.0*Opm::pow(temperature, 1.75))/(pressure*std::sqrt(Mab)*tmp*tmp);
+    return 1e-4 * (143.0*pow(temperature, 1.75))/(pressure*std::sqrt(Mab)*tmp*tmp);
 }
 
 } // namespace BinaryCoeff

--- a/opm/material/binarycoefficients/H2O_Air.hpp
+++ b/opm/material/binarycoefficients/H2O_Air.hpp
@@ -53,7 +53,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation henry(const Evaluation& temperature)
-    { return 1.0/((0.8942+1.47*Opm::exp(-0.04394*(temperature-273.15)))*1e-10); }
+    { return 1.0/((0.8942+1.47*exp(-0.04394*(temperature-273.15)))*1e-10); }
 
     /*!
      * \brief Binary diffusion coefficent \f$\mathrm{[m^2/s]}\f$ for molecular water and air
@@ -74,7 +74,7 @@ public:
         double pg0=1.e5;     /* reference pressure */
         double T0=273.15;    /* reference temperature */
 
-        return Daw*(pg0/pressure)*Opm::pow((temperature/T0),Theta);
+        return Daw*(pg0/pressure)*pow((temperature/T0),Theta);
     }
 
     /*!

--- a/opm/material/binarycoefficients/H2O_CO2.hpp
+++ b/opm/material/binarycoefficients/H2O_CO2.hpp
@@ -73,8 +73,8 @@ public:
     template <class Scalar, class Evaluation = Scalar>
     static Evaluation gasDiffCoeff(const Evaluation& temperature, const Evaluation& pressure)
     {
-        typedef Opm::H2O<Scalar> H2O;
-        typedef Opm::SimpleCO2<Scalar> CO2;
+        typedef H2O<Scalar> H2O;
+        typedef SimpleCO2<Scalar> CO2;
 
         // atomic diffusion volumes
         const Scalar SigmaNu[2] = { 13.1 /* H2O */,  26.9 /* CO2 */ };

--- a/opm/material/binarycoefficients/H2O_Mesitylene.hpp
+++ b/opm/material/binarycoefficients/H2O_Mesitylene.hpp
@@ -66,13 +66,13 @@ public:
     template <class Evaluation>
     static Evaluation gasDiffCoeff(Evaluation temperature, Evaluation pressure)
     {
-        typedef Opm::H2O<double> H2O;
-        typedef Opm::Mesitylene<double> Mesitylene;
+        typedef H2O<double> H2O;
+        typedef Mesitylene<double> Mesitylene;
 
-        temperature = Opm::max(temperature, 1e-9); // regularization
-        temperature = Opm::min(temperature, 500.0); // regularization
-        pressure = Opm::max(pressure, 0.0); // regularization
-        pressure = Opm::min(pressure, 1e8); // regularization
+        temperature = max(temperature, 1e-9); // regularization
+        temperature = min(temperature, 500.0); // regularization
+        pressure = max(pressure, 0.0); // regularization
+        pressure = min(pressure, 1e8); // regularization
 
         const double M_m = 1e3*Mesitylene::molarMass(); // [g/mol] molecular weight of mesitylene
         const double M_w = 1e3*H2O::molarMass(); // [g/mol] molecular weight of water
@@ -87,13 +87,13 @@ public:
         const double T_scal_m = 1.15*Tb_m;
         const double T_scal_wm = std::sqrt(T_scal_w*T_scal_m);
 
-        const Evaluation T_star = Opm::max(temperature/T_scal_wm, 1e-5);
+        const Evaluation T_star = max(temperature/T_scal_wm, 1e-5);
 
-        const Evaluation& Omega = 1.06036/Opm::pow(T_star,0.1561) + 0.193/Opm::exp(T_star*0.47635)
-            + 1.03587/Opm::exp(T_star*1.52996) + 1.76474/Opm::exp(T_star*3.89411);
+        const Evaluation& Omega = 1.06036/pow(T_star,0.1561) + 0.193/exp(T_star*0.47635)
+            + 1.03587/exp(T_star*1.52996) + 1.76474/exp(T_star*3.89411);
         const double B_ = 0.00217 - 0.0005*std::sqrt(1.0/M_w + 1.0/M_m);
         const double Mr = (M_w + M_m)/(M_w*M_m);
-        const Evaluation D_wm = (B_*Opm::pow(temperature,1.6)*std::sqrt(Mr))
+        const Evaluation D_wm = (B_*pow(temperature,1.6)*std::sqrt(Mr))
                            /(1e-5*pressure*std::pow(sigma_wm, 2.0)*Omega); // [cm^2/s]
 
         return D_wm*1e-4;   //  [m^2/s]

--- a/opm/material/binarycoefficients/H2O_N2.hpp
+++ b/opm/material/binarycoefficients/H2O_N2.hpp
@@ -69,8 +69,8 @@ public:
     template <class Evaluation>
     static Evaluation gasDiffCoeff(const Evaluation& temperature, const Evaluation& pressure)
     {
-        typedef Opm::H2O<double> H2O;
-        typedef Opm::N2<double> N2;
+        typedef H2O<double> H2O;
+        typedef N2<double> N2;
 
         // atomic diffusion volumes
         const double SigmaNu[2] = { 13.1 /* H2O */,  18.5 /* N2 */ };

--- a/opm/material/binarycoefficients/H2O_Xylene.hpp
+++ b/opm/material/binarycoefficients/H2O_Xylene.hpp
@@ -65,13 +65,13 @@ public:
     template <class Evaluation>
     static Evaluation gasDiffCoeff(Evaluation temperature, Evaluation pressure)
     {
-        typedef Opm::H2O<double> H2O;
-        typedef Opm::Xylene<double> Xylene;
+        typedef H2O<double> H2O;
+        typedef Xylene<double> Xylene;
 
-        temperature = Opm::max(temperature, 1e-9); // regularization
-        temperature = Opm::min(temperature, 500.0); // regularization
-        pressure = Opm::max(pressure, 0.0); // regularization
-        pressure = Opm::min(pressure, 1e8); // regularization
+        temperature = max(temperature, 1e-9); // regularization
+        temperature = min(temperature, 500.0); // regularization
+        pressure = max(pressure, 0.0); // regularization
+        pressure = min(pressure, 1e8); // regularization
 
         const double M_x = 1e3*Xylene::molarMass(); // [g/mol] molecular weight of xylene
         const double M_w = 1e3*H2O::molarMass(); // [g/mol] molecular weight of water
@@ -86,14 +86,14 @@ public:
         const double T_scal_x = 1.15*Tb_x;
         const double T_scal_wx = std::sqrt(T_scal_w*T_scal_x);
 
-        const Evaluation& T_star = Opm::max(temperature/T_scal_wx, 1e-5);
+        const Evaluation& T_star = max(temperature/T_scal_wx, 1e-5);
 
-        const Evaluation& Omega = 1.06036/Opm::pow(T_star, 0.1561) + 0.193/Opm::exp(T_star*0.47635)
-            + 1.03587/Opm::exp(T_star*1.52996) + 1.76474/Opm::exp(T_star*3.89411);
+        const Evaluation& Omega = 1.06036/pow(T_star, 0.1561) + 0.193/exp(T_star*0.47635)
+            + 1.03587/exp(T_star*1.52996) + 1.76474/exp(T_star*3.89411);
         const double  B_ = 0.00217 - 0.0005*std::sqrt(1.0/M_w + 1.0/M_x);
         const double Mr = (M_w + M_x)/(M_w*M_x);
         return 1e-4
-            *(B_*Opm::pow(temperature,1.6)*std::sqrt(Mr))
+            *(B_*pow(temperature,1.6)*std::sqrt(Mr))
             /(1e-5*pressure*std::pow(sigma_wx, 2.0)*Omega);
     }
 

--- a/opm/material/binarycoefficients/HenryIapws.hpp
+++ b/opm/material/binarycoefficients/HenryIapws.hpp
@@ -48,7 +48,7 @@ inline Evaluation henryIAPWS(Scalar E,
                              Scalar H,
                              const Evaluation& temperature)
 {
-    typedef Opm::H2O<Evaluation> H2O;
+    typedef H2O<Evaluation> H2O;
 
     Evaluation Tr = temperature/H2O::criticalTemperature();
     Evaluation tau = 1 - Tr;
@@ -65,20 +65,20 @@ inline Evaluation henryIAPWS(Scalar E,
 
     Evaluation f = 0;
     for (int i = 0; i < 6; ++i) {
-        f += c[i]*Opm::pow(tau, d[i]);
+        f += c[i]*pow(tau, d[i]);
     }
 
     const Evaluation& exponent =
         q*F +
         E/temperature*f +
         (F +
-         G*Opm::pow(tau, 2.0/3) +
+         G*pow(tau, 2.0/3) +
          H*tau)*
-        Opm::exp((H2O::tripleTemperature() - temperature)/100);
+        exp((H2O::tripleTemperature() - temperature)/100);
     // CAUTION: K_D is formulated in mole fractions. We have to
     // multiply it with the vapor pressure of water in order to get
     // derivative of the partial pressure.
-    return Opm::exp(exponent)*H2O::vaporPressure(temperature);
+    return exp(exponent)*H2O::vaporPressure(temperature);
 }
 } // namespace Opm
 

--- a/opm/material/common/Exceptions.hpp
+++ b/opm/material/common/Exceptions.hpp
@@ -39,7 +39,7 @@
 namespace Opm {
 class NumericalIssue
 #if HAVE_OPM_COMMON
-    : public Opm::NumericalProblem
+    : public NumericalProblem
 #else
     : public std::runtime_error
 #endif
@@ -47,7 +47,7 @@ class NumericalIssue
 public:
     explicit NumericalIssue(const std::string &message)
 #if HAVE_OPM_COMMON
-      : Opm::NumericalProblem(message)
+      : NumericalProblem(message)
 #else
       : std::runtime_error(message)
 #endif

--- a/opm/material/common/HasMemberGeneratorMacros.hpp
+++ b/opm/material/common/HasMemberGeneratorMacros.hpp
@@ -55,7 +55,7 @@ struct AlwaysVoid
                                                                         \
     template <class T>                                                  \
     struct HasMember_##MEMBER_NAME##_Helper<T,                             \
-      typename Opm::AlwaysVoid<decltype(std::declval<T>().MEMBER_NAME(__VA_ARGS__))>::type> \
+      typename ::Opm::AlwaysVoid<decltype(std::declval<T>().MEMBER_NAME(__VA_ARGS__))>::type> \
     {                                                                   \
         static constexpr bool value = true;                             \
     };                                                                  \

--- a/opm/material/common/MathToolbox.hpp
+++ b/opm/material/common/MathToolbox.hpp
@@ -74,7 +74,7 @@ public:
      * endpoints in the "nesting graph". This typedef makes sense if nested automatic
      * differentiation is used, though...
      */
-    typedef Opm::MathToolbox<Scalar> InnerToolbox;
+    typedef MathToolbox<Scalar> InnerToolbox;
 
     /*!
      * \brief Return the value of the function at a given evaluation point.
@@ -281,118 +281,118 @@ struct ReturnEval_
 // these are convenience functions for not having to type MathToolbox<Scalar>::foo()
 template <class Evaluation>
 Evaluation blank(const Evaluation& x)
-{ return Opm::MathToolbox<Evaluation>::createBlank(x); }
+{ return MathToolbox<Evaluation>::createBlank(x); }
 
 template <class Evaluation, class Scalar>
 Evaluation constant(const Scalar& value)
-{ return Opm::MathToolbox<Evaluation>::createConstant(value); }
+{ return MathToolbox<Evaluation>::createConstant(value); }
 
 template <class Evaluation, class Scalar>
 Evaluation constant(unsigned numDeriv, const Scalar& value)
-{ return Opm::MathToolbox<Evaluation>::createConstant(numDeriv, value); }
+{ return MathToolbox<Evaluation>::createConstant(numDeriv, value); }
 
 template <class Evaluation, class Scalar>
 Evaluation constant(const Evaluation& x, const Scalar& value)
-{ return Opm::MathToolbox<Evaluation>::createConstant(x, value); }
+{ return MathToolbox<Evaluation>::createConstant(x, value); }
 
 template <class Evaluation, class Scalar>
 Evaluation variable(unsigned numDeriv, const Scalar& value, unsigned idx)
-{ return Opm::MathToolbox<Evaluation>::createVariable(numDeriv, value, idx); }
+{ return MathToolbox<Evaluation>::createVariable(numDeriv, value, idx); }
 
 template <class Evaluation, class Scalar>
 Evaluation variable(const Evaluation& x, const Scalar& value, unsigned idx)
-{ return Opm::MathToolbox<Evaluation>::createVariable(x, value, idx); }
+{ return MathToolbox<Evaluation>::createVariable(x, value, idx); }
 
 template <class Evaluation, class Scalar>
 Evaluation variable(const Scalar& value, unsigned idx)
-{ return Opm::MathToolbox<Evaluation>::createVariable(value, idx); }
+{ return MathToolbox<Evaluation>::createVariable(value, idx); }
 
 template <class ResultEval, class Evaluation>
 auto decay(const Evaluation& value)
-    -> decltype(Opm::MathToolbox<Evaluation>::template decay<ResultEval>(value))
-{ return Opm::MathToolbox<Evaluation>::template decay<ResultEval>(value); }
+    -> decltype(MathToolbox<Evaluation>::template decay<ResultEval>(value))
+{ return MathToolbox<Evaluation>::template decay<ResultEval>(value); }
 
 template <class Evaluation>
 auto getValue(const Evaluation& val)
-    -> decltype(Opm::MathToolbox<Evaluation>::value(val))
-{ return Opm::MathToolbox<Evaluation>::value(val); }
+    -> decltype(MathToolbox<Evaluation>::value(val))
+{ return MathToolbox<Evaluation>::value(val); }
 
 template <class Evaluation>
 auto scalarValue(const Evaluation& val)
-    -> decltype(Opm::MathToolbox<Evaluation>::scalarValue(val))
-{ return Opm::MathToolbox<Evaluation>::scalarValue(val); }
+    -> decltype(MathToolbox<Evaluation>::scalarValue(val))
+{ return MathToolbox<Evaluation>::scalarValue(val); }
 
 template <class Evaluation1, class Evaluation2>
 typename ReturnEval_<Evaluation1, Evaluation2>::type
 max(const Evaluation1& arg1, const Evaluation2& arg2)
-{ return Opm::MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::max(arg1, arg2); }
+{ return MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::max(arg1, arg2); }
 
 template <class Evaluation1, class Evaluation2>
 typename ReturnEval_<Evaluation1, Evaluation2>::type
 min(const Evaluation1& arg1, const Evaluation2& arg2)
-{ return Opm::MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::min(arg1, arg2); }
+{ return MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::min(arg1, arg2); }
 
 template <class Evaluation>
 Evaluation abs(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::abs(value); }
+{ return MathToolbox<Evaluation>::abs(value); }
 
 template <class Evaluation>
 Evaluation tan(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::tan(value); }
+{ return MathToolbox<Evaluation>::tan(value); }
 
 template <class Evaluation>
 Evaluation atan(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::atan(value); }
+{ return MathToolbox<Evaluation>::atan(value); }
 
 template <class Evaluation1, class Evaluation2>
 typename ReturnEval_<Evaluation1, Evaluation2>::type
 atan2(const Evaluation1& value1, const Evaluation2& value2)
-{ return Opm::MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::atan2(value1, value2); }
+{ return MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::atan2(value1, value2); }
 
 template <class Evaluation>
 Evaluation sin(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::sin(value); }
+{ return MathToolbox<Evaluation>::sin(value); }
 
 template <class Evaluation>
 Evaluation asin(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::asin(value); }
+{ return MathToolbox<Evaluation>::asin(value); }
 
 template <class Evaluation>
 Evaluation cos(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::cos(value); }
+{ return MathToolbox<Evaluation>::cos(value); }
 
 template <class Evaluation>
 Evaluation acos(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::acos(value); }
+{ return MathToolbox<Evaluation>::acos(value); }
 
 template <class Evaluation>
 Evaluation sqrt(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::sqrt(value); }
+{ return MathToolbox<Evaluation>::sqrt(value); }
 
 template <class Evaluation>
 Evaluation exp(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::exp(value); }
+{ return MathToolbox<Evaluation>::exp(value); }
 
 template <class Evaluation>
 Evaluation log(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::log(value); }
+{ return MathToolbox<Evaluation>::log(value); }
 
 template <class Evaluation>
 Evaluation log10(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::log10(value); }
+{ return MathToolbox<Evaluation>::log10(value); }
 
 template <class Evaluation1, class Evaluation2>
 typename ReturnEval_<Evaluation1, Evaluation2>::type
 pow(const Evaluation1& base, const Evaluation2& exp)
-{ return Opm::MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::pow(base, exp); }
+{ return MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::pow(base, exp); }
 
 template <class Evaluation>
 bool isfinite(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::isfinite(value); }
+{ return MathToolbox<Evaluation>::isfinite(value); }
 
 template <class Evaluation>
 bool isnan(const Evaluation& value)
-{ return Opm::MathToolbox<Evaluation>::isnan(value); }
+{ return MathToolbox<Evaluation>::isnan(value); }
 
 } // namespace Opm
 

--- a/opm/material/common/PolynomialUtils.hpp
+++ b/opm/material/common/PolynomialUtils.hpp
@@ -52,7 +52,7 @@ unsigned invertLinearPolynomial(SolContainer& sol,
                                 Scalar a,
                                 Scalar b)
 {
-    if (std::abs(Opm::scalarValue(a)) < 1e-30)
+    if (std::abs(scalarValue(a)) < 1e-30)
         return 0;
 
     sol[0] = -b/a;
@@ -82,7 +82,7 @@ unsigned invertQuadraticPolynomial(SolContainer& sol,
                                    Scalar c)
 {
     // check for a line
-    if (std::abs(Opm::scalarValue(a)) < 1e-30)
+    if (std::abs(scalarValue(a)) < 1e-30)
         return invertLinearPolynomial(sol, b, c);
 
     // discriminant
@@ -90,7 +90,7 @@ unsigned invertQuadraticPolynomial(SolContainer& sol,
     if (Delta < 0)
         return 0; // no real roots
 
-    Delta = Opm::sqrt(Delta);
+    Delta = sqrt(Delta);
     sol[0] = (- b + Delta)/(2*a);
     sol[1] = (- b - Delta)/(2*a);
 
@@ -116,12 +116,12 @@ void invertCubicPolynomialPostProcess_(SolContainer& sol,
         Scalar fOld = d + x*(c + x*(b + x*a));
 
         Scalar fPrime = c + x*(2*b + x*3*a);
-        if (std::abs(Opm::scalarValue(fPrime)) < 1e-30)
+        if (std::abs(scalarValue(fPrime)) < 1e-30)
             continue;
         x -= fOld/fPrime;
 
         Scalar fNew = d + x*(c + x*(b + x*a));
-        if (std::abs(Opm::scalarValue(fNew)) < std::abs(Opm::scalarValue(fOld)))
+        if (std::abs(scalarValue(fNew)) < std::abs(scalarValue(fOld)))
             sol[i] = x;
     }
 }
@@ -152,7 +152,7 @@ unsigned invertCubicPolynomial(SolContainer* sol,
                                Scalar d)
 {
     // reduces to a quadratic polynomial
-    if (std::abs(Opm::scalarValue(a)) < 1e-30)
+    if (std::abs(scalarValue(a)) < 1e-30)
         return invertQuadraticPolynomial(sol, b, c, d);
 
     // normalize the polynomial
@@ -165,7 +165,7 @@ unsigned invertCubicPolynomial(SolContainer* sol,
     Scalar p = c - b*b/3;
     Scalar q = d + (2*b*b*b - 9*b*c)/27;
 
-    if (std::abs(Opm::scalarValue(p)) > 1e-30 && std::abs(Opm::scalarValue(q)) > 1e-30) {
+    if (std::abs(scalarValue(p)) > 1e-30 && std::abs(scalarValue(q)) > 1e-30) {
         // At this point
         //
         // t^3 + p*t + q = 0
@@ -199,9 +199,9 @@ unsigned invertCubicPolynomial(SolContainer* sol,
         Scalar wDisc = q*q/4 + p*p*p/27;
         if (wDisc >= 0) { // the positive discriminant case:
             // calculate the cube root of - q/2 + sqrt(q^2/4 + p^3/27)
-            Scalar u = - q/2 + Opm::sqrt(wDisc);
-            if (u < 0) u = - Opm::pow(-u, 1.0/3);
-            else u = Opm::pow(u, 1.0/3);
+            Scalar u = - q/2 + sqrt(wDisc);
+            if (u < 0) u = - pow(-u, 1.0/3);
+            else u = pow(u, 1.0/3);
 
             // at this point, u != 0 since p^3 = 0 is necessary in order
             // for u = 0 to hold, so
@@ -214,10 +214,10 @@ unsigned invertCubicPolynomial(SolContainer* sol,
         }
         else { // the negative discriminant case:
             Scalar uCubedRe = - q/2;
-            Scalar uCubedIm = Opm::sqrt(-wDisc);
+            Scalar uCubedIm = sqrt(-wDisc);
             // calculate the cube root of - q/2 + sqrt(q^2/4 + p^3/27)
-            Scalar uAbs  = Opm::pow(Opm::sqrt(uCubedRe*uCubedRe + uCubedIm*uCubedIm), 1.0/3);
-            Scalar phi = Opm::atan2(uCubedIm, uCubedRe)/3;
+            Scalar uAbs  = pow(sqrt(uCubedRe*uCubedRe + uCubedIm*uCubedIm), 1.0/3);
+            Scalar phi = atan2(uCubedIm, uCubedRe)/3;
 
             // calculate the length and the angle of the primitive root
 
@@ -259,7 +259,7 @@ unsigned invertCubicPolynomial(SolContainer* sol,
             // values for phi which differ by 2/3*pi. This allows to
             // calculate the three real roots of the polynomial:
             for (int i = 0; i < 3; ++i) {
-                sol[i] = Opm::cos(phi)*(uAbs - p/(3*uAbs)) - b/3;
+                sol[i] = cos(phi)*(uAbs - p/(3*uAbs)) - b/3;
                 phi += 2*M_PI/3;
             }
 
@@ -275,24 +275,24 @@ unsigned invertCubicPolynomial(SolContainer* sol,
     }
     // Handle some (pretty unlikely) special cases required to avoid
     // divisions by zero in the code above...
-    else if (std::abs(Opm::scalarValue(p)) < 1e-30 && std::abs(Opm::scalarValue(q)) < 1e-30) {
+    else if (std::abs(scalarValue(p)) < 1e-30 && std::abs(scalarValue(q)) < 1e-30) {
         // t^3 = 0, i.e. triple root at t = 0
         sol[0] = sol[1] = sol[2] = 0.0 - b/3;
         return 3;
     }
-    else if (std::abs(Opm::scalarValue(p)) < 1e-30 && std::abs(Opm::scalarValue(q)) > 1e-30) {
+    else if (std::abs(scalarValue(p)) < 1e-30 && std::abs(scalarValue(q)) > 1e-30) {
         // t^3 + q = 0,
         //
         // i. e. single real root at t=curt(q)
         Scalar t;
-        if (-q > 0) t = Opm::pow(-q, 1./3);
-        else t = - Opm::pow(q, 1./3);
+        if (-q > 0) t = pow(-q, 1./3);
+        else t = - pow(q, 1./3);
         sol[0] = t - b/3;
 
         return 1;
     }
 
-    assert(std::abs(Opm::scalarValue(p)) > 1e-30 && std::abs(Opm::scalarValue(q)) > 1e-30);
+    assert(std::abs(scalarValue(p)) > 1e-30 && std::abs(scalarValue(q)) > 1e-30);
 
     // t^3 + p*t = 0 = t*(t^2 + p),
     //
@@ -303,9 +303,9 @@ unsigned invertCubicPolynomial(SolContainer* sol,
     }
 
     // two additional real roots at t = sqrt(-p) and t = -sqrt(-p)
-    sol[0] = -Opm::sqrt(-p) - b/3;;
+    sol[0] = -sqrt(-p) - b/3;;
     sol[1] = 0.0 - b/3;
-    sol[2] = Opm::sqrt(-p) - b/3;
+    sol[2] = sqrt(-p) - b/3;
 
     return 3;
 }

--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -90,7 +90,7 @@ namespace Opm
 template<class Scalar>
 class Spline
 {
-    typedef Opm::TridiagonalMatrix<Scalar> Matrix;
+    typedef TridiagonalMatrix<Scalar> Matrix;
     typedef std::vector<Scalar> Vector;
 
 public:
@@ -798,7 +798,7 @@ public:
     Evaluation eval(const Evaluation& x, bool extrapolate = false) const
     {
         if (!extrapolate && !applies(x))
-            throw Opm::NumericalIssue("Tried to evaluate a spline outside of its range");
+            throw NumericalIssue("Tried to evaluate a spline outside of its range");
 
         // handle extrapolation
         if (extrapolate) {
@@ -815,7 +815,7 @@ public:
             }
         }
 
-        return eval_(x, segmentIdx_(Opm::scalarValue(x)));
+        return eval_(x, segmentIdx_(scalarValue(x)));
     }
 
     /*!
@@ -834,7 +834,7 @@ public:
     Evaluation evalDerivative(const Evaluation& x, bool extrapolate = false) const
     {
         if (!extrapolate && !applies(x))
-            throw Opm::NumericalIssue("Tried to evaluate the derivative of a spline outside of its range");
+            throw NumericalIssue("Tried to evaluate the derivative of a spline outside of its range");
 
         // handle extrapolation
         if (extrapolate) {
@@ -844,7 +844,7 @@ public:
                 return evalDerivative_(xAt(numSamples() - 1), /*segmentIdx=*/numSamples() - 2);
         }
 
-        return evalDerivative_(x, segmentIdx_(Opm::scalarValue(x)));
+        return evalDerivative_(x, segmentIdx_(scalarValue(x)));
     }
 
     /*!
@@ -863,11 +863,11 @@ public:
     Evaluation evalSecondDerivative(const Evaluation& x, bool extrapolate = false) const
     {
         if (!extrapolate && !applies(x))
-            throw Opm::NumericalIssue("Tried to evaluate the second derivative of a spline outside of its range");
+            throw NumericalIssue("Tried to evaluate the second derivative of a spline outside of its range");
         else if (extrapolate)
             return 0.0;
 
-        return evalDerivative2_(x, segmentIdx_(Opm::scalarValue(x)));
+        return evalDerivative2_(x, segmentIdx_(scalarValue(x)));
     }
 
     /*!
@@ -886,11 +886,11 @@ public:
     Evaluation evalThirdDerivative(const Evaluation& x, bool extrapolate = false) const
     {
         if (!extrapolate && !applies(x))
-            throw Opm::NumericalIssue("Tried to evaluate the third derivative of a spline outside of its range");
+            throw NumericalIssue("Tried to evaluate the third derivative of a spline outside of its range");
         else if (extrapolate)
             return 0.0;
 
-        return evalDerivative3_(x, segmentIdx_(Opm::scalarValue(x)));
+        return evalDerivative3_(x, segmentIdx_(scalarValue(x)));
     }
 
     /*!
@@ -1713,7 +1713,7 @@ protected:
                              Scalar x0 = -1e30, Scalar x1 = 1e30) const
     {
         unsigned n =
-            Opm::invertCubicPolynomial(sol,
+            invertCubicPolynomial(sol,
                                        a_(segIdx) - a,
                                        b_(segIdx) - b,
                                        c_(segIdx) - c,

--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -454,7 +454,7 @@ private:
     size_t findSegmentIndex_(const Evaluation& x, bool extrapolate = false) const
     {
         if (!extrapolate && !applies(x))
-            throw Opm::NumericalIssue("Tried to evaluate a tabulated function outside of its range");
+            throw NumericalIssue("Tried to evaluate a tabulated function outside of its range");
 
         // we need at least two sampling points!
         assert(xValues_.size() >= 2);

--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -195,7 +195,7 @@ public:
         if (!applies(x,y))
         {
             throw NumericalIssue("Attempt to get tabulated value for ("
-                                   +std::to_string(double(Opm::scalarValue(x)))+", "+std::to_string(double(Opm::scalarValue(y)))
+                                   +std::to_string(double(scalarValue(x)))+", "+std::to_string(double(scalarValue(y)))
                                    +") on a table of extend "
                                    +std::to_string(xMin())+" to "+std::to_string(xMax())+" times "
                                    +std::to_string(yMin())+" to "+std::to_string(yMax()));
@@ -208,11 +208,11 @@ public:
         unsigned i =
             static_cast<unsigned>(
                 std::max(0, std::min(static_cast<int>(numX()) - 2,
-                                     static_cast<int>(Opm::scalarValue(alpha)))));
+                                     static_cast<int>(scalarValue(alpha)))));
         unsigned j =
             static_cast<unsigned>(
                 std::max(0, std::min(static_cast<int>(numY()) - 2,
-                                     static_cast<int>(Opm::scalarValue(beta)))));
+                                     static_cast<int>(scalarValue(beta)))));
 
         alpha -= i;
         beta -= j;

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -291,7 +291,7 @@ public:
             return false;
 
         unsigned i = xSegmentIndex(x, /*extrapolate=*/false);
-        Scalar alpha = xToAlpha(Opm::decay<Scalar>(x), i);
+        Scalar alpha = xToAlpha(decay<Scalar>(x), i);
 
         const auto& col1SamplePoints = samples_.at(i);
         const auto& col2SamplePoints = samples_.at(i + 1);

--- a/opm/material/components/Air.hpp
+++ b/opm/material/components/Air.hpp
@@ -46,7 +46,7 @@ namespace Opm {
 template <class Scalar>
 class Air : public Component<Scalar, Air<Scalar> >
 {
-    typedef Opm::IdealGas<Scalar> IdealGas;
+    typedef ::Opm::IdealGas<Scalar> IdealGas;
 
 public:
     /*!
@@ -150,10 +150,10 @@ public:
         Scalar Fc = 1 - 0.2756*omega + 0.059035*mu_r4;
         Evaluation Tstar = 1.2593 * temperature/Tc;
         Evaluation Omega_v =
-            1.16145*Opm::pow(Tstar, -0.14874) +
-            0.52487*Opm::exp(- 0.77320*Tstar) +
-            2.16178*Opm::exp(- 2.43787*Tstar);
-        return 40.7851e-7*Fc*Opm::sqrt(M*temperature)/(std::pow(Vc, 2./3)*Omega_v);
+            1.16145*pow(Tstar, -0.14874) +
+            0.52487*exp(- 0.77320*Tstar) +
+            2.16178*exp(- 2.43787*Tstar);
+        return 40.7851e-7*Fc*sqrt(M*temperature)/(std::pow(Vc, 2./3)*Omega_v);
     }
 
     // simpler method, from old constrelAir.hh
@@ -161,9 +161,9 @@ public:
     static Evaluation simpleGasViscosity(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
         if(temperature < 273.15 || temperature > 660.) {
-            throw NumericalIssue("Air: Temperature "+std::to_string(Opm::scalarValue(temperature))+"K out of range");
+            throw NumericalIssue("Air: Temperature "+std::to_string(scalarValue(temperature))+"K out of range");
         }
-        return 1.496e-6*Opm::pow(temperature, 1.5)/(temperature + 120);
+        return 1.496e-6*pow(temperature, 1.5)/(temperature + 120);
     }
 
     /*!

--- a/opm/material/components/Brine.hpp
+++ b/opm/material/components/Brine.hpp
@@ -155,8 +155,8 @@ public:
         const Evaluation& S_lSAT =
             f[0]
             + f[1]*theta
-            + f[2]*Opm::pow(theta, 2)
-            + f[3]*Opm::pow(theta, 3);
+            + f[2]*pow(theta, 2)
+            + f[3]*pow(theta, 3);
 
         // Regularization
         if (S > S_lSAT)
@@ -169,7 +169,7 @@ public:
             (3.6710e4*temperature
              + (6.2770e1/2)*temperature*temperature
              - (6.6670e-2/3)*temperature*temperature*temperature
-             + (2.8000e-5/4)*Opm::pow(temperature, 4.0))/58.44e3
+             + (2.8000e-5/4)*pow(temperature, 4.0))/58.44e3
             - 2.045698e+02; // [kJ/kg]
 
         const Evaluation& m = S/(1-S)/58.44e-3;
@@ -177,7 +177,7 @@ public:
         Evaluation d_h = 0;
         for (int i = 0; i<=3; ++i) {
             for (int j = 0; j <= 2; ++j) {
-                d_h += a[i][j] * Opm::pow(theta, i) * Opm::pow(m, j);
+                d_h += a[i][j] * pow(theta, i) * pow(m, j);
             }
         }
 
@@ -196,7 +196,7 @@ public:
     static Evaluation liquidHeatCapacity(const Evaluation& temperature,
                                          const Evaluation& pressure)
     {
-        Scalar eps = Opm::scalarValue(temperature)*1e-8;
+        Scalar eps = scalarValue(temperature)*1e-8;
         return (liquidEnthalpy(temperature + eps, pressure) - liquidEnthalpy(temperature, pressure))/eps;
     }
 
@@ -286,12 +286,12 @@ public:
         // assume the pressure to be 10% higher than the vapor
         // pressure
         Evaluation pressure = 1.1*vaporPressure(temperature);
-        Scalar eps = Opm::scalarValue(pressure)*1e-7;
+        Scalar eps = scalarValue(pressure)*1e-7;
 
         Evaluation deltaP = pressure*2;
         for (int i = 0;
              i < 5
-                 && std::abs(Opm::scalarValue(pressure)*1e-9) < std::abs(Opm::scalarValue(deltaP));
+                 && std::abs(scalarValue(pressure)*1e-9) < std::abs(scalarValue(deltaP));
              ++i)
         {
             const Evaluation& f = liquidDensity(temperature, pressure) - density;
@@ -330,8 +330,8 @@ public:
         if(temperature <= 275.) // regularization
             T_C = 275.0;
 
-        Evaluation A = (0.42*std::pow((std::pow(salinity, 0.8)-0.17), 2) + 0.045)*Opm::pow(T_C, 0.8);
-        Evaluation mu_brine = 0.1 + 0.333*salinity + (1.65+91.9*salinity*salinity*salinity)*Opm::exp(-A);
+        Evaluation A = (0.42*std::pow((std::pow(salinity, 0.8)-0.17), 2) + 0.045)*pow(T_C, 0.8);
+        Evaluation mu_brine = 0.1 + 0.333*salinity + (1.65+91.9*salinity*salinity*salinity)*exp(-A);
 
         return mu_brine/1000.0; // convert to [Pa s] (todo: check if correct cP->Pa s is times 10...)
     }

--- a/opm/material/components/CO2.hpp
+++ b/opm/material/components/CO2.hpp
@@ -139,10 +139,10 @@ public:
         Evaluation exponent = 0;
         Evaluation Tred = T/criticalTemperature();
         for (int i = 0; i < 4; ++i)
-            exponent += a[i]*Opm::pow(1 - Tred, t[i]);
+            exponent += a[i]*pow(1 - Tred, t[i]);
         exponent *= 1.0/Tred;
 
-        return Opm::exp(exponent)*criticalPressure();
+        return exp(exponent)*criticalPressure();
     }
 
 
@@ -218,10 +218,10 @@ public:
         Evaluation TStar = temperature/ESP;
 
         // mu0: viscosity in zero-density limit
-        const Evaluation& logTStar = Opm::log(TStar);
-        Evaluation SigmaStar = Opm::exp(a0 + logTStar*(a1 + logTStar*(a2 + logTStar*(a3 + logTStar*a4))));
+        const Evaluation& logTStar = log(TStar);
+        Evaluation SigmaStar = exp(a0 + logTStar*(a1 + logTStar*(a2 + logTStar*(a3 + logTStar*a4))));
 
-        Evaluation mu0 = 1.00697*Opm::sqrt(temperature) / SigmaStar;
+        Evaluation mu0 = 1.00697*sqrt(temperature) / SigmaStar;
 
         const Evaluation& rho = gasDensity(temperature, pressure); // CO2 mass density [kg/m^3]
 
@@ -229,9 +229,9 @@ public:
         Evaluation dmu =
             d11*rho
             + d21*rho*rho
-            + d64*Opm::pow(rho, 6.0)/(TStar*TStar*TStar)
-            + d81*Opm::pow(rho, 8.0)
-            + d82*Opm::pow(rho, 8.0)/TStar;
+            + d64*pow(rho, 6.0)/(TStar*TStar*TStar)
+            + d81*pow(rho, 8.0)
+            + d82*pow(rho, 8.0)/TStar;
 
         return (mu0 + dmu)/1.0e6; // conversion to [Pa s]
     }

--- a/opm/material/components/H2O.hpp
+++ b/opm/material/components/H2O.hpp
@@ -357,7 +357,7 @@ public:
 
 
         // regularization
-        Scalar pv = vaporPressure<Scalar>(Opm::scalarValue(temperature));
+        Scalar pv = vaporPressure<Scalar>(scalarValue(temperature));
         if (pressure < pv) {
             // the pressure is too low, in this case we use the slope
             // of the internal energy at the vapor pressure to
@@ -428,7 +428,7 @@ public:
                 -
                 Rs*temperature; // = p*v   for an ideal gas!
         }
-        Scalar pv = vaporPressure(Opm::scalarValue(temperature));
+        Scalar pv = vaporPressure(scalarValue(temperature));
         if (pressure > pv) {
             // the pressure is too high, in this case we use the slope
             // of the internal energy at the vapor pressure to
@@ -598,7 +598,7 @@ public:
 
             // calculate the partial derivative of the specific volume
             // to the pressure at the vapor pressure.
-            Scalar eps = Opm::scalarValue(pv)*1e-8;
+            Scalar eps = scalarValue(pv)*1e-8;
             Evaluation v0 = volumeRegion2_(temperature, pv);
             Evaluation v1 = volumeRegion2_(temperature, pv + eps);
             Evaluation dv_dp = (v1 - v0)/eps;
@@ -658,7 +658,7 @@ public:
         Evaluation deltaP = pressure*2;
         Valgrind::CheckDefined(pressure);
         Valgrind::CheckDefined(deltaP);
-        for (int i = 0; i < 5 && std::abs(Opm::scalarValue(pressure)*1e-9) < std::abs(Opm::scalarValue(deltaP)); ++i) {
+        for (int i = 0; i < 5 && std::abs(scalarValue(pressure)*1e-9) < std::abs(scalarValue(deltaP)); ++i) {
             Evaluation f = gasDensity(temperature, pressure) - density;
 
             Evaluation df_dp;
@@ -707,7 +707,7 @@ public:
 
             // calculate the partial derivative of the specific volume
             // to the pressure at the vapor pressure.
-            Scalar eps = Opm::scalarValue(pv)*1e-8;
+            Scalar eps = scalarValue(pv)*1e-8;
             Evaluation v0 = volumeRegion1_(temperature, pv);
             Evaluation v1 = volumeRegion1_(temperature, pv + eps);
             Evaluation dv_dp = (v1 - v0)/eps;
@@ -757,10 +757,10 @@ public:
         // assume the pressure to be 10% higher than the vapor
         // pressure
         Evaluation pressure = 1.1*vaporPressure(temperature);
-        Scalar eps = Opm::scalarValue(pressure)*1e-7;
+        Scalar eps = scalarValue(pressure)*1e-7;
 
         Evaluation deltaP = pressure*2;
-        for (int i = 0; i < 5 && std::abs(Opm::scalarValue(pressure)*1e-9) < std::abs(Opm::scalarValue(deltaP)); ++i) {
+        for (int i = 0; i < 5 && std::abs(scalarValue(pressure)*1e-9) < std::abs(scalarValue(deltaP)); ++i) {
             Evaluation f = liquidDensity(temperature, pressure) - density;
 
             Evaluation df_dp;
@@ -887,7 +887,7 @@ private:
     static Evaluation heatCap_p_Region1_(const Evaluation& temperature, const Evaluation& pressure)
     {
         return
-            - Opm::pow(Region1::tau(temperature), 2.0) *
+            - pow(Region1::tau(temperature), 2.0) *
             Region1::ddgamma_ddtau(temperature, pressure) *
             Rs;
     }
@@ -951,7 +951,7 @@ private:
     static Evaluation heatCap_p_Region2_(const Evaluation& temperature, const Evaluation& pressure)
     {
         return
-            - Opm::pow(Region2::tau(temperature), 2 ) *
+            - pow(Region2::tau(temperature), 2 ) *
             Region2::ddgamma_ddtau(temperature, pressure) *
             Rs;
     }

--- a/opm/material/components/Mesitylene.hpp
+++ b/opm/material/components/Mesitylene.hpp
@@ -43,7 +43,7 @@ namespace Opm {
 template <class Scalar>
 class Mesitylene : public Component<Scalar, Mesitylene<Scalar> >
 {
-    typedef Opm::Constants<Scalar> Consts;
+    typedef Constants<Scalar> Consts;
 
 public:
     /*!
@@ -104,7 +104,7 @@ public:
 
         const Evaluation& T = temperature - 273.15;
 
-        return 100 * 1.334 * Opm::pow(10.0, A - (B / (T + C)));
+        return 100 * 1.334 * pow(10.0, A - (B / (T + C)));
     }
 
 
@@ -143,8 +143,8 @@ public:
     template <class Evaluation>
     static Evaluation heatVap(const Evaluation& temperature, const Evaluation& /*pressure*/)
     {
-        Evaluation T = Opm::min(temperature, criticalTemperature()); // regularization
-        T = Opm::max(T, 0.0); // regularization
+        Evaluation T = min(temperature, criticalTemperature()); // regularization
+        T = max(T, 0.0); // regularization
 
         const Scalar T_crit = criticalTemperature();
         const Scalar Tr1 = boilingTemperature()/criticalTemperature();
@@ -159,7 +159,7 @@ public:
         /* Variation with temp according to Watson relation eq 7-12.1*/
         const Evaluation& Tr2 = T/criticalTemperature();
         const Scalar n = 0.375;
-        const Evaluation& DH_vap = DH_v_boil * Opm::pow(((1.0 - Tr2)/(1.0 - Tr1)), n);
+        const Evaluation& DH_vap = DH_v_boil * pow(((1.0 - Tr2)/(1.0 - Tr1)), n);
 
         return (DH_vap/molarMass());          // we need [J/kg]
     }
@@ -228,8 +228,8 @@ public:
     template <class Evaluation>
     static Evaluation gasViscosity(Evaluation temperature, const Evaluation& /*pressure*/, bool /*regularize*/=true)
     {
-        temperature = Opm::min(temperature, 500.0); // regularization
-        temperature = Opm::max(temperature, 250.0);
+        temperature = min(temperature, 500.0); // regularization
+        temperature = max(temperature, 250.0);
 
         // reduced temperature
         const Evaluation& Tr = temperature/criticalTemperature();
@@ -237,9 +237,9 @@ public:
         Scalar Fp0 = 1.0;
         Scalar xi = 0.00474;
         const Evaluation& eta_xi =
-            Fp0*(0.807*Opm::pow(Tr,0.618)
-                 - 0.357*Opm::exp(-0.449*Tr)
-                 + 0.34*Opm::exp(-4.058*Tr)
+            Fp0*(0.807*pow(Tr,0.618)
+                 - 0.357*exp(-0.449*Tr)
+                 + 0.34*exp(-4.058*Tr)
                  + 0.018);
 
         return eta_xi/xi/1e7; // [Pa s]
@@ -254,13 +254,13 @@ public:
     template <class Evaluation>
     static Evaluation liquidViscosity(Evaluation temperature, const Evaluation& /*pressure*/)
     {
-        temperature = Opm::min(temperature, 500.0); // regularization
-        temperature = Opm::max(temperature, 250.0);
+        temperature = min(temperature, 500.0); // regularization
+        temperature = max(temperature, 250.0);
 
         const Scalar A = -6.749;
         const Scalar B = 2010.0;
 
-        return Opm::exp(A + B/temperature)*1e-3; // [Pa s]
+        return exp(A + B/temperature)*1e-3; // [Pa s]
     }
 
     /*!
@@ -320,12 +320,12 @@ protected:
     template <class Evaluation>
     static Evaluation molarLiquidDensity_(Evaluation temperature)
     {
-        temperature = Opm::min(temperature, 500.0); // regularization
-        temperature = Opm::max(temperature, 250.0);
+        temperature = min(temperature, 500.0); // regularization
+        temperature = max(temperature, 250.0);
 
         const Scalar Z_RA = 0.2556; // from equation
-        const Evaluation& expo = 1.0 + Opm::pow(1.0 - temperature/criticalTemperature(), 2.0/7.0);
-        const Evaluation& V = Consts::R*criticalTemperature()/criticalPressure()*Opm::pow(Z_RA, expo); // liquid molar volume [cm^3/mol]
+        const Evaluation& expo = 1.0 + pow(1.0 - temperature/criticalTemperature(), 2.0/7.0);
+        const Evaluation& V = Consts::R*criticalTemperature()/criticalPressure()*pow(Z_RA, expo); // liquid molar volume [cm^3/mol]
 
         return 1.0/V; // molar density [mol/m^3]
     }

--- a/opm/material/components/N2.hpp
+++ b/opm/material/components/N2.hpp
@@ -49,7 +49,7 @@ namespace Opm
 template <class Scalar>
 class N2 : public Component<Scalar, N2<Scalar> >
 {
-    typedef Opm::IdealGas<Scalar> IdealGas;
+    typedef ::Opm::IdealGas<Scalar> IdealGas;
 
 public:
     /*!
@@ -113,14 +113,14 @@ public:
 
         // note: this is the ancillary equation given on page 1368
         const Evaluation& sigma = 1.0 - temperature/criticalTemperature();
-        const Evaluation& sqrtSigma = Opm::sqrt(sigma);
+        const Evaluation& sqrtSigma = sqrt(sigma);
         const Scalar N1 = -6.12445284;
         const Scalar N2 = 1.26327220;
         const Scalar N3 = -0.765910082;
         const Scalar N4 = -1.77570564;
         return
             criticalPressure() *
-            Opm::exp(criticalTemperature()/temperature*
+            exp(criticalTemperature()/temperature*
                          (sigma*(N1 +
                                  sqrtSigma*N2 +
                                  sigma*(sqrtSigma*N3 +
@@ -271,10 +271,10 @@ public:
         Scalar Fc = 1 - 0.2756*omega + 0.059035*mu_r4;
         const Evaluation& Tstar = 1.2593 * temperature/Tc;
         const Evaluation& Omega_v =
-            1.16145*Opm::pow(Tstar, -0.14874) +
-            0.52487*Opm::exp(- 0.77320*Tstar) +
-            2.16178*Opm::exp(- 2.43787*Tstar);
-        const Evaluation& mu = 40.785*Fc*Opm::sqrt(M*temperature)/(std::pow(Vc, 2./3)*Omega_v);
+            1.16145*pow(Tstar, -0.14874) +
+            0.52487*exp(- 0.77320*Tstar) +
+            2.16178*exp(- 2.43787*Tstar);
+        const Evaluation& mu = 40.785*Fc*sqrt(M*temperature)/(std::pow(Vc, 2./3)*Omega_v);
 
         // convertion from micro poise to Pa s
         return mu/1e6 / 10;

--- a/opm/material/components/SimpleCO2.hpp
+++ b/opm/material/components/SimpleCO2.hpp
@@ -49,7 +49,7 @@ namespace Opm {
 template <class Scalar>
 class SimpleCO2 : public Component<Scalar, SimpleCO2<Scalar> >
 {
-    typedef Opm::IdealGas<Scalar> IdealGas;
+    typedef ::Opm::IdealGas<Scalar> IdealGas;
 
 public:
     /*!
@@ -179,10 +179,10 @@ public:
         Scalar Fc = 1 - 0.2756*omega + 0.059035*mu_r4;
         Evaluation Tstar = 1.2593 * temperature/Tc;
         Evaluation Omega_v =
-            1.16145*Opm::pow(Tstar, -0.14874) +
-            0.52487*Opm::exp(- 0.77320*Tstar) +
-            2.16178*Opm::exp(- 2.43787*Tstar);
-        Evaluation mu = 40.785*Fc*Opm::sqrt(M*temperature)/(std::pow(Vc, 2./3)*Omega_v);
+            1.16145*pow(Tstar, -0.14874) +
+            0.52487*exp(- 0.77320*Tstar) +
+            2.16178*exp(- 2.43787*Tstar);
+        Evaluation mu = 40.785*Fc*sqrt(M*temperature)/(std::pow(Vc, 2./3)*Omega_v);
 
         // convertion from micro poise to Pa s
         return mu/1e6 / 10;

--- a/opm/material/components/SimpleH2O.hpp
+++ b/opm/material/components/SimpleH2O.hpp
@@ -55,7 +55,7 @@ namespace Opm {
 template <class Scalar>
 class SimpleH2O : public Component<Scalar, SimpleH2O<Scalar> >
 {
-    typedef Opm::IdealGas<Scalar> IdealGas;
+    typedef ::Opm::IdealGas<Scalar> IdealGas;
 
     static const Scalar R;  // specific gas constant of water
 
@@ -147,7 +147,7 @@ public:
         Evaluation B = (n[2]*sigma + n[3])*sigma + n[4];
         Evaluation C = (n[5]*sigma + n[6])*sigma + n[7];
 
-        Evaluation tmp = 2.0*C/(Opm::sqrt(B*B - 4.0*A*C) - B);
+        Evaluation tmp = 2.0*C/(sqrt(B*B - 4.0*A*C) - B);
         tmp *= tmp;
         tmp *= tmp;
 
@@ -335,7 +335,7 @@ public:
 };
 
 template <class Scalar>
-const Scalar SimpleH2O<Scalar>::R = Opm::Constants<Scalar>::R / 18e-3;
+const Scalar SimpleH2O<Scalar>::R = Constants<Scalar>::R / 18e-3;
 
 } // namespace Opm
 

--- a/opm/material/components/SimpleHuDuanH2O.hpp
+++ b/opm/material/components/SimpleHuDuanH2O.hpp
@@ -62,7 +62,7 @@ namespace Opm {
 template <class Scalar>
 class SimpleHuDuanH2O : public Component<Scalar, SimpleHuDuanH2O<Scalar> >
 {
-    typedef Opm::IdealGas<Scalar> IdealGas;
+    typedef ::Opm::IdealGas<Scalar> IdealGas;
     typedef IAPWS::Common<Scalar> Common;
 
     static const Scalar R;  // specific gas constant of water
@@ -155,7 +155,7 @@ public:
         Evaluation B = (n[2]*sigma + n[3])*sigma + n[4];
         Evaluation C = (n[5]*sigma + n[6])*sigma + n[7];
 
-        Evaluation tmp = 2.0*C/(Opm::sqrt(B*B - 4.0*A*C) - B);
+        Evaluation tmp = 2.0*C/(sqrt(B*B - 4.0*A*C) - B);
         tmp *= tmp;
         tmp *= tmp;
 
@@ -392,7 +392,7 @@ private:
 };
 
 template <class Scalar>
-const Scalar SimpleHuDuanH2O<Scalar>::R = Opm::Constants<Scalar>::R / 18e-3;
+const Scalar SimpleHuDuanH2O<Scalar>::R = Constants<Scalar>::R / 18e-3;
 
 } // namespace Opm
 

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -255,7 +255,7 @@ public:
     static Evaluation vaporPressure(const Evaluation& temperature)
     {
         const Evaluation& result = interpolateT_(vaporPressure_, temperature);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::vaporPressure(temperature);
         return result;
     }
@@ -272,7 +272,7 @@ public:
         const Evaluation& result = interpolateGasTP_(gasEnthalpy_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::gasEnthalpy(temperature, pressure);
         return result;
     }
@@ -289,7 +289,7 @@ public:
         const Evaluation& result = interpolateLiquidTP_(liquidEnthalpy_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::liquidEnthalpy(temperature, pressure);
         return result;
     }
@@ -306,7 +306,7 @@ public:
         const Evaluation& result = interpolateGasTP_(gasHeatCapacity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::gasHeatCapacity(temperature, pressure);
         return result;
     }
@@ -323,7 +323,7 @@ public:
         const Evaluation& result = interpolateLiquidTP_(liquidHeatCapacity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::liquidHeatCapacity(temperature, pressure);
         return result;
     }
@@ -360,7 +360,7 @@ public:
         const Evaluation& result = interpolateGasTRho_(gasPressure_,
                                                        temperature,
                                                        density);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::gasPressure(temperature,
                                              density);
         return result;
@@ -378,7 +378,7 @@ public:
         const Evaluation& result = interpolateLiquidTRho_(liquidPressure_,
                                                           temperature,
                                                           density);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::liquidPressure(temperature,
                                                 density);
         return result;
@@ -416,7 +416,7 @@ public:
         const Evaluation& result = interpolateGasTP_(gasDensity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::gasDensity(temperature, pressure);
         return result;
     }
@@ -434,7 +434,7 @@ public:
         const Evaluation& result = interpolateLiquidTP_(liquidDensity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::liquidDensity(temperature, pressure);
         return result;
     }
@@ -451,7 +451,7 @@ public:
         const Evaluation& result = interpolateGasTP_(gasViscosity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::gasViscosity(temperature, pressure);
         return result;
     }
@@ -468,7 +468,7 @@ public:
         const Evaluation& result = interpolateLiquidTP_(liquidViscosity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::liquidViscosity(temperature, pressure);
         return result;
     }
@@ -485,7 +485,7 @@ public:
         const Evaluation& result = interpolateGasTP_(gasThermalConductivity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::gasThermalConductivity(temperature, pressure);
         return result;
     }
@@ -502,7 +502,7 @@ public:
         const Evaluation& result = interpolateLiquidTP_(liquidThermalConductivity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(Opm::scalarValue(result)))
+        if (std::isnan(scalarValue(result)))
             return RawComponent::liquidThermalConductivity(temperature, pressure);
         return result;
     }
@@ -516,7 +516,7 @@ private:
         if (alphaT < 0 || alphaT >= nTemp_ - 1)
             return std::numeric_limits<Scalar>::quiet_NaN();
 
-        size_t iT = static_cast<size_t>(Opm::scalarValue(alphaT));
+        size_t iT = static_cast<size_t>(scalarValue(alphaT));
         alphaT -= iT;
 
         return
@@ -533,7 +533,7 @@ private:
         if (alphaT < 0 || alphaT >= nTemp_ - 1)
             return std::numeric_limits<Scalar>::quiet_NaN();
 
-        size_t iT = static_cast<size_t>(Opm::scalarValue(alphaT));
+        size_t iT = static_cast<size_t>(scalarValue(alphaT));
         alphaT -= iT;
 
         Evaluation alphaP1 = pressLiquidIdx_(p, iT);
@@ -542,11 +542,11 @@ private:
         size_t iP1 =
             static_cast<size_t>(
                 std::max<int>(0, std::min(static_cast<int>(nPress_) - 2,
-                                          static_cast<int>(Opm::scalarValue(alphaP1)))));
+                                          static_cast<int>(scalarValue(alphaP1)))));
         size_t iP2 =
             static_cast<size_t>(
                 std::max(0, std::min(static_cast<int>(nPress_) - 2,
-                                     static_cast<int>(Opm::scalarValue(alphaP2)))));
+                                     static_cast<int>(scalarValue(alphaP2)))));
         alphaP1 -= iP1;
         alphaP2 -= iP2;
 
@@ -569,7 +569,7 @@ private:
         size_t iT =
             static_cast<size_t>(
                 std::max(0, std::min(static_cast<int>(nTemp_) - 2,
-                                     static_cast<int>(Opm::scalarValue(alphaT)))));
+                                     static_cast<int>(scalarValue(alphaT)))));
         alphaT -= iT;
 
         Evaluation alphaP1 = pressGasIdx_(p, iT);
@@ -577,11 +577,11 @@ private:
         size_t iP1 =
             static_cast<size_t>(
                 std::max(0, std::min(static_cast<int>(nPress_) - 2,
-                                     static_cast<int>(Opm::scalarValue(alphaP1)))));
+                                     static_cast<int>(scalarValue(alphaP1)))));
         size_t iP2 =
             static_cast<size_t>(
                 std::max(0, std::min(static_cast<int>(nPress_) - 2,
-                                     static_cast<int>(Opm::scalarValue(alphaP2)))));
+                                     static_cast<int>(scalarValue(alphaP2)))));
         alphaP1 -= iP1;
         alphaP2 -= iP2;
 

--- a/opm/material/components/Xylene.hpp
+++ b/opm/material/components/Xylene.hpp
@@ -46,7 +46,7 @@ template <class Scalar>
 class Xylene : public Component<Scalar, Xylene<Scalar> >
 {
     typedef Constants<Scalar> Consts;
-    typedef Opm::IdealGas<Scalar> IdealGas;
+    typedef ::Opm::IdealGas<Scalar> IdealGas;
 
 public:
     /*!
@@ -98,7 +98,7 @@ public:
         const Scalar B = 1462.266;;
         const Scalar C = 215.110;;
 
-        return 100*1.334*Opm::pow(10.0, (A - (B/(temperature - 273.15 + C))));
+        return 100*1.334*pow(10.0, (A - (B/(temperature - 273.15 + C))));
     }
 
     /*!
@@ -181,8 +181,8 @@ public:
     static Evaluation heatVap(Evaluation temperature,
                               const Evaluation& /*pressure*/)
     {
-        temperature = Opm::min(temperature, criticalTemperature()); // regularization
-        temperature = Opm::max(temperature, 0.0); // regularization
+        temperature = min(temperature, criticalTemperature()); // regularization
+        temperature = max(temperature, 0.0); // regularization
 
         const Scalar T_crit = criticalTemperature();
         const Scalar Tr1 = boilingTemperature()/criticalTemperature();
@@ -196,7 +196,7 @@ public:
         /* Variation with temperature according to Watson relation eq 7-12.1*/
         const Evaluation& Tr2 = temperature/criticalTemperature();
         const Scalar n = 0.375;
-        const Evaluation& DH_vap = DH_v_boil * Opm::pow(((1.0 - Tr2)/(1.0 - Tr1)), n);
+        const Evaluation& DH_vap = DH_v_boil * pow(((1.0 - Tr2)/(1.0 - Tr1)), n);
 
         return (DH_vap/molarMass());          // we need [J/kg]
     }
@@ -249,13 +249,13 @@ public:
         // saturated molar volume according to Lide, CRC Handbook of
         // Thermophysical and Thermochemical Data, CRC Press, 1994
         // valid for 245 < Temperature < 600
-        temperature = Opm::min(temperature, 500.0); // regularization
-        temperature = Opm::max(temperature, 250.0); // regularization
+        temperature = min(temperature, 500.0); // regularization
+        temperature = max(temperature, 250.0); // regularization
 
         const Scalar A1 = 0.25919;           // from table
         const Scalar A2 = 0.0014569;         // from table
-        const Evaluation& expo = 1.0 + Opm::pow((1.0 - temperature/criticalTemperature()), (2.0/7.0));
-        return 1.0/(A2*Opm::pow(A1, expo));
+        const Evaluation& expo = 1.0 + pow((1.0 - temperature/criticalTemperature()), (2.0/7.0));
+        return 1.0/(A2*pow(A1, expo));
     }
 
     /*!
@@ -289,15 +289,15 @@ public:
     template <class Evaluation>
     static Evaluation gasViscosity(Evaluation temperature, const Evaluation& /*pressure*/)
     {
-        temperature = Opm::min(temperature, 500.0); // regularization
-        temperature = Opm::max(temperature, 250.0); // regularization
+        temperature = min(temperature, 500.0); // regularization
+        temperature = max(temperature, 250.0); // regularization
 
-        const Evaluation& Tr = Opm::max(temperature/criticalTemperature(), 1e-10);
+        const Evaluation& Tr = max(temperature/criticalTemperature(), 1e-10);
         const Scalar Fp0 = 1.0;
         const Scalar xi = 0.004623;
-        const Evaluation& eta_xi = Fp0*(0.807*Opm::pow(Tr, 0.618)
-                                   - 0.357*Opm::exp(-0.449*Tr)
-                                   + 0.34*Opm::exp(-4.058*Tr)
+        const Evaluation& eta_xi = Fp0*(0.807*pow(Tr, 0.618)
+                                   - 0.357*exp(-0.449*Tr)
+                                   + 0.34*exp(-4.058*Tr)
                                    + 0.018);
         return eta_xi/xi / 1e7; // [Pa s]
     }
@@ -308,15 +308,15 @@ public:
     template <class Evaluation>
     static Evaluation liquidViscosity(Evaluation temperature, const Evaluation& /*pressure*/)
     {
-        temperature = Opm::min(temperature, 500.0); // regularization
-        temperature = Opm::max(temperature, 250.0); // regularization
+        temperature = min(temperature, 500.0); // regularization
+        temperature = max(temperature, 250.0); // regularization
 
         const Scalar A = -3.82;
         const Scalar B = 1027.0;
         const Scalar C = -6.38e-4;
         const Scalar D = 4.52e-7;
 
-        return 1e-3*Opm::exp(A
+        return 1e-3*exp(A
                              + B/temperature
                              + C*temperature
                              + D*temperature*temperature); // in [cP]

--- a/opm/material/components/iapws/Common.hpp
+++ b/opm/material/components/iapws/Common.hpp
@@ -124,10 +124,10 @@ public:
             tmp3 *= 1.0/TBar - 1;
         };
         muBar *= rhoBar;
-        muBar = Opm::exp(muBar);
+        muBar = exp(muBar);
 
         // muBar *= muBar_0
-        muBar  *= 100*Opm::sqrt(TBar);
+        muBar  *= 100*sqrt(TBar);
         const Scalar H[4] = {
             1.67752, 2.20462, 0.6366564, -0.241605
         };
@@ -191,7 +191,7 @@ public:
         Evaluation rhobar = rho / thcond_rhostar;
 
         /* fast implementation... minimised calls to 'pow' routine... */
-        Evaluation Troot = Opm::sqrt(Tbar);
+        Evaluation Troot = sqrt(Tbar);
         Evaluation Tpow = Troot;
         Evaluation lam = 0;
 
@@ -203,10 +203,10 @@ public:
         lam +=
             thcond_b0 + thcond_b1
             * rhobar + thcond_b2
-            * Opm::exp(thcond_B1 * ((rhobar + thcond_B2)*(rhobar + thcond_B2)));
+            * exp(thcond_B1 * ((rhobar + thcond_B2)*(rhobar + thcond_B2)));
 
-        Evaluation DTbar = Opm::abs(Tbar - 1) + thcond_c4;
-        Evaluation DTbarpow = Opm::pow(DTbar, 3./5);
+        Evaluation DTbar = abs(Tbar - 1) + thcond_c4;
+        Evaluation DTbarpow = pow(DTbar, 3./5);
         Evaluation Q = 2. + thcond_c5 / DTbarpow;
 
         Evaluation S;
@@ -215,16 +215,16 @@ public:
         else
             S = thcond_c6 / DTbarpow;
 
-        Evaluation rhobar18 = Opm::pow(rhobar, 1.8);
-        Evaluation rhobarQ = Opm::pow(rhobar, Q);
+        Evaluation rhobar18 = pow(rhobar, 1.8);
+        Evaluation rhobarQ = pow(rhobar, Q);
 
         lam +=
-            (thcond_d1 / Opm::pow(Tbar,10.0) + thcond_d2) * rhobar18 *
-            Opm::exp(thcond_c1 * (1 - rhobar * rhobar18))
+            (thcond_d1 / pow(Tbar,10.0) + thcond_d2) * rhobar18 *
+            exp(thcond_c1 * (1 - rhobar * rhobar18))
             + thcond_d3 * S * rhobarQ *
-            Opm::exp((Q/(1+Q))*(1 - rhobar*rhobarQ))
+            exp((Q/(1+Q))*(1 - rhobar*rhobarQ))
             + thcond_d4 *
-            Opm::exp(thcond_c2 * Opm::pow(Troot,3.0) + thcond_c3 / Opm::pow(rhobar,5.0));
+            exp(thcond_c2 * pow(Troot,3.0) + thcond_c3 / pow(rhobar,5.0));
         return /*thcond_kstar * */ lam;
     }
 };
@@ -232,7 +232,7 @@ public:
 template <class Scalar>
 const Scalar Common<Scalar>::molarMass = 18.01518e-3;
 template <class Scalar>
-const Scalar Common<Scalar>::Rs = Opm::Constants<Scalar>::R/molarMass;
+const Scalar Common<Scalar>::Rs = Constants<Scalar>::R/molarMass;
 template <class Scalar>
 const Scalar Common<Scalar>::criticalTemperature = 647.096;
 template <class Scalar>

--- a/opm/material/components/iapws/Region1.hpp
+++ b/opm/material/components/iapws/Region1.hpp
@@ -140,7 +140,7 @@ public:
 
         Evaluation result = 0;
         for (int i = 0; i < 34; ++i) {
-            result += n(i)*Opm::pow(7.1 - pi_, I(i))*Opm::pow(tau_ - 1.222, J(i));
+            result += n(i)*pow(7.1 - pi_, I(i))*pow(tau_ - 1.222, J(i));
         }
 
         return result;
@@ -168,8 +168,8 @@ public:
         for (int i = 0; i < 34; i++) {
             result +=
                 n(i) *
-                Opm::pow(7.1 - pi_, static_cast<Scalar>(I(i))) *
-                Opm::pow(tau_ - 1.222,  static_cast<Scalar>(J(i)-1)) *
+                pow(7.1 - pi_, static_cast<Scalar>(I(i))) *
+                pow(tau_ - 1.222,  static_cast<Scalar>(J(i)-1)) *
                 J(i);
         }
 
@@ -198,8 +198,8 @@ public:
             result +=
                 -n(i) *
                 I(i) *
-                Opm::pow(7.1 - pi_, static_cast<Scalar>(I(i) - 1)) *
-                Opm::pow(tau_ - 1.222, static_cast<Scalar>(J(i)));
+                pow(7.1 - pi_, static_cast<Scalar>(I(i) - 1)) *
+                pow(tau_ - 1.222, static_cast<Scalar>(J(i)));
         }
 
         return result;
@@ -229,8 +229,8 @@ public:
                 -n(i) *
                 I(i) *
                 J(i) *
-                Opm::pow(7.1 - pi_, static_cast<Scalar>(I(i) - 1)) *
-                Opm::pow(tau_ - 1.222, static_cast<Scalar>(J(i) - 1));
+                pow(7.1 - pi_, static_cast<Scalar>(I(i) - 1)) *
+                pow(tau_ - 1.222, static_cast<Scalar>(J(i) - 1));
         }
 
         return result;
@@ -260,8 +260,8 @@ public:
                 n(i) *
                 I(i) *
                 (I(i) - 1) *
-                Opm::pow(7.1 - pi_, I(i) - 2) *
-                Opm::pow(tau_ - 1.222, J(i));
+                pow(7.1 - pi_, I(i) - 2) *
+                pow(tau_ - 1.222, J(i));
         }
 
         return result;
@@ -288,10 +288,10 @@ public:
         for (int i = 0; i < 34; i++) {
             result +=
                 n(i) *
-                Opm::pow(7.1 - pi_, I(i)) *
+                pow(7.1 - pi_, I(i)) *
                 J(i) *
                 (J(i) - 1) *
-                Opm::pow(tau_ - 1.222,  J(i) - 2);
+                pow(tau_ - 1.222,  J(i) - 2);
         }
 
         return result;

--- a/opm/material/components/iapws/Region2.hpp
+++ b/opm/material/components/iapws/Region2.hpp
@@ -141,16 +141,16 @@ public:
         Evaluation result;
 
         // ideal gas part
-        result = Opm::log(pi_);
+        result = log(pi_);
         for (int i = 0; i < 9; ++i)
-            result += n_g(i)*Opm::pow(tau_, J_g(i));
+            result += n_g(i)*pow(tau_, J_g(i));
 
         // residual part
         for (int i = 0; i < 43; ++i)
             result +=
                 n_r(i)*
-                Opm::pow(pi_, I_r(i))*
-                Opm::pow(tau_ - 0.5, J_r(i));
+                pow(pi_, I_r(i))*
+                pow(tau_ - 0.5, J_r(i));
         return result;
     }
 
@@ -178,16 +178,16 @@ public:
             result +=
                 n_g(i) *
                 J_g(i) *
-                Opm::pow(tau_, static_cast<Scalar>(J_g(i) - 1));
+                pow(tau_, static_cast<Scalar>(J_g(i) - 1));
         }
 
         // residual part
         for (int i = 0; i < 43; i++) {
             result +=
                 n_r(i) *
-                Opm::pow(pi_,  static_cast<Scalar>(I_r(i))) *
+                pow(pi_,  static_cast<Scalar>(I_r(i))) *
                 J_r(i) *
-                Opm::pow(tau_ - 0.5, static_cast<Scalar>(J_r(i) - 1));
+                pow(tau_ - 0.5, static_cast<Scalar>(J_r(i) - 1));
         }
 
         return result;
@@ -219,8 +219,8 @@ public:
             result +=
                 n_r(i) *
                 I_r(i) *
-                Opm::pow(pi_, static_cast<Scalar>(I_r(i) - 1)) *
-                Opm::pow(tau_ - 0.5, static_cast<Scalar>(J_r(i)));
+                pow(pi_, static_cast<Scalar>(I_r(i) - 1)) *
+                pow(tau_ - 0.5, static_cast<Scalar>(J_r(i)));
         }
 
         return result;
@@ -253,8 +253,8 @@ public:
                 n_r(i) *
                 I_r(i) *
                 J_r(i) *
-                Opm::pow(pi_, static_cast<Scalar>(I_r(i) - 1)) *
-                Opm::pow(tau_ - 0.5, static_cast<Scalar>(J_r(i) - 1));
+                pow(pi_, static_cast<Scalar>(I_r(i) - 1)) *
+                pow(tau_ - 0.5, static_cast<Scalar>(J_r(i) - 1));
         }
 
         return result;
@@ -287,8 +287,8 @@ public:
                 n_r(i) *
                 I_r(i) *
                 (I_r(i) - 1) *
-                Opm::pow(pi_, static_cast<Scalar>(I_r(i) - 2)) *
-                Opm::pow(tau_ - 0.5, static_cast<Scalar>(J_r(i)));
+                pow(pi_, static_cast<Scalar>(I_r(i) - 2)) *
+                pow(tau_ - 0.5, static_cast<Scalar>(J_r(i)));
         }
 
         return result;
@@ -319,17 +319,17 @@ public:
                 n_g(i) *
                 J_g(i) *
                 (J_g(i) - 1) *
-                Opm::pow(tau_, static_cast<Scalar>(J_g(i) - 2));
+                pow(tau_, static_cast<Scalar>(J_g(i) - 2));
         }
 
         // residual part
         for (int i = 0; i < 43; i++) {
             result +=
                 n_r(i) *
-                Opm::pow(pi_,  I_r(i)) *
+                pow(pi_,  I_r(i)) *
                 J_r(i) *
                 (J_r(i) - 1.) *
-                Opm::pow(tau_ - 0.5, static_cast<Scalar>(J_r(i) - 2));
+                pow(tau_ - 0.5, static_cast<Scalar>(J_r(i) - 2));
         }
 
         return result;

--- a/opm/material/components/iapws/Region4.hpp
+++ b/opm/material/components/iapws/Region4.hpp
@@ -75,7 +75,7 @@ public:
         const Evaluation& B = (n[2]*sigma + n[3])*sigma + n[4];
         const Evaluation& C = (n[5]*sigma + n[6])*sigma + n[7];
 
-        Evaluation tmp = 2*C/(Opm::sqrt(B*B - 4*A*C) - B);
+        Evaluation tmp = 2*C/(sqrt(B*B - 4*A*C) - B);
         tmp *= tmp;
         tmp *= tmp;
 
@@ -105,9 +105,9 @@ public:
         const Evaluation& F = n[0]*beta2 + n[3]*beta + n[6];
         const Evaluation& G = n[1]*beta2 + n[4]*beta + n[7];
 
-        const Evaluation& D = ( 2.*G)/(-F -Opm::sqrt(pow(F,2.) - 4.*E*G));
+        const Evaluation& D = ( 2.*G)/(-F -sqrt(pow(F,2.) - 4.*E*G));
 
-        const Evaluation& temperature = (n[9] + D - Opm::sqrt(pow(n[9]+D , 2.) - 4.* (n[8] + n[9]*D)) ) * 0.5;
+        const Evaluation& temperature = (n[9] + D - sqrt(pow(n[9]+D , 2.) - 4.* (n[8] + n[9]*D)) ) * 0.5;
 
         return temperature;
     }

--- a/opm/material/constraintsolvers/CompositionFromFugacities.hpp
+++ b/opm/material/constraintsolvers/CompositionFromFugacities.hpp
@@ -131,7 +131,7 @@ public:
             x = 0.0;
             try { J.solve(x, b); }
             catch (const Dune::FMatrixError& e)
-            { throw Opm::NumericalIssue(e.what()); }
+            { throw NumericalIssue(e.what()); }
 
             //std::cout << "original delta: " << x << "\n";
 
@@ -171,7 +171,7 @@ public:
             << xInit
             << "}, {fug_t} = {" << targetFug << "}, p = " << fluidState.pressure(phaseIdx)
             << ", T = " << fluidState.temperature(phaseIdx);
-        throw Opm::NumericalIssue(oss.str());
+        throw NumericalIssue(oss.str());
     }
 
 
@@ -228,7 +228,7 @@ protected:
             fluidState.setFugacityCoefficient(phaseIdx, i, phi);
 
             defect[i] = targetFug[i] - f;
-            absError = std::max(absError, std::abs(Opm::scalarValue(defect[i])));
+            absError = std::max(absError, std::abs(scalarValue(defect[i])));
         }
 
         // assemble jacobian matrix of the constraints for the composition
@@ -292,10 +292,10 @@ protected:
         Evaluation sumx = 0.0;
         for (unsigned i = 0; i < numComponents; ++i) {
             origComp[i] = fluidState.moleFraction(phaseIdx, i);
-            relError = std::max(relError, std::abs(Opm::scalarValue(x[i])));
+            relError = std::max(relError, std::abs(scalarValue(x[i])));
 
-            sumx += Opm::abs(fluidState.moleFraction(phaseIdx, i));
-            sumDelta += Opm::abs(x[i]);
+            sumx += abs(fluidState.moleFraction(phaseIdx, i));
+            sumDelta += abs(x[i]);
         }
 
         // chop update to at most 20% change in composition
@@ -308,10 +308,10 @@ protected:
             Evaluation newx = origComp[i] - x[i];
             // only allow negative mole fractions if the target fugacity is negative
             if (targetFug[i] > 0)
-                newx = Opm::max(0.0, newx);
+                newx = max(0.0, newx);
             // only allow positive mole fractions if the target fugacity is positive
             else if (targetFug[i] < 0)
-                newx = Opm::min(0.0, newx);
+                newx = min(0.0, newx);
             // if the target fugacity is zero, the mole fraction must also be zero
             else
                 newx = 0;

--- a/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
+++ b/opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
@@ -65,7 +65,7 @@ class ComputeFromReferencePhase
 {
     enum { numPhases = FluidSystem::numPhases };
     enum { numComponents = FluidSystem::numComponents };
-    typedef Opm::CompositionFromFugacities<Scalar, FluidSystem, Evaluation> CompositionFromFugacities;
+    typedef ::Opm::CompositionFromFugacities<Scalar, FluidSystem, Evaluation> CompositionFromFugacities;
     typedef Dune::FieldVector<Evaluation, numComponents> ComponentVector;
 
 public:
@@ -148,7 +148,7 @@ public:
             ComponentVector fugVec;
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 const auto& fug = fluidState.fugacity(refPhaseIdx, compIdx);
-                fugVec[compIdx] = Opm::decay<Evaluation>(fug);
+                fugVec[compIdx] = decay<Evaluation>(fug);
             }
 
             CompositionFromFugacities::solve(fluidState, paramCache, phaseIdx, fugVec);

--- a/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
+++ b/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
@@ -185,7 +185,7 @@ public:
             // coefficients of the components cannot depend on
             // composition, i.e. the parameters in the cache are valid
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-                Evaluation fugCoeff = Opm::decay<Evaluation>(
+                Evaluation fugCoeff = decay<Evaluation>(
                     FluidSystem::fugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx));
                 fluidState.setFugacityCoefficient(phaseIdx, compIdx, fugCoeff);
             }

--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -156,11 +156,11 @@ public:
         typedef Dune::FieldMatrix<InputEval, numEq, numEq> Matrix;
         typedef Dune::FieldVector<InputEval, numEq> Vector;
 
-        typedef Opm::DenseAd::Evaluation</*Scalar=*/InputEval,
-                                         /*numDerivs=*/numEq> FlashEval;
+        typedef DenseAd::Evaluation</*Scalar=*/InputEval,
+                                    /*numDerivs=*/numEq> FlashEval;
 
         typedef Dune::FieldVector<FlashEval, numEq> FlashDefectVector;
-        typedef Opm::CompositionalFluidState<FlashEval, FluidSystem, /*energy=*/false> FlashFluidState;
+        typedef CompositionalFluidState<FlashEval, FluidSystem, /*energy=*/false> FlashFluidState;
 
 #if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,7)
         Dune::FMatrixPrecision<InputEval>::set_singular_limit(1e-35);
@@ -220,7 +220,7 @@ public:
             deltaX = 0.0;
             try { J.solve(deltaX, b); }
             catch (const Dune::FMatrixError& e) {
-                throw Opm::NumericalIssue(e.what());
+                throw NumericalIssue(e.what());
             }
             Valgrind::CheckDefined(deltaX);
 
@@ -468,7 +468,7 @@ protected:
         // make sure we don't swallow non-finite update vectors
         assert(deltaX.dimension == numEq);
         for (unsigned i = 0; i < numEq; ++i)
-            assert(std::isfinite(Opm::scalarValue(deltaX[i])));
+            assert(std::isfinite(scalarValue(deltaX[i])));
 #endif
 
         Scalar relError = 0;
@@ -477,21 +477,21 @@ protected:
             InnerEval delta = deltaX[pvIdx];
 
             relError = std::max(relError,
-                                std::abs(Opm::scalarValue(delta))
+                                std::abs(scalarValue(delta))
                                 * quantityWeight_(fluidState, pvIdx));
 
             if (isSaturationIdx_(pvIdx)) {
                 // dampen to at most 25% change in saturation per iteration
-                delta = Opm::min(0.25, Opm::max(-0.25, delta));
+                delta = min(0.25, max(-0.25, delta));
             }
             else if (isMoleFracIdx_(pvIdx)) {
                 // dampen to at most 20% change in mole fraction per iteration
-                delta = Opm::min(0.20, Opm::max(-0.20, delta));
+                delta = min(0.20, max(-0.20, delta));
             }
             else if (isPressureIdx_(pvIdx)) {
                 // dampen to at most 50% change in pressure per iteration
-                delta = Opm::min(0.5*fluidState.pressure(0).value(),
-                                 Opm::max(-0.5*fluidState.pressure(0).value(),
+                delta = min(0.5*fluidState.pressure(0).value(),
+                                 max(-0.5*fluidState.pressure(0).value(),
                                           delta));
             }
 

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -566,12 +566,12 @@ using DynamicEvaluation = Evaluation<Scalar, DynamicSize, staticSize>;
 } // namespace DenseAd
 
 template <class Scalar, unsigned staticSize>
-Opm::DenseAd::Evaluation<Scalar, -1, staticSize> constant(int numDerivatives, const Scalar& value)
-{ return Opm::DenseAd::Evaluation<Scalar, -1, staticSize>::createConstant(numDerivatives, value); }
+DenseAd::Evaluation<Scalar, -1, staticSize> constant(int numDerivatives, const Scalar& value)
+{ return DenseAd::Evaluation<Scalar, -1, staticSize>::createConstant(numDerivatives, value); }
 
 template <class Scalar, unsigned staticSize>
-Opm::DenseAd::Evaluation<Scalar, -1, staticSize> variable(int numDerivatives, const Scalar& value, unsigned idx)
-{ return Opm::DenseAd::Evaluation<Scalar, -1, staticSize>::createVariable(numDerivatives, value, idx); }
+DenseAd::Evaluation<Scalar, -1, staticSize> variable(int numDerivatives, const Scalar& value, unsigned idx)
+{ return DenseAd::Evaluation<Scalar, -1, staticSize>::createVariable(numDerivatives, value, idx); }
 
 } // namespace Opm
 

--- a/opm/material/densead/Math.hpp
+++ b/opm/material/densead/Math.hpp
@@ -422,14 +422,14 @@ Evaluation<ValueType, numVars, staticSize> log10(const Evaluation<ValueType, num
 // a kind of traits class for the automatic differentiation case. (The toolbox for the
 // scalar case is provided by the MathToolbox.hpp header file.)
 template <class ValueT, int numVars, unsigned staticSize>
-struct MathToolbox<Opm::DenseAd::Evaluation<ValueT, numVars, staticSize> >
+struct MathToolbox<DenseAd::Evaluation<ValueT, numVars, staticSize> >
 {
 private:
 public:
     typedef ValueT ValueType;
-    typedef Opm::MathToolbox<ValueType> InnerToolbox;
+    typedef MathToolbox<ValueType> InnerToolbox;
     typedef typename InnerToolbox::Scalar Scalar;
-    typedef Opm::DenseAd::Evaluation<ValueType, numVars, staticSize> Evaluation;
+    typedef DenseAd::Evaluation<ValueType, numVars, staticSize> Evaluation;
 
     static ValueType value(const Evaluation& eval)
     { return eval.value(); }
@@ -496,66 +496,66 @@ public:
     // arithmetic functions
     template <class Arg1Eval, class Arg2Eval>
     static Evaluation max(const Arg1Eval& arg1, const Arg2Eval& arg2)
-    { return Opm::DenseAd::max(arg1, arg2); }
+    { return DenseAd::max(arg1, arg2); }
 
     template <class Arg1Eval, class Arg2Eval>
     static Evaluation min(const Arg1Eval& arg1, const Arg2Eval& arg2)
-    { return Opm::DenseAd::min(arg1, arg2); }
+    { return DenseAd::min(arg1, arg2); }
 
     static Evaluation abs(const Evaluation& arg)
-    { return Opm::DenseAd::abs(arg); }
+    { return DenseAd::abs(arg); }
 
     static Evaluation tan(const Evaluation& arg)
-    { return Opm::DenseAd::tan(arg); }
+    { return DenseAd::tan(arg); }
 
     static Evaluation atan(const Evaluation& arg)
-    { return Opm::DenseAd::atan(arg); }
+    { return DenseAd::atan(arg); }
 
     static Evaluation atan2(const Evaluation& arg1, const Evaluation& arg2)
-    { return Opm::DenseAd::atan2(arg1, arg2); }
+    { return DenseAd::atan2(arg1, arg2); }
 
     template <class Eval2>
     static Evaluation atan2(const Evaluation& arg1, const Eval2& arg2)
-    { return Opm::DenseAd::atan2(arg1, arg2); }
+    { return DenseAd::atan2(arg1, arg2); }
 
     template <class Eval1>
     static Evaluation atan2(const Eval1& arg1, const Evaluation& arg2)
-    { return Opm::DenseAd::atan2(arg1, arg2); }
+    { return DenseAd::atan2(arg1, arg2); }
 
     static Evaluation sin(const Evaluation& arg)
-    { return Opm::DenseAd::sin(arg); }
+    { return DenseAd::sin(arg); }
 
     static Evaluation asin(const Evaluation& arg)
-    { return Opm::DenseAd::asin(arg); }
+    { return DenseAd::asin(arg); }
 
     static Evaluation cos(const Evaluation& arg)
-    { return Opm::DenseAd::cos(arg); }
+    { return DenseAd::cos(arg); }
 
     static Evaluation acos(const Evaluation& arg)
-    { return Opm::DenseAd::acos(arg); }
+    { return DenseAd::acos(arg); }
 
     static Evaluation sqrt(const Evaluation& arg)
-    { return Opm::DenseAd::sqrt(arg); }
+    { return DenseAd::sqrt(arg); }
 
     static Evaluation exp(const Evaluation& arg)
-    { return Opm::DenseAd::exp(arg); }
+    { return DenseAd::exp(arg); }
 
     static Evaluation log(const Evaluation& arg)
-    { return Opm::DenseAd::log(arg); }
+    { return DenseAd::log(arg); }
 
     static Evaluation log10(const Evaluation& arg)
-    { return Opm::DenseAd::log10(arg); }
+    { return DenseAd::log10(arg); }
 
     template <class RhsValueType>
     static Evaluation pow(const Evaluation& arg1, const RhsValueType& arg2)
-    { return Opm::DenseAd::pow(arg1, arg2); }
+    { return DenseAd::pow(arg1, arg2); }
 
     template <class RhsValueType>
     static Evaluation pow(const RhsValueType& arg1, const Evaluation& arg2)
-    { return Opm::DenseAd::pow(arg1, arg2); }
+    { return DenseAd::pow(arg1, arg2); }
 
     static Evaluation pow(const Evaluation& arg1, const Evaluation& arg2)
-    { return Opm::DenseAd::pow(arg1, arg2); }
+    { return DenseAd::pow(arg1, arg2); }
 
     static bool isfinite(const Evaluation& arg)
     {

--- a/opm/material/eos/PengRobinson.hpp
+++ b/opm/material/eos/PengRobinson.hpp
@@ -129,7 +129,7 @@ public:
             const Evaluation& delta = f/df_dp;
             pVap = pVap - delta;
 
-            if (std::abs(Opm::scalarValue(delta/pVap)) < 1e-10)
+            if (std::abs(scalarValue(delta/pVap)) < 1e-10)
                 break;
         }
 
@@ -162,10 +162,10 @@ public:
         const Evaluation& a = params.a(phaseIdx); // "attractive factor"
         const Evaluation& b = params.b(phaseIdx); // "co-volume"
 
-        if (!std::isfinite(Opm::scalarValue(a))
-            || std::abs(Opm::scalarValue(a)) < 1e-30)
+        if (!std::isfinite(scalarValue(a))
+            || std::abs(scalarValue(a)) < 1e-30)
             return std::numeric_limits<Scalar>::quiet_NaN();
-        if (!std::isfinite(Opm::scalarValue(b)) || b <= 0)
+        if (!std::isfinite(scalarValue(b)) || b <= 0)
             return std::numeric_limits<Scalar>::quiet_NaN();
 
         const Evaluation& RT= R*T;
@@ -227,7 +227,7 @@ public:
         }
 
         Valgrind::CheckDefined(Vm);
-        assert(std::isfinite(Opm::scalarValue(Vm)));
+        assert(std::isfinite(scalarValue(Vm)));
         assert(Vm > 0);
         return Vm;
     }
@@ -258,8 +258,8 @@ public:
             (Vm + params.b()*(1 - std::sqrt(2)));
         const Evaluation& expo = - params.a()/(RT * 2 * params.b() * std::sqrt(2));
         const Evaluation& fugCoeff =
-            Opm::exp(Z - 1) / (Z - Bstar) *
-            Opm::pow(tmp, expo);
+            exp(Z - 1) / (Z - Bstar) *
+            pow(tmp, expo);
 
         return fugCoeff;
     }
@@ -297,9 +297,9 @@ protected:
         //Evaluation Vcrit = criticalMolarVolume_.eval(params.a(phaseIdx), params.b(phaseIdx));
 
         if (isGasPhase)
-            Vm = Opm::max(Vm, Vcrit);
+            Vm = max(Vm, Vcrit);
         else
-            Vm = Opm::min(Vm, Vcrit);
+            Vm = min(Vm, Vcrit);
     }
 
     template <class Evaluation>
@@ -349,14 +349,14 @@ protected:
             const Scalar eps = - 1e-11;
             bool hasExtrema OPM_OPTIM_UNUSED = findExtrema_(minVm, maxVm, minP, maxP, a, b, T + eps);
             assert(hasExtrema);
-            assert(std::isfinite(Opm::scalarValue(maxVm)));
+            assert(std::isfinite(scalarValue(maxVm)));
             Evaluation fStar = maxVm - minVm;
 
             // derivative of the difference between the maximum's
             // molar volume and the minimum's molar volume regarding
             // temperature
             Evaluation fPrime = (fStar - f)/eps;
-            if (std::abs(Opm::scalarValue(fPrime)) < 1e-40) {
+            if (std::abs(scalarValue(fPrime)) < 1e-40) {
                 Tcrit = T;
                 pcrit = (minP + maxP)/2;
                 Vcrit = (maxVm + minVm)/2;
@@ -365,7 +365,7 @@ protected:
 
             // update value for the current iteration
             Evaluation delta = f/fPrime;
-            assert(std::isfinite(Opm::scalarValue(delta)));
+            assert(std::isfinite(scalarValue(delta)));
             if (delta > 0)
                 delta = -10;
 
@@ -423,11 +423,11 @@ protected:
         const Evaluation& a4 = 2*RT*u*w*b*b*b + 2*u*a*b*b - 2*a*b*b;
         const Evaluation& a5 = RT*w*w*b*b*b*b - u*a*b*b*b;
 
-        assert(std::isfinite(Opm::scalarValue(a1)));
-        assert(std::isfinite(Opm::scalarValue(a2)));
-        assert(std::isfinite(Opm::scalarValue(a3)));
-        assert(std::isfinite(Opm::scalarValue(a4)));
-        assert(std::isfinite(Opm::scalarValue(a5)));
+        assert(std::isfinite(scalarValue(a1)));
+        assert(std::isfinite(scalarValue(a2)));
+        assert(std::isfinite(scalarValue(a3)));
+        assert(std::isfinite(scalarValue(a4)));
+        assert(std::isfinite(scalarValue(a5)));
 
         // Newton method to find first root
 
@@ -436,11 +436,11 @@ protected:
         // above the covolume
         Evaluation V = b*1.1;
         Evaluation delta = 1.0;
-        for (unsigned i = 0; std::abs(Opm::scalarValue(delta)) > 1e-12; ++i) {
+        for (unsigned i = 0; std::abs(scalarValue(delta)) > 1e-12; ++i) {
             const Evaluation& f = a5 + V*(a4 + V*(a3 + V*(a2 + V*a1)));
             const Evaluation& fPrime = a4 + V*(2*a3 + V*(3*a2 + V*4*a1));
 
-            if (std::abs(Opm::scalarValue(fPrime)) < 1e-20) {
+            if (std::abs(scalarValue(fPrime)) < 1e-20) {
                 // give up if the derivative is zero
                 return false;
             }
@@ -454,7 +454,7 @@ protected:
                 return false;
             }
         }
-        assert(std::isfinite(Opm::scalarValue(V)));
+        assert(std::isfinite(scalarValue(V)));
 
         // polynomial division
         Evaluation b1 = a1;
@@ -465,7 +465,7 @@ protected:
         // invert resulting cubic polynomial analytically
         Evaluation allV[4];
         allV[0] = V;
-        int numSol = 1 + Opm::invertCubicPolynomial<Evaluation>(allV + 1, b1, b2, b3, b4);
+        int numSol = 1 + invertCubicPolynomial<Evaluation>(allV + 1, b1, b2, b3, b4);
 
         // sort all roots of the derivative
         std::sort(allV + 0, allV + numSol);
@@ -505,9 +505,9 @@ protected:
         const Evaluation& tau = 1 - Tr;
         const Evaluation& omega = Component::acentricFactor();
 
-        const Evaluation& f0 = (tau*(-5.97616 + Opm::sqrt(tau)*(1.29874 - tau*0.60394)) - 1.06841*Opm::pow(tau, 5))/Tr;
-        const Evaluation& f1 = (tau*(-5.03365 + Opm::sqrt(tau)*(1.11505 - tau*5.41217)) - 7.46628*Opm::pow(tau, 5))/Tr;
-        const Evaluation& f2 = (tau*(-0.64771 + Opm::sqrt(tau)*(2.41539 - tau*4.26979)) + 3.25259*Opm::pow(tau, 5))/Tr;
+        const Evaluation& f0 = (tau*(-5.97616 + sqrt(tau)*(1.29874 - tau*0.60394)) - 1.06841*pow(tau, 5))/Tr;
+        const Evaluation& f1 = (tau*(-5.03365 + sqrt(tau)*(1.11505 - tau*5.41217)) - 7.46628*pow(tau, 5))/Tr;
+        const Evaluation& f2 = (tau*(-0.64771 + sqrt(tau)*(2.41539 - tau*4.26979)) + 3.25259*pow(tau, 5))/Tr;
 
         return Component::criticalPressure()*std::exp(f0 + omega * (f1 + omega*f2));
     }
@@ -538,7 +538,7 @@ protected:
 };
 
 template <class Scalar>
-const Scalar PengRobinson<Scalar>::R = Opm::Constants<Scalar>::R;
+const Scalar PengRobinson<Scalar>::R = Constants<Scalar>::R;
 
 /*
 template <class Scalar>

--- a/opm/material/eos/PengRobinsonMixture.hpp
+++ b/opm/material/eos/PengRobinsonMixture.hpp
@@ -42,7 +42,7 @@ template <class Scalar, class StaticParameters>
 class PengRobinsonMixture
 {
     enum { numComponents = StaticParameters::numComponents };
-    typedef Opm::PengRobinson<Scalar> PengRobinson;
+    typedef ::Opm::PengRobinson<Scalar> PengRobinson;
 
     // this class cannot be instantiated!
     PengRobinsonMixture() {}
@@ -114,13 +114,13 @@ public:
         LhsEval sumMoleFractions = 0.0;
         for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx)
             sumMoleFractions += fs.moleFraction(phaseIdx, compJIdx);
-        LhsEval deltai = 2*Opm::sqrt(params.aPure(phaseIdx, compIdx))/params.a(phaseIdx);
+        LhsEval deltai = 2*sqrt(params.aPure(phaseIdx, compIdx))/params.a(phaseIdx);
         LhsEval tmp = 0;
         for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
             tmp +=
                 fs.moleFraction(phaseIdx, compJIdx)
                 / sumMoleFractions
-                * Opm::sqrt(params.aPure(phaseIdx, compJIdx))
+                * sqrt(params.aPure(phaseIdx, compJIdx))
                 * (1.0 - StaticParameters::interactionCoefficient(compIdx, compJIdx));
         };
         deltai *= tmp;
@@ -131,8 +131,8 @@ public:
         LhsEval expo =  Astar/(Bstar*std::sqrt(u*u - 4*w))*(bi_b - deltai);
 
         LhsEval fugCoeff =
-            Opm::exp(bi_b*(Z - 1))/Opm::max(1e-9, Z - Bstar) *
-            Opm::pow(base, expo);
+            exp(bi_b*(Z - 1))/max(1e-9, Z - Bstar) *
+            pow(base, expo);
 
         ////////
         // limit the fugacity coefficient to a reasonable range:
@@ -140,12 +140,12 @@ public:
         // on one side, we want the mole fraction to be at
         // least 10^-3 if the fugacity is at the current pressure
         //
-        fugCoeff = Opm::min(1e10, fugCoeff);
+        fugCoeff = min(1e10, fugCoeff);
         //
         // on the other hand, if the mole fraction of the component is 100%, we want the
         // fugacity to be at least 10^-3 Pa
         //
-        fugCoeff = Opm::max(1e-10, fugCoeff);
+        fugCoeff = max(1e-10, fugCoeff);
         ///////////
 
         return fugCoeff;
@@ -154,7 +154,7 @@ public:
 };
 
 template <class Scalar, class StaticParameters>
-const Scalar PengRobinsonMixture<Scalar, StaticParameters>::R = Opm::Constants<Scalar>::R;
+const Scalar PengRobinsonMixture<Scalar, StaticParameters>::R = Constants<Scalar>::R;
 template<class Scalar, class StaticParameters>
 const Scalar PengRobinsonMixture<Scalar, StaticParameters>::u = 2.0;
 template<class Scalar, class StaticParameters>

--- a/opm/material/eos/PengRobinsonParamsMixture.hpp
+++ b/opm/material/eos/PengRobinsonParamsMixture.hpp
@@ -61,7 +61,7 @@ class PengRobinsonParamsMixture
     enum { numComponents = FluidSystem::numComponents };
 
     // Peng-Robinson parameters for pure substances
-    typedef Opm::PengRobinsonParams<Scalar> PureParams;
+    typedef PengRobinsonParams<Scalar> PureParams;
 
     typedef MathToolbox<Scalar> Toolbox;
 
@@ -111,13 +111,13 @@ public:
 
             Valgrind::CheckDefined(f_omega);
 
-            Scalar tmp = 1 + f_omega*(1 - Opm::sqrt(Tr));
+            Scalar tmp = 1 + f_omega*(1 - sqrt(Tr));
             tmp = tmp*tmp;
 
             Scalar newA = 0.4572355*RTc*RTc/pc * tmp;
             Scalar newB = 0.0777961 * RTc / pc;
-            assert(std::isfinite(Opm::scalarValue(newA)));
-            assert(std::isfinite(Opm::scalarValue(newB)));
+            assert(std::isfinite(scalarValue(newA)));
+            assert(std::isfinite(scalarValue(newB)));
 
             this->pureParams_[i].setA(newA);
             this->pureParams_[i].setB(newB);
@@ -151,23 +151,23 @@ public:
         Scalar newB = 0;
         for (unsigned compIIdx = 0; compIIdx < numComponents; ++compIIdx) {
             const Scalar moleFracI = fs.moleFraction(phaseIdx, compIIdx);
-            Scalar xi = Opm::max(0.0, Opm::min(1.0, moleFracI));
+            Scalar xi = max(0.0, min(1.0, moleFracI));
             Valgrind::CheckDefined(xi);
 
             for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
                 const Scalar moleFracJ = fs.moleFraction(phaseIdx, compJIdx );
-                Scalar xj = Opm::max(0.0, Opm::min(1.0, moleFracJ));
+                Scalar xj = max(0.0, min(1.0, moleFracJ));
                 Valgrind::CheckDefined(xj);
 
                 // mixing rule from Reid, page 82
                 newA +=  xi * xj * aCache_[compIIdx][compJIdx];
 
-                assert(std::isfinite(Opm::scalarValue(newA)));
+                assert(std::isfinite(scalarValue(newA)));
             }
 
             // mixing rule from Reid, page 82
-            newB += Opm::max(0.0, xi) * this->pureParams_[compIIdx].b();
-            assert(std::isfinite(Opm::scalarValue(newB)));
+            newB += max(0.0, xi) * this->pureParams_[compIIdx].b();
+            assert(std::isfinite(scalarValue(newB)));
         }
 
         // assert(newB > 0);
@@ -236,7 +236,7 @@ private:
                 Scalar Psi = FluidSystem::interactionCoefficient(compIIdx, compJIdx);
 
                 aCache_[compIIdx][compJIdx] =
-                    Opm::sqrt(this->pureParams_[compIIdx].a()
+                    sqrt(this->pureParams_[compIIdx].a()
                                   * this->pureParams_[compJIdx].a())
                     * (1 - Psi);
             }
@@ -247,7 +247,7 @@ private:
 };
 
 template <class Scalar, class FluidSystem, unsigned phaseIdx, bool useSpe5Relations>
-const Scalar PengRobinsonParamsMixture<Scalar, FluidSystem, phaseIdx, useSpe5Relations>::R = Opm::Constants<Scalar>::R;
+const Scalar PengRobinsonParamsMixture<Scalar, FluidSystem, phaseIdx, useSpe5Relations>::R = Constants<Scalar>::R;
 
 } // namespace Opm
 

--- a/opm/material/fluidmatrixinteractions/BrooksCorey.hpp
+++ b/opm/material/fluidmatrixinteractions/BrooksCorey.hpp
@@ -152,7 +152,7 @@ public:
     static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
         assert(0.0 <= Sw && Sw <= 1.0);
 
@@ -164,7 +164,7 @@ public:
     {
         assert(0.0 <= Sw && Sw <= 1.0);
 
-        return params.entryPressure()*Opm::pow(Sw, -1/params.lambda());
+        return params.entryPressure()*pow(Sw, -1/params.lambda());
     }
 
     template <class Evaluation>
@@ -172,7 +172,7 @@ public:
     {
         assert(pcnw > 0.0);
 
-        return Opm::pow(params.entryPressure()/pcnw, -params.lambda());
+        return pow(params.entryPressure()/pcnw, -params.lambda());
     }
 
     /*!
@@ -191,8 +191,8 @@ public:
     static Evaluation Sw(const Params& params, const FluidState& fs)
     {
         Evaluation pC =
-            Opm::decay<Evaluation>(fs.pressure(Traits::nonWettingPhaseIdx))
-            - Opm::decay<Evaluation>(fs.pressure(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.pressure(Traits::nonWettingPhaseIdx))
+            - decay<Evaluation>(fs.pressure(Traits::wettingPhaseIdx));
         return twoPhaseSatSw(params, pC);
     }
 
@@ -201,7 +201,7 @@ public:
     {
         assert(pc > 0.0); // if we don't assume that, std::pow will screw up!
 
-        return Opm::pow(pc/params.entryPressure(), -params.lambda());
+        return pow(pc/params.entryPressure(), -params.lambda());
     }
 
     /*!
@@ -227,7 +227,7 @@ public:
     static Evaluation krw(const Params& params, const FluidState& fs)
     {
         const auto& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
         return twoPhaseSatKrw(params, Sw);
     }
@@ -237,13 +237,13 @@ public:
     {
         assert(0.0 <= Sw && Sw <= 1.0);
 
-        return Opm::pow(Sw, 2.0/params.lambda() + 3.0);
+        return pow(Sw, 2.0/params.lambda() + 3.0);
     }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatKrwInv(const Params& params, const Evaluation& krw)
     {
-        return Opm::pow(krw, 1.0/(2.0/params.lambda() + 3.0));
+        return pow(krw, 1.0/(2.0/params.lambda() + 3.0));
     }
 
     /*!
@@ -258,7 +258,7 @@ public:
     static Evaluation krn(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            1.0 - Opm::decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
+            1.0 - decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
 
         return twoPhaseSatKrn(params, Sw);
     }
@@ -270,7 +270,7 @@ public:
 
         Scalar exponent = 2.0/params.lambda() + 1.0;
         const Evaluation Sn = 1.0 - Sw;
-        return Sn*Sn*(1. - Opm::pow(Sw, exponent));
+        return Sn*Sn*(1. - pow(Sw, exponent));
     }
 
     template <class Evaluation>
@@ -289,7 +289,7 @@ public:
             Sw -= delta;
             if (Sw < 0)
                 Sw = 0.0;
-            if (Opm::abs(delta) < 1e-10)
+            if (abs(delta) < 1e-10)
                 return Sw;
         }
 

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -227,7 +227,7 @@ public:
                            const FluidState& fs)
     {
         // Maximum attainable oil saturation is 1-SWL.
-        const auto Sw = 1.0 - params.Swl() - Opm::decay<Evaluation>(fs.saturation(gasPhaseIdx));
+        const auto Sw = 1.0 - params.Swl() - decay<Evaluation>(fs.saturation(gasPhaseIdx));
         return GasOilMaterialLaw::twoPhaseSatPcnw(params.gasOilParams(), Sw);
     }
 
@@ -244,7 +244,7 @@ public:
     static Evaluation pcnw(const Params& params,
                            const FluidState& fs)
     {
-        const auto Sw = Opm::decay<Evaluation>(fs.saturation(waterPhaseIdx));
+        const auto Sw = decay<Evaluation>(fs.saturation(waterPhaseIdx));
         return OilWaterMaterialLaw::twoPhaseSatPcnw(params.oilWaterParams(), Sw);
     }
 
@@ -324,7 +324,7 @@ public:
                           const FluidState& fluidState)
     {
         // Maximum attainable oil saturation is 1-SWL.
-        const Evaluation Sw = 1.0 - params.Swl() - Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation Sw = 1.0 - params.Swl() - decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
         return GasOilMaterialLaw::twoPhaseSatKrn(params.gasOilParams(), Sw);
     }
 
@@ -335,7 +335,7 @@ public:
     static Evaluation krw(const Params& params,
                           const FluidState& fluidState)
     {
-        const Evaluation Sw = Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+        const Evaluation Sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
         return OilWaterMaterialLaw::twoPhaseSatKrw(params.oilWaterParams(), Sw);
     }
 
@@ -349,10 +349,10 @@ public:
         const Scalar Swco = params.Swl();
 
         const Evaluation Sw =
-            Opm::max(Evaluation(Swco),
-                     Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
+            max(Evaluation(Swco),
+                     decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
 
-        const Evaluation Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
 
         const Evaluation Sw_ow = Sg + Sw;
         const Evaluation kro_ow = relpermOilInOilWaterSystem<Evaluation>(params, fluidState);
@@ -362,9 +362,9 @@ public:
         // < epsilon/2 and interpolate between the oridinary and the regularized kro between
         // epsilon and epsilon/2
         const Scalar epsilon = 1e-5;
-        if (Opm::scalarValue(Sw_ow) - Swco < epsilon) {
+        if (scalarValue(Sw_ow) - Swco < epsilon) {
             const Evaluation kro2 = (kro_ow + kro_go)/2;
-            if (Opm::scalarValue(Sw_ow) - Swco > epsilon/2) {
+            if (scalarValue(Sw_ow) - Swco > epsilon/2) {
                 const Evaluation kro1 = (Sg*kro_go + (Sw - Swco)*kro_ow)/(Sw_ow - Swco);
                 const Evaluation alpha = (epsilon - (Sw_ow - Swco))/(epsilon/2);
 
@@ -385,10 +385,10 @@ public:
                                                const FluidState& fluidState)
     {
         const Evaluation Sw =
-            Opm::max(Evaluation{ params.Swl() },
-                     Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
+            max(Evaluation{ params.Swl() },
+                     decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
 
-        const Evaluation Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
         const Evaluation So_go = 1.0 - (Sg + Sw);
 
         return GasOilMaterialLaw::twoPhaseSatKrw(params.gasOilParams(), So_go);
@@ -402,10 +402,10 @@ public:
                                                  const FluidState& fluidState)
     {
         const Evaluation Sw =
-            Opm::max(Evaluation{ params.Swl() },
-                     Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
+            max(Evaluation{ params.Swl() },
+                     decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
 
-        const Evaluation Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
         const Evaluation Sw_ow = Sg + Sw;
 
         return OilWaterMaterialLaw::twoPhaseSatKrn(params.oilWaterParams(), Sw_ow);
@@ -462,7 +462,7 @@ public:
     template <class FluidState>
     static Scalar clampSaturation(const FluidState& fluidState, const int phaseIndex)
     {
-        const auto sat = Opm::scalarValue(fluidState.saturation(phaseIndex));
+        const auto sat = scalarValue(fluidState.saturation(phaseIndex));
         return std::clamp(sat, Scalar{0.0}, Scalar{1.0});
     }
 };

--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -189,8 +189,8 @@ public:
      *
      * This requires that the opm-parser module is available.
      */
-    void initFromState(const Opm::EclipseState& eclState,
-                       Opm::EclTwoPhaseSystemType twoPhaseSystemType,
+    void initFromState(const EclipseState& eclState,
+                       EclTwoPhaseSystemType twoPhaseSystemType,
                        const std::string& prefix = "",
                        const std::string& suffix = "")
     {
@@ -215,11 +215,11 @@ public:
         if (eclState.getTableManager().useJFunc()) {
             const auto flag = eclState.getTableManager().getJFunc().flag();
 
-            enableLeverettScaling_ = (flag == Opm::JFunc::Flag::BOTH)
+            enableLeverettScaling_ = (flag == JFunc::Flag::BOTH)
                 || ((twoPhaseSystemType == EclOilWaterSystem) &&
-                    (flag == Opm::JFunc::Flag::WATER))
+                    (flag == JFunc::Flag::WATER))
                 || ((twoPhaseSystemType == EclGasOilSystem) &&
-                    (flag == Opm::JFunc::Flag::GAS));
+                    (flag == JFunc::Flag::GAS));
         }
 
         const auto& fp = eclState.fieldProps();

--- a/opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
@@ -78,7 +78,7 @@ class EclEpsGridProperties
 public:
 #if HAVE_ECL_INPUT
 
-    EclEpsGridProperties(const Opm::EclipseState& eclState,
+    EclEpsGridProperties(const EclipseState& eclState,
                          bool useImbibition)
     {
         const std::string kwPrefix = useImbibition ? "I" : "";

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -150,8 +150,8 @@ struct EclEpsScalingPointsInfo
      * I.e., the values which are used for the nested Fluid-Matrix interactions and which
      * are produced by them.
      */
-    void extractUnscaled(const Opm::satfunc::RawTableEndPoints& rtep,
-                         const Opm::satfunc::RawFunctionValues& rfunc,
+    void extractUnscaled(const satfunc::RawTableEndPoints& rtep,
+                         const satfunc::RawFunctionValues& rfunc,
                          const std::vector<double>::size_type   satRegionIdx)
     {
         this->Swl = rtep.connate.water[satRegionIdx];
@@ -193,7 +193,7 @@ struct EclEpsScalingPointsInfo
      *
      * I.e., the values which are "seen" by the physical model.
      */
-    void extractScaled(const Opm::EclipseState& eclState,
+    void extractScaled(const EclipseState& eclState,
                        const EclEpsGridProperties& epsProperties,
                        unsigned activeIndex)
     {
@@ -231,13 +231,13 @@ struct EclEpsScalingPointsInfo
             const auto& jfuncDir = jfunc.direction();
 
             Scalar perm;
-            if (jfuncDir == Opm::JFunc::Direction::X)
+            if (jfuncDir == JFunc::Direction::X)
                 perm = epsProperties.permx(activeIndex);
-            else if (jfuncDir == Opm::JFunc::Direction::Y)
+            else if (jfuncDir == JFunc::Direction::Y)
                 perm = epsProperties.permy(activeIndex);
-            else if (jfuncDir == Opm::JFunc::Direction::Z)
+            else if (jfuncDir == JFunc::Direction::Z)
                 perm = epsProperties.permz(activeIndex);
-            else if (jfuncDir == Opm::JFunc::Direction::XY)
+            else if (jfuncDir == JFunc::Direction::XY)
                 // TODO: verify that this really is the arithmetic mean. (the
                 // documentation just says that the "average" should be used, IMO the
                 // harmonic mean would be more appropriate because that's what's usually
@@ -245,7 +245,7 @@ struct EclEpsScalingPointsInfo
             {
                 double permx = epsProperties.permx(activeIndex);
                 double permy = epsProperties.permy(activeIndex);
-                perm = Opm::arithmeticMean(permx, permy);
+                perm = arithmeticMean(permx, permy);
             } else
                 throw std::runtime_error("Illegal direction indicator for the JFUNC "
                                          "keyword ("+std::to_string(int(jfuncDir))+")");
@@ -267,7 +267,7 @@ struct EclEpsScalingPointsInfo
 
             // compute the oil-water Leverett factor.
             const auto& jfuncFlag = jfunc.flag();
-            if (jfuncFlag == Opm::JFunc::Flag::WATER || jfuncFlag == Opm::JFunc::Flag::BOTH) {
+            if (jfuncFlag == JFunc::Flag::WATER || jfuncFlag == JFunc::Flag::BOTH) {
                 // note that we use the surface tension in terms of [dyn/cm]
                 Scalar gamma =
                     jfunc.owSurfaceTension();
@@ -275,7 +275,7 @@ struct EclEpsScalingPointsInfo
             }
 
             // compute the gas-oil Leverett factor.
-            if (jfuncFlag == Opm::JFunc::Flag::GAS || jfuncFlag == Opm::JFunc::Flag::BOTH) {
+            if (jfuncFlag == JFunc::Flag::GAS || jfuncFlag == JFunc::Flag::BOTH) {
                 // note that we use the surface tension in terms of [dyn/cm]
                 Scalar gamma =
                     jfunc.goSurfaceTension();

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
@@ -57,7 +57,7 @@ class EclEpsTwoPhaseLawParams : public EnsureFinalized
 
 public:
     typedef typename EffLawParams::Traits Traits;
-    typedef Opm::EclEpsScalingPoints<Scalar> ScalingPoints;
+    typedef EclEpsScalingPoints<Scalar> ScalingPoints;
 
     EclEpsTwoPhaseLawParams()
     {

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -111,7 +111,7 @@ public:
      *
      * This requires that the opm-parser module is available.
      */
-    void initFromState(const Opm::Runspec& runspec)
+    void initFromState(const Runspec& runspec)
     {
         enableHysteresis_ = false;
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -130,7 +130,7 @@ public:
     EclMaterialLawManager()
     {}
 
-    void initFromState(const Opm::EclipseState& eclState)
+    void initFromState(const EclipseState& eclState)
     {
         // get the number of saturation regions and the number of cells in the deck
         const auto&  runspec       = eclState.runspec();
@@ -146,12 +146,12 @@ public:
         readGlobalThreePhaseOptions_(runspec);
 
         // Read the end point scaling configuration (once per run).
-        gasOilConfig = std::make_shared<Opm::EclEpsConfig>();
-        oilWaterConfig = std::make_shared<Opm::EclEpsConfig>();
-        gasWaterConfig = std::make_shared<Opm::EclEpsConfig>();
-        gasOilConfig->initFromState(eclState, Opm::EclGasOilSystem);
-        oilWaterConfig->initFromState(eclState, Opm::EclOilWaterSystem);
-        gasWaterConfig->initFromState(eclState, Opm::EclGasWaterSystem);
+        gasOilConfig = std::make_shared<EclEpsConfig>();
+        oilWaterConfig = std::make_shared<EclEpsConfig>();
+        gasWaterConfig = std::make_shared<EclEpsConfig>();
+        gasOilConfig->initFromState(eclState, EclGasOilSystem);
+        oilWaterConfig->initFromState(eclState, EclOilWaterSystem);
+        gasWaterConfig->initFromState(eclState, EclGasWaterSystem);
 
 
         const auto& tables = eclState.getTableManager();
@@ -477,18 +477,18 @@ public:
                 Sw = elemScaledEpsInfo.Swl;
 
             // specify a fluid state which only stores the saturations
-            typedef Opm::SimpleModularFluidState<Scalar,
-                                                 numPhases,
-                                                 /*numComponents=*/0,
-                                                 /*FluidSystem=*/void, /* -> don't care */
-                                                 /*storePressure=*/false,
-                                                 /*storeTemperature=*/false,
-                                                 /*storeComposition=*/false,
-                                                 /*storeFugacity=*/false,
-                                                 /*storeSaturation=*/true,
-                                                 /*storeDensity=*/false,
-                                                 /*storeViscosity=*/false,
-                                                 /*storeEnthalpy=*/false> FluidState;
+            typedef SimpleModularFluidState<Scalar,
+                                            numPhases,
+                                            /*numComponents=*/0,
+                                            /*FluidSystem=*/void, /* -> don't care */
+                                            /*storePressure=*/false,
+                                            /*storeTemperature=*/false,
+                                            /*storeComposition=*/false,
+                                            /*storeFugacity=*/false,
+                                            /*storeSaturation=*/true,
+                                            /*storeDensity=*/false,
+                                            /*storeViscosity=*/false,
+                                            /*storeEnthalpy=*/false> FluidState;
             FluidState fs;
             fs.setSaturation(waterPhaseIdx, Sw);
             fs.setSaturation(gasPhaseIdx, 0);
@@ -502,7 +502,7 @@ public:
             if (std::abs(pcowAtSw) > pcowAtSwThreshold) {
                 elemScaledEpsInfo.maxPcow *= pcow/pcowAtSw;
                 auto& elemEclEpsScalingPoints = oilWaterScaledEpsPointsDrainage(elemIdx);
-                elemEclEpsScalingPoints.init(elemScaledEpsInfo, *oilWaterEclEpsConfig_, Opm::EclOilWaterSystem);
+                elemEclEpsScalingPoints.init(elemScaledEpsInfo, *oilWaterEclEpsConfig_, EclOilWaterSystem);
             }
         }
 
@@ -710,28 +710,28 @@ public:
         }
     }
 
-    const Opm::EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(size_t elemIdx) const
+    const EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(size_t elemIdx) const
     { return *oilWaterScaledEpsInfoDrainage_[elemIdx]; }
 
     std::shared_ptr<EclEpsScalingPointsInfo<Scalar> >& oilWaterScaledEpsInfoDrainagePointerReferenceHack(unsigned elemIdx)
     { return oilWaterScaledEpsInfoDrainage_[elemIdx]; }
 
 private:
-    void readGlobalEpsOptions_(const Opm::EclipseState& eclState)
+    void readGlobalEpsOptions_(const EclipseState& eclState)
     {
-        oilWaterEclEpsConfig_ = std::make_shared<Opm::EclEpsConfig>();
-        oilWaterEclEpsConfig_->initFromState(eclState, Opm::EclOilWaterSystem);
+        oilWaterEclEpsConfig_ = std::make_shared<EclEpsConfig>();
+        oilWaterEclEpsConfig_->initFromState(eclState, EclOilWaterSystem);
 
         enableEndPointScaling_ = eclState.getTableManager().hasTables("ENKRVD");
     }
 
-    void readGlobalHysteresisOptions_(const Opm::EclipseState& state)
+    void readGlobalHysteresisOptions_(const EclipseState& state)
     {
-        hysteresisConfig_ = std::make_shared<Opm::EclHysteresisConfig>();
+        hysteresisConfig_ = std::make_shared<EclHysteresisConfig>();
         hysteresisConfig_->initFromState(state.runspec());
     }
 
-    void readGlobalThreePhaseOptions_(const Opm::Runspec& runspec)
+    void readGlobalThreePhaseOptions_(const Runspec& runspec)
     {
         bool gasEnabled = runspec.phases().active(Phase::GAS);
         bool oilEnabled = runspec.phases().active(Phase::OIL);
@@ -769,7 +769,7 @@ private:
 
     template <class Container>
     void readGasOilEffectiveParameters_(Container& dest,
-                                        const Opm::EclipseState& eclState,
+                                        const EclipseState& eclState,
                                         unsigned satRegionIdx)
     {
         if (!hasGas || !hasOil)
@@ -825,7 +825,7 @@ private:
     void readGasOilEffectiveParametersSgof_(GasOilEffectiveTwoPhaseParams& effParams,
                                             const Scalar Swco,
                                             const double tolcrit,
-                                            const Opm::SgofTable& sgofTable)
+                                            const SgofTable& sgofTable)
     {
         // convert the saturations of the SGOF keyword from gas to oil saturations
         std::vector<double> SoSamples(sgofTable.numRows());
@@ -842,7 +842,7 @@ private:
     void readGasOilEffectiveParametersSlgof_(GasOilEffectiveTwoPhaseParams& effParams,
                                              const Scalar Swco,
                                              const double tolcrit,
-                                             const Opm::SlgofTable& slgofTable)
+                                             const SlgofTable& slgofTable)
     {
         // convert the saturations of the SLGOF keyword from "liquid" to oil saturations
         std::vector<double> SoSamples(slgofTable.numRows());
@@ -859,8 +859,8 @@ private:
     void readGasOilEffectiveParametersFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
                                                const Scalar Swco,
                                                const double tolcrit,
-                                               const Opm::Sof3Table& sof3Table,
-                                               const Opm::SgfnTable& sgfnTable)
+                                               const Sof3Table& sof3Table,
+                                               const SgfnTable& sgfnTable)
     {
         // convert the saturations of the SGFN keyword from gas to oil saturations
         std::vector<double> SoSamples(sgfnTable.numRows());
@@ -878,8 +878,8 @@ private:
     void readGasOilEffectiveParametersFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
                                                const Scalar Swco,
                                                const double tolcrit,
-                                               const Opm::Sof2Table& sof2Table,
-                                               const Opm::SgfnTable& sgfnTable)
+                                               const Sof2Table& sof2Table,
+                                               const SgfnTable& sgfnTable)
     {
         // convert the saturations of the SGFN keyword from gas to oil saturations
         std::vector<double> SoSamples(sgfnTable.numRows());
@@ -896,7 +896,7 @@ private:
 
     template <class Container>
     void readOilWaterEffectiveParameters_(Container& dest,
-                                          const Opm::EclipseState& eclState,
+                                          const EclipseState& eclState,
                                           unsigned satRegionIdx)
     {
         if (!hasOil || !hasWater)
@@ -949,7 +949,7 @@ private:
 
     template <class Container>
     void readGasWaterEffectiveParameters_(Container& dest,
-                                        const Opm::EclipseState& eclState,
+                                        const EclipseState& eclState,
                                         unsigned satRegionIdx)
     {
         if (!hasGas || !hasWater || hasOil)
@@ -997,7 +997,7 @@ private:
     template <class Container>
     void readGasOilUnscaledPoints_(Container& dest,
                                    std::shared_ptr<EclEpsConfig> config,
-                                   const Opm::EclipseState& /* eclState */,
+                                   const EclipseState& /* eclState */,
                                    unsigned satRegionIdx)
     {
         if (!hasGas || !hasOil)
@@ -1011,7 +1011,7 @@ private:
     template <class Container>
     void readOilWaterUnscaledPoints_(Container& dest,
                                      std::shared_ptr<EclEpsConfig> config,
-                                     const Opm::EclipseState& /* eclState */,
+                                     const EclipseState& /* eclState */,
                                      unsigned satRegionIdx)
     {
         if (!hasOil || !hasWater)
@@ -1025,7 +1025,7 @@ private:
     template <class Container>
     void readGasWaterUnscaledPoints_(Container& dest,
                                      std::shared_ptr<EclEpsConfig> config,
-                                     const Opm::EclipseState& /* eclState */,
+                                     const EclipseState& /* eclState */,
                                      unsigned satRegionIdx)
     {
         if (hasOil)
@@ -1040,7 +1040,7 @@ private:
     void readGasOilScaledPoints_(InfoContainer& destInfo,
                                  PointsContainer& destPoints,
                                  std::shared_ptr<EclEpsConfig> config,
-                                 const Opm::EclipseState& eclState,
+                                 const EclipseState& eclState,
                                  const EclEpsGridProperties& epsGridProperties,
                                  unsigned elemIdx)
     {
@@ -1057,7 +1057,7 @@ private:
     void readOilWaterScaledPoints_(InfoContainer& destInfo,
                                    PointsContainer& destPoints,
                                    std::shared_ptr<EclEpsConfig> config,
-                                   const Opm::EclipseState& eclState,
+                                   const EclipseState& eclState,
                                    const EclEpsGridProperties& epsGridProperties,
                                    unsigned elemIdx)
     {
@@ -1074,7 +1074,7 @@ private:
     void readGasWaterScaledPoints_(InfoContainer& destInfo,
                                    PointsContainer& destPoints,
                                    std::shared_ptr<EclEpsConfig> config,
-                                   const Opm::EclipseState& eclState,
+                                   const EclipseState& eclState,
                                    const EclEpsGridProperties& epsGridProperties,
                                    unsigned elemIdx)
     {
@@ -1087,7 +1087,7 @@ private:
         destPoints[elemIdx]->init(*destInfo[elemIdx], *config, EclGasWaterSystem);
     }
 
-    void initThreePhaseParams_(const Opm::EclipseState& /* eclState */,
+    void initThreePhaseParams_(const EclipseState& /* eclState */,
                                MaterialLawParams& materialParams,
                                unsigned satRegionIdx,
                                const EclEpsScalingPointsInfo<Scalar>& epsInfo,
@@ -1166,7 +1166,7 @@ private:
     std::shared_ptr<EclHysteresisConfig> hysteresisConfig_;
 
     std::shared_ptr<EclEpsConfig> oilWaterEclEpsConfig_;
-    std::vector<Opm::EclEpsScalingPointsInfo<Scalar>> unscaledEpsInfo_;
+    std::vector<EclEpsScalingPointsInfo<Scalar>> unscaledEpsInfo_;
     OilWaterScalingInfoVector oilWaterScaledEpsInfoDrainage_;
 
     std::shared_ptr<EclEpsConfig> gasWaterEclEpsConfig_;
@@ -1180,7 +1180,7 @@ private:
     OilWaterEffectiveParamVector oilWaterEffectiveParamVector_;
     GasWaterEffectiveParamVector gasWaterEffectiveParamVector_;
 
-    Opm::EclMultiplexerApproach threePhaseApproach_ = EclMultiplexerApproach::EclDefaultApproach;
+    EclMultiplexerApproach threePhaseApproach_ = EclMultiplexerApproach::EclDefaultApproach;
     // this attribute only makes sense for twophase simulations!
     enum EclTwoPhaseApproach twoPhaseApproach_ = EclTwoPhaseApproach::EclTwoPhaseGasOil;
 
@@ -1194,9 +1194,9 @@ private:
     bool hasOil;
     bool hasWater;
 
-    std::shared_ptr<Opm::EclEpsConfig> gasOilConfig;
-    std::shared_ptr<Opm::EclEpsConfig> oilWaterConfig;
-    std::shared_ptr<Opm::EclEpsConfig> gasWaterConfig;
+    std::shared_ptr<EclEpsConfig> gasOilConfig;
+    std::shared_ptr<EclEpsConfig> oilWaterConfig;
+    std::shared_ptr<EclEpsConfig> gasWaterConfig;
 };
 } // namespace Opm
 

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -61,10 +61,10 @@ public:
     typedef OilWaterMaterialLawT OilWaterMaterialLaw;
     typedef GasWaterMaterialLawT GasWaterMaterialLaw;
 
-    typedef Opm::EclStone1Material<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw> Stone1Material;
-    typedef Opm::EclStone2Material<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw> Stone2Material;
-    typedef Opm::EclDefaultMaterial<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw> DefaultMaterial;
-    typedef Opm::EclTwoPhaseMaterial<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw, GasWaterMaterialLaw> TwoPhaseMaterial;
+    typedef EclStone1Material<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw> Stone1Material;
+    typedef EclStone2Material<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw> Stone2Material;
+    typedef EclDefaultMaterial<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw> DefaultMaterial;
+    typedef EclTwoPhaseMaterial<TraitsT, GasOilMaterialLaw, OilWaterMaterialLaw, GasWaterMaterialLaw> TwoPhaseMaterial;
 
     // some safety checks
     static_assert(TraitsT::numPhases == 3,

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -61,10 +61,10 @@ class EclMultiplexerMaterialParams : public Traits, public EnsureFinalized
     typedef typename Traits::Scalar Scalar;
     enum { numPhases = 3 };
 
-    typedef Opm::EclStone1Material<Traits, GasOilMaterialLawT, OilWaterMaterialLawT> Stone1Material;
-    typedef Opm::EclStone2Material<Traits, GasOilMaterialLawT, OilWaterMaterialLawT> Stone2Material;
-    typedef Opm::EclDefaultMaterial<Traits, GasOilMaterialLawT, OilWaterMaterialLawT> DefaultMaterial;
-    typedef Opm::EclTwoPhaseMaterial<Traits, GasOilMaterialLawT, OilWaterMaterialLawT, GasWaterMaterialLawT> TwoPhaseMaterial;
+    typedef EclStone1Material<Traits, GasOilMaterialLawT, OilWaterMaterialLawT> Stone1Material;
+    typedef EclStone2Material<Traits, GasOilMaterialLawT, OilWaterMaterialLawT> Stone2Material;
+    typedef EclDefaultMaterial<Traits, GasOilMaterialLawT, OilWaterMaterialLawT> DefaultMaterial;
+    typedef EclTwoPhaseMaterial<Traits, GasOilMaterialLawT, OilWaterMaterialLawT, GasWaterMaterialLawT> TwoPhaseMaterial;
 
     typedef typename Stone1Material::Params Stone1Params;
     typedef typename Stone2Material::Params Stone2Params;

--- a/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
@@ -227,7 +227,7 @@ public:
                            const FluidState& fs)
     {
         // Maximum attainable oil saturation is 1-SWL
-        const auto Sw = 1.0 - params.Swl() - Opm::decay<Evaluation>(fs.saturation(gasPhaseIdx));
+        const auto Sw = 1.0 - params.Swl() - decay<Evaluation>(fs.saturation(gasPhaseIdx));
         return GasOilMaterialLaw::twoPhaseSatPcnw(params.gasOilParams(), Sw);
     }
 
@@ -244,7 +244,7 @@ public:
     static Evaluation pcnw(const Params& params,
                            const FluidState& fs)
     {
-        const auto Sw = Opm::decay<Evaluation>(fs.saturation(waterPhaseIdx));
+        const auto Sw = decay<Evaluation>(fs.saturation(waterPhaseIdx));
         Valgrind::CheckDefined(Sw);
 
         const auto result = OilWaterMaterialLaw::twoPhaseSatPcnw(params.oilWaterParams(), Sw);
@@ -329,7 +329,7 @@ public:
                           const FluidState& fluidState)
     {
         // Maximum attainable oil saturation is 1-SWL,
-        const Evaluation Sw = 1 - params.Swl() - Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation Sw = 1 - params.Swl() - decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
         return GasOilMaterialLaw::twoPhaseSatKrn(params.gasOilParams(), Sw);
     }
 
@@ -340,7 +340,7 @@ public:
     static Evaluation krw(const Params& params,
                           const FluidState& fluidState)
     {
-        const Evaluation Sw = Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+        const Evaluation Sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
         return OilWaterMaterialLaw::twoPhaseSatKrw(params.oilWaterParams(), Sw);
     }
 
@@ -359,8 +359,8 @@ public:
         // oil relperm at connate water saturations (with Sg=0)
         const Scalar krocw = params.krocw();
 
-        const Evaluation Sw = Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
-        const Evaluation Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation Sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
 
         const Evaluation kro_ow = relpermOilInOilWaterSystem<Evaluation>(params, fluidState);
         const Evaluation kro_go = relpermOilInOilGasSystem<Evaluation>(params, fluidState);
@@ -379,10 +379,10 @@ public:
             if (SSw >= 1.0 || SSg >= 1.0)
                 beta = 1.0;
             else
-                beta = Opm::pow( SSo/((1 - SSw)*(1 - SSg)), params.eta());
+                beta = pow( SSo/((1 - SSw)*(1 - SSg)), params.eta());
         }
 
-        return Opm::max(0.0, Opm::min(1.0, beta*kro_ow*kro_go/krocw));
+        return max(0.0, min(1.0, beta*kro_ow*kro_go/krocw));
     }
 
     /*!
@@ -392,7 +392,7 @@ public:
     static Evaluation relpermOilInOilGasSystem(const Params& params,
                                                const FluidState& fluidState)
     {
-        const Evaluation Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
 
         return GasOilMaterialLaw::twoPhaseSatKrw(params.gasOilParams(), 1 - Sg - params.Swl());
     }
@@ -404,7 +404,7 @@ public:
     static Evaluation relpermOilInOilWaterSystem(const Params& params,
                                                  const FluidState& fluidState)
     {
-        const Evaluation Sw = Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+        const Evaluation Sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
 
         return OilWaterMaterialLaw::twoPhaseSatKrn(params.oilWaterParams(), Sw);
     }
@@ -420,8 +420,8 @@ public:
     static void updateHysteresis(Params& params, const FluidState& fluidState)
     {
         const Scalar Swco = params.Swl();
-        const Scalar Sw = Opm::scalarValue(fluidState.saturation(waterPhaseIdx));
-        const Scalar Sg = Opm::scalarValue(fluidState.saturation(gasPhaseIdx));
+        const Scalar Sw = scalarValue(fluidState.saturation(waterPhaseIdx));
+        const Scalar Sg = scalarValue(fluidState.saturation(gasPhaseIdx));
 
         params.oilWaterParams().update(/*pcSw=*/Sw, /*krwSw=*/Sw, /*krnSw=*/Sw);
         params.gasOilParams().update(/*pcSw=*/  1.0 - Swco - Sg,

--- a/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
@@ -228,7 +228,7 @@ public:
                            const FluidState& fs)
     {
         // Maximum attainable oil saturation is 1-SWL.
-        const auto Sw = 1.0 - params.Swl() - Opm::decay<Evaluation>(fs.saturation(gasPhaseIdx));
+        const auto Sw = 1.0 - params.Swl() - decay<Evaluation>(fs.saturation(gasPhaseIdx));
         return GasOilMaterialLaw::twoPhaseSatPcnw(params.gasOilParams(), Sw);
     }
 
@@ -245,7 +245,7 @@ public:
     static Evaluation pcnw(const Params& params,
                            const FluidState& fs)
     {
-        const auto Sw = Opm::decay<Evaluation>(fs.saturation(waterPhaseIdx));
+        const auto Sw = decay<Evaluation>(fs.saturation(waterPhaseIdx));
         Valgrind::CheckDefined(Sw);
 
         const auto result = OilWaterMaterialLaw::twoPhaseSatPcnw(params.oilWaterParams(), Sw);
@@ -330,7 +330,7 @@ public:
                           const FluidState& fluidState)
     {
         // Maximum attainable oil saturation is 1-SWL.
-        const Evaluation Sw = 1 - params.Swl() - Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation Sw = 1 - params.Swl() - decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
         return GasOilMaterialLaw::twoPhaseSatKrn(params.gasOilParams(), Sw);
     }
 
@@ -341,7 +341,7 @@ public:
     static Evaluation krw(const Params& params,
                           const FluidState& fluidState)
     {
-        const Evaluation Sw = Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+        const Evaluation Sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
         return OilWaterMaterialLaw::twoPhaseSatKrw(params.oilWaterParams(), Sw);
     }
 
@@ -354,8 +354,8 @@ public:
     {
         const Scalar Swco = params.Swl();
 
-        const Evaluation Sw = Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
-        const Evaluation Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation Sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
 
         const Scalar krocw = OilWaterMaterialLaw::twoPhaseSatKrn(params.oilWaterParams(), Swco);
         const Evaluation krow = relpermOilInOilWaterSystem<Evaluation>(params, fluidState);
@@ -363,7 +363,7 @@ public:
         const Evaluation krg = GasOilMaterialLaw::twoPhaseSatKrn(params.gasOilParams(), 1 - Swco - Sg);
         const Evaluation krog = relpermOilInOilGasSystem<Evaluation>(params, fluidState);
 
-        return Opm::max(krocw * ((krow/krocw + krw) * (krog/krocw + krg) - krw - krg), Evaluation{0});
+        return max(krocw * ((krow/krocw + krw) * (krog/krocw + krg) - krw - krg), Evaluation{0});
     }
 
 
@@ -375,7 +375,7 @@ public:
                                                const FluidState& fluidState)
     {
         const Scalar Swco = params.Swl();
-        const Evaluation Sg = Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
 
         return GasOilMaterialLaw::twoPhaseSatKrw(params.gasOilParams(), 1 - Swco - Sg);
     }
@@ -388,7 +388,7 @@ public:
     static Evaluation relpermOilInOilWaterSystem(const Params& params,
                                                  const FluidState& fluidState)
     {
-        const Evaluation Sw = Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+        const Evaluation Sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
 
         return OilWaterMaterialLaw::twoPhaseSatKrn(params.oilWaterParams(), Sw);
     }
@@ -404,8 +404,8 @@ public:
     static void updateHysteresis(Params& params, const FluidState& fluidState)
     {
         const Scalar Swco = params.Swl();
-        const Scalar Sw = Opm::scalarValue(fluidState.saturation(waterPhaseIdx));
-        const Scalar Sg = Opm::scalarValue(fluidState.saturation(gasPhaseIdx));
+        const Scalar Sw = scalarValue(fluidState.saturation(waterPhaseIdx));
+        const Scalar Sg = scalarValue(fluidState.saturation(gasPhaseIdx));
 
         params.oilWaterParams().update(/*pcSw=*/Sw, /*krwSw=*/Sw, /*krnSw=*/Sw);
         params.gasOilParams().update(/*pcSw=*/  1.0 - Swco - Sg,

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -135,7 +135,7 @@ public:
         switch (params.approach()) {
         case EclTwoPhaseApproach::EclTwoPhaseGasOil: {
             const Evaluation& So =
-                Opm::decay<Evaluation>(fluidState.saturation(oilPhaseIdx));
+                decay<Evaluation>(fluidState.saturation(oilPhaseIdx));
 
             values[oilPhaseIdx] = 0.0;
             values[gasPhaseIdx] = GasOilMaterialLaw::twoPhaseSatPcnw(params.gasOilParams(), So);
@@ -144,7 +144,7 @@ public:
 
         case EclTwoPhaseApproach::EclTwoPhaseOilWater: {
             const Evaluation& Sw =
-                Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+                decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
 
             values[waterPhaseIdx] = 0.0;
             values[oilPhaseIdx] = OilWaterMaterialLaw::twoPhaseSatPcnw(params.oilWaterParams(), Sw);
@@ -153,7 +153,7 @@ public:
 
         case EclTwoPhaseApproach::EclTwoPhaseGasWater: {
             const Evaluation& Sw =
-                Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+                decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
 
             values[waterPhaseIdx] = 0.0;           
             values[gasPhaseIdx] = GasWaterMaterialLaw::twoPhaseSatPcnw(params.gasWaterParams(), Sw);
@@ -323,7 +323,7 @@ public:
         switch (params.approach()) {
         case EclTwoPhaseApproach::EclTwoPhaseGasOil: {
             const Evaluation& So =
-                Opm::decay<Evaluation>(fluidState.saturation(oilPhaseIdx));
+                decay<Evaluation>(fluidState.saturation(oilPhaseIdx));
 
             values[oilPhaseIdx] = GasOilMaterialLaw::twoPhaseSatKrw(params.gasOilParams(), So);
             values[gasPhaseIdx] = GasOilMaterialLaw::twoPhaseSatKrn(params.gasOilParams(), So);
@@ -332,7 +332,7 @@ public:
 
         case EclTwoPhaseApproach::EclTwoPhaseOilWater: {
             const Evaluation& Sw =
-                Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+                decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
 
             values[waterPhaseIdx] = OilWaterMaterialLaw::twoPhaseSatKrw(params.oilWaterParams(), Sw);
             values[oilPhaseIdx] = OilWaterMaterialLaw::twoPhaseSatKrn(params.oilWaterParams(), Sw);
@@ -341,7 +341,7 @@ public:
 
         case EclTwoPhaseApproach::EclTwoPhaseGasWater: {
             const Evaluation& Sw =
-                Opm::decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+                decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
             
             values[waterPhaseIdx] = GasWaterMaterialLaw::twoPhaseSatKrw(params.gasWaterParams(), Sw);
             values[gasPhaseIdx] = GasWaterMaterialLaw::twoPhaseSatKrn(params.gasWaterParams(), Sw);
@@ -394,21 +394,21 @@ public:
     {
         switch (params.approach()) {
         case EclTwoPhaseApproach::EclTwoPhaseGasOil: {
-            Scalar So = Opm::scalarValue(fluidState.saturation(oilPhaseIdx));
+            Scalar So = scalarValue(fluidState.saturation(oilPhaseIdx));
 
             params.gasOilParams().update(/*pcSw=*/So, /*krwSw=*/So, /*krnSw=*/So);
             break;
         }
 
         case EclTwoPhaseApproach::EclTwoPhaseOilWater: {
-            Scalar Sw = Opm::scalarValue(fluidState.saturation(waterPhaseIdx));
+            Scalar Sw = scalarValue(fluidState.saturation(waterPhaseIdx));
 
             params.oilWaterParams().update(/*pcSw=*/Sw, /*krwSw=*/Sw, /*krnSw=*/Sw);
             break;
         }
 
         case EclTwoPhaseApproach::EclTwoPhaseGasWater: {
-            Scalar Sw = Opm::scalarValue(fluidState.saturation(waterPhaseIdx));
+            Scalar Sw = scalarValue(fluidState.saturation(waterPhaseIdx));
            
             params.gasWaterParams().update(/*pcSw=*/1.0, /*krwSw=*/0.0, /*krnSw=*/Sw);
             break;

--- a/opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp
@@ -116,7 +116,7 @@ public:
     template <class Container, class FluidState>
     static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
     {
-        typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
+        typedef SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
         OverlayFluidState overlayFs(fs);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
@@ -142,7 +142,7 @@ public:
     template <class Container, class FluidState>
     static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
     {
-        typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
+        typedef SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
         OverlayFluidState overlayFs(fs);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
@@ -169,7 +169,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
-        typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
+        typedef SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
         static_assert(FluidState::numPhases == numPhases,
                       "The fluid state and the material law must exhibit the same "
@@ -274,7 +274,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation krw(const Params& params, const FluidState& fs)
     {
-        typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
+        typedef SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
         static_assert(FluidState::numPhases == numPhases,
                       "The fluid state and the material law must exhibit the same "
@@ -302,7 +302,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation krn(const Params& params, const FluidState& fs)
     {
-        typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
+        typedef SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
         static_assert(FluidState::numPhases == numPhases,
                       "The fluid state and the material law must exhibit the same "
@@ -333,7 +333,7 @@ public:
     static typename std::enable_if< (Traits::numPhases > 2), Evaluation>::type
     krg(const Params& params, const FluidState& fs)
     {
-        typedef Opm::SaturationOverlayFluidState<FluidState> OverlayFluidState;
+        typedef SaturationOverlayFluidState<FluidState> OverlayFluidState;
 
         static_assert(FluidState::numPhases == numPhases,
                       "The fluid state and the material law must exhibit the same "

--- a/opm/material/fluidmatrixinteractions/LinearMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/LinearMaterial.hpp
@@ -103,7 +103,7 @@ public:
 
         for (unsigned phaseIdx = 0; phaseIdx < Traits::numPhases; ++phaseIdx) {
             const Evaluation& S =
-                Opm::decay<Evaluation>(state.saturation(phaseIdx));
+                decay<Evaluation>(state.saturation(phaseIdx));
             Valgrind::CheckDefined(S);
 
             values[phaseIdx] =
@@ -135,10 +135,10 @@ public:
 
         for (unsigned phaseIdx = 0; phaseIdx < Traits::numPhases; ++phaseIdx) {
             const Evaluation& S =
-                Opm::decay<Evaluation>(state.saturation(phaseIdx));
+                decay<Evaluation>(state.saturation(phaseIdx));
             Valgrind::CheckDefined(S);
 
-            values[phaseIdx] = Opm::max(Opm::min(S,1.0),0.0);
+            values[phaseIdx] = max(min(S,1.0),0.0);
         }
     }
 
@@ -149,7 +149,7 @@ public:
     static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
         Valgrind::CheckDefined(Sw);
 
         const Evaluation& wPhasePressure =
@@ -157,7 +157,7 @@ public:
             (1.0 - Sw)*params.pcMinSat(Traits::wettingPhaseIdx);
 
         const Evaluation& Sn =
-            Opm::decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
         Valgrind::CheckDefined(Sn);
 
         const Evaluation& nPhasePressure =
@@ -227,14 +227,14 @@ public:
     static Evaluation krw(const Params& /*params*/, const FluidState& fs)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
-        return Opm::max(0.0, Opm::min(1.0, Sw));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+        return max(0.0, min(1.0, Sw));
     }
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
     twoPhaseSatKrw(const Params& /*params*/, const Evaluation& Sw)
-    { return Opm::max(0.0, Opm::min(1.0, Sw)); }
+    { return max(0.0, min(1.0, Sw)); }
 
     /*!
      * \brief The relative permability of the liquid non-wetting phase
@@ -243,15 +243,15 @@ public:
     static Evaluation krn(const Params& /*params*/, const FluidState& fs)
     {
         const Evaluation& Sn =
-            Opm::decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
-        return Opm::max(0.0, Opm::min(1.0, Sn));
+            decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
+        return max(0.0, min(1.0, Sn));
     }
 
     template <class Evaluation = Scalar>
     static typename std::enable_if<Traits::numPhases == 2, Evaluation>::type
     twoPhaseSatKrn(const Params& /*params*/, const Evaluation& Sw)
     {
-        return Opm::max(0.0, Opm::min(1.0, Sw));
+        return max(0.0, min(1.0, Sw));
     }
 
     /*!
@@ -264,8 +264,8 @@ public:
     krg(const Params& /*params*/, const FluidState& fs)
     {
         const Evaluation& Sg =
-            Opm::decay<Evaluation>(fs.saturation(Traits::gasPhaseIdx));
-        return Opm::max(0.0, Opm::min(1.0, Sg));
+            decay<Evaluation>(fs.saturation(Traits::gasPhaseIdx));
+        return max(0.0, min(1.0, Sg));
     }
 
     /*!
@@ -278,7 +278,7 @@ public:
     pcgn(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sn =
-            Opm::decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
         Valgrind::CheckDefined(Sn);
 
         const Evaluation& nPhasePressure =
@@ -286,7 +286,7 @@ public:
             (1.0 - Sn)*params.pcMinSat(Traits::nonWettingPhaseIdx);
 
         const Evaluation& Sg =
-            Opm::decay<Evaluation>(fs.saturation(Traits::gasPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::gasPhaseIdx));
         Valgrind::CheckDefined(Sg);
 
         const Evaluation& gPhasePressure =

--- a/opm/material/fluidmatrixinteractions/NullMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/NullMaterial.hpp
@@ -116,8 +116,8 @@ public:
 
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             const Evaluation& S =
-                Opm::decay<Evaluation>(fluidState.saturation(phaseIdx));
-            values[phaseIdx] = Opm::max(Opm::min(S, 1.0), 0.0);
+                decay<Evaluation>(fluidState.saturation(phaseIdx));
+            values[phaseIdx] = max(min(S, 1.0), 0.0);
         }
     }
 
@@ -179,15 +179,15 @@ public:
     krw(const Params& /*params*/, const FluidState& fluidState)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fluidState.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fluidState.saturation(Traits::wettingPhaseIdx));
 
-        return Opm::max(0.0, Opm::min(1.0, Sw));
+        return max(0.0, min(1.0, Sw));
     }
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
     twoPhaseSatKrw(const Params& /*params*/, const Evaluation& Sw)
-    { return Opm::max(0.0, Opm::min(1.0, Sw)); }
+    { return max(0.0, min(1.0, Sw)); }
 
     /*!
      * \brief The relative permability of the liquid non-wetting phase
@@ -197,16 +197,16 @@ public:
     krn(const Params& /*params*/, const FluidState& fluidState)
     {
         const Evaluation& Sn =
-            Opm::decay<Evaluation>(fluidState.saturation(Traits::nonWettingPhaseIdx));
+            decay<Evaluation>(fluidState.saturation(Traits::nonWettingPhaseIdx));
 
-        return Opm::max(0.0, Opm::min(1.0, Sn));
+        return max(0.0, min(1.0, Sn));
     }
 
     template <class Evaluation>
     static typename std::enable_if<numPhases == 2, Evaluation>::type
     twoPhaseSatKrn(const Params& /*params*/, const Evaluation& Sw)
     {
-        return Opm::max(0.0, Opm::min(1.0, 1.0 - Opm::decay<Evaluation>(Sw)));
+        return max(0.0, min(1.0, 1.0 - decay<Evaluation>(Sw)));
     }
 
     /*!
@@ -219,9 +219,9 @@ public:
     krg(const Params& /*params*/, const FluidState& fluidState)
     {
         const Evaluation& Sg =
-            Opm::decay<Evaluation>(fluidState.saturation(Traits::gasPhaseIdx));
+            decay<Evaluation>(fluidState.saturation(Traits::gasPhaseIdx));
 
-        return Opm::max(0.0, Opm::min(1.0, Sg));
+        return max(0.0, min(1.0, Sg));
     }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
+++ b/opm/material/fluidmatrixinteractions/ParkerLenhard.hpp
@@ -279,7 +279,7 @@ public:
 
 private:
     typedef typename ParamsT::VanGenuchten VanGenuchten;
-    typedef Opm::PLScanningCurve<Scalar> ScanningCurve;
+    typedef PLScanningCurve<Scalar> ScanningCurve;
 
 public:
     /*!
@@ -302,7 +302,7 @@ public:
     template <class FluidState>
     static void update(Params& params, const FluidState& fs)
     {
-        Scalar Sw = Opm::scalarValue(fs.saturation(Traits::wettingPhaseIdx));
+        Scalar Sw = scalarValue(fs.saturation(Traits::wettingPhaseIdx));
 
         if (Sw > 1 - 1e-5) {
             // if the absolute saturation is almost 1,
@@ -377,7 +377,7 @@ public:
     static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
         return twoPhaseSatPcnw(params, Sw);
     }
@@ -386,7 +386,7 @@ public:
     static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         // calculate the current apparent saturation
-        ScanningCurve* sc = findScanningCurve_(params, Opm::scalarValue(Sw));
+        ScanningCurve* sc = findScanningCurve_(params, scalarValue(Sw));
 
         // calculate the apparant saturation
         const Evaluation& Sw_app = absoluteToApparentSw_(params, Sw);
@@ -448,7 +448,7 @@ public:
     static Evaluation krw(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
         return twoPhaseSatKrw(params, Sw);
     }
@@ -470,7 +470,7 @@ public:
     static Evaluation krn(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
         return twoPhaseSatKrn(params, Sw);
     }

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -130,7 +130,7 @@ public:
     static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         const auto& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
         return twoPhaseSatPcnw(params, Sw);
     }
@@ -177,7 +177,7 @@ public:
     static Evaluation krw(const Params& params, const FluidState& fs)
     {
         const auto& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
         return twoPhaseSatKrw(params, Sw);
     }
@@ -198,7 +198,7 @@ public:
     static Evaluation krn(const Params& params, const FluidState& fs)
     {
         const auto& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
         return twoPhaseSatKrn(params, Sw);
     }
@@ -232,7 +232,7 @@ private:
         if (x >= xValues.back())
             return yValues.back();
 
-        size_t segIdx = findSegmentIndex_(xValues, Opm::scalarValue(x));
+        size_t segIdx = findSegmentIndex_(xValues, scalarValue(x));
 
         Scalar x0 = xValues[segIdx];
         Scalar x1 = xValues[segIdx + 1];
@@ -255,7 +255,7 @@ private:
         if (x <= xValues.back())
             return yValues.back();
 
-        size_t segIdx = findSegmentIndexDescending_(xValues, Opm::scalarValue(x));
+        size_t segIdx = findSegmentIndexDescending_(xValues, scalarValue(x));
 
         Scalar x0 = xValues[segIdx];
         Scalar x1 = xValues[segIdx + 1];
@@ -278,7 +278,7 @@ private:
         if (x >= xValues.back())
             return 0.0;
 
-        size_t segIdx = findSegmentIndex_(xValues, Opm::scalarValue(x));
+        size_t segIdx = findSegmentIndex_(xValues, scalarValue(x));
 
         Scalar x0 = xValues[segIdx];
         Scalar x1 = xValues[segIdx + 1];

--- a/opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp
@@ -64,7 +64,7 @@ namespace Opm {
 template <class TraitsT, class ParamsT = RegularizedBrooksCoreyParams<TraitsT> >
 class RegularizedBrooksCorey : public TraitsT
 {
-    typedef Opm::BrooksCorey<TraitsT, ParamsT> BrooksCorey;
+    typedef ::Opm::BrooksCorey<TraitsT, ParamsT> BrooksCorey;
 
 public:
     typedef TraitsT Traits;
@@ -173,7 +173,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
-        const auto& Sw = Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+        const auto& Sw = decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
         return twoPhaseSatPcnw(params, Sw);
     }
 
@@ -208,8 +208,8 @@ public:
     static Evaluation Sw(const Params& params, const FluidState& fs)
     {
         const Evaluation& pC =
-            Opm::decay<Evaluation>(fs.pressure(Traits::nonWettingPhaseIdx))
-            - Opm::decay<Evaluation>(fs.pressure(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.pressure(Traits::nonWettingPhaseIdx))
+            - decay<Evaluation>(fs.pressure(Traits::wettingPhaseIdx));
         return twoPhaseSatSw(params, pC);
     }
 
@@ -277,7 +277,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation krw(const Params& params, const FluidState& fs)
     {
-        const auto& Sw = Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+        const auto& Sw = decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
         return twoPhaseSatKrw(params, Sw);
     }
 
@@ -321,7 +321,7 @@ public:
     static Evaluation krn(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            1.0 - Opm::decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
+            1.0 - decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
         return twoPhaseSatKrn(params, Sw);
     }
 

--- a/opm/material/fluidmatrixinteractions/RegularizedBrooksCoreyParams.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedBrooksCoreyParams.hpp
@@ -42,10 +42,10 @@ namespace Opm {
  *          the Brooks-Corey capillary pressure model.
  */
 template <class TraitsT>
-class RegularizedBrooksCoreyParams : public Opm::BrooksCoreyParams<TraitsT>
+class RegularizedBrooksCoreyParams : public BrooksCoreyParams<TraitsT>
 {
-    typedef Opm::BrooksCoreyParams<TraitsT> BrooksCoreyParams;
-    typedef Opm::BrooksCorey<TraitsT, RegularizedBrooksCoreyParams> BrooksCorey;
+    typedef ::Opm::BrooksCoreyParams<TraitsT> BrooksCoreyParams;
+    typedef ::Opm::BrooksCorey<TraitsT, RegularizedBrooksCoreyParams> BrooksCorey;
     typedef typename TraitsT::Scalar Scalar;
 
 public:

--- a/opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp
@@ -70,7 +70,7 @@ namespace Opm {
 template <class TraitsT, class ParamsT = RegularizedVanGenuchtenParams<TraitsT> >
 class RegularizedVanGenuchten : public TraitsT
 {
-    typedef Opm::VanGenuchten<TraitsT, ParamsT> VanGenuchten;
+    typedef ::Opm::VanGenuchten<TraitsT, ParamsT> VanGenuchten;
 
 public:
     typedef TraitsT Traits;
@@ -162,7 +162,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
-        const auto& Sw = Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+        const auto& Sw = decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
         return twoPhaseSatPcnw(params, Sw);
     }
 
@@ -222,8 +222,8 @@ public:
     static Evaluation Sw(const Params& params, const FluidState& fs)
     {
         const Evaluation& pC =
-            Opm::decay<Evaluation>(fs.pressure(Traits::nonWettingPhaseIdx))
-            - Opm::decay<Evaluation>(fs.pressure(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.pressure(Traits::nonWettingPhaseIdx))
+            - decay<Evaluation>(fs.pressure(Traits::wettingPhaseIdx));
         return twoPhaseSatSw(params, pC);
     }
 
@@ -293,7 +293,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     static Evaluation krw(const Params& params, const FluidState& fs)
     {
-        const auto& Sw = Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+        const auto& Sw = decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
         return twoPhaseSatKrw(params, Sw);
     }
 
@@ -327,7 +327,7 @@ public:
     static Evaluation krn(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            1.0 - Opm::decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
+            1.0 - decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
         return twoPhaseSatKrn(params, Sw);
     }
 

--- a/opm/material/fluidmatrixinteractions/RegularizedVanGenuchtenParams.hpp
+++ b/opm/material/fluidmatrixinteractions/RegularizedVanGenuchtenParams.hpp
@@ -47,7 +47,7 @@ class RegularizedVanGenuchtenParams : public VanGenuchtenParams<TraitsT>
 {
     typedef typename TraitsT::Scalar Scalar;
     typedef VanGenuchtenParams<TraitsT> Parent;
-    typedef Opm::VanGenuchten<TraitsT> VanGenuchten;
+    typedef ::Opm::VanGenuchten<TraitsT> VanGenuchten;
 
 public:
     using Parent :: finalize;

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterial.hpp
@@ -124,7 +124,7 @@ public:
     static Evaluation pcnw(const Params& params, const FluidState& fluidState)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fluidState.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fluidState.saturation(Traits::wettingPhaseIdx));
 
         return twoPhaseSatPcnw(params, Sw);
     }
@@ -193,7 +193,7 @@ public:
     static Evaluation krw(const Params& params, const FluidState& fluidState)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fluidState.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fluidState.saturation(Traits::wettingPhaseIdx));
 
         return twoPhaseSatKrw(params, Sw);
     }
@@ -232,7 +232,7 @@ public:
     static Evaluation krn(const Params& params, const FluidState& fluidState)
     {
         const Evaluation& Sn =
-            Opm::decay<Evaluation>(fluidState.saturation(Traits::nonWettingPhaseIdx));
+            decay<Evaluation>(fluidState.saturation(Traits::nonWettingPhaseIdx));
 
         return twoPhaseSatKrn(params, 1.0 - Sn);
     }

--- a/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterialParams.hpp
@@ -49,7 +49,7 @@ public:
 
 public:
     typedef std::vector<Scalar> SamplePoints;
-    typedef Opm::Spline<Scalar> Spline;
+    typedef ::Opm::Spline<Scalar> Spline;
     typedef typename Spline::SplineType SplineType;
 
     typedef TraitsT Traits;

--- a/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp
@@ -126,8 +126,8 @@ public:
 
         // sum of liquid saturations
         const auto& St =
-            Opm::decay<Evaluation>(fluidState.saturation(wettingPhaseIdx))
-            + Opm::decay<Evaluation>(fluidState.saturation(nonWettingPhaseIdx));
+            decay<Evaluation>(fluidState.saturation(wettingPhaseIdx))
+            + decay<Evaluation>(fluidState.saturation(nonWettingPhaseIdx));
 
         Evaluation Se = (St - params.Swrx())/(1. - params.Swrx());
 
@@ -139,8 +139,8 @@ public:
 
         if (Se>PC_VG_REG && Se<1-PC_VG_REG)
         {
-            const Evaluation& x = Opm::pow(Se,-1/params.vgM()) - 1;
-            return Opm::pow(x, 1.0 - params.vgM())/params.vgAlpha();
+            const Evaluation& x = pow(Se,-1/params.vgM()) - 1;
+            return pow(x, 1.0 - params.vgM())/params.vgAlpha();
         }
 
         // value and derivative at regularization point
@@ -150,9 +150,9 @@ public:
         else
             Se_regu = 1-PC_VG_REG;
         const Evaluation& x = std::pow(Se_regu,-1/params.vgM())-1;
-        const Evaluation& pc = Opm::pow(x, 1.0/params.vgN())/params.vgAlpha();
+        const Evaluation& pc = pow(x, 1.0/params.vgN())/params.vgAlpha();
         const Evaluation& pc_prime =
-            Opm::pow(x, 1/params.vgN()-1)
+            pow(x, 1/params.vgN()-1)
             * std::pow(Se_regu,-1/params.vgM()-1)
             / (-params.vgM())
             / params.vgAlpha()
@@ -176,7 +176,7 @@ public:
     static Evaluation pcnw(const Params& params, const FluidState& fluidState)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fluidState.saturation(wettingPhaseIdx));
+            decay<Evaluation>(fluidState.saturation(wettingPhaseIdx));
         Evaluation Se = (Sw-params.Swr())/(1.-params.Snr());
 
         Scalar PC_VG_REG = 0.01;
@@ -188,8 +188,8 @@ public:
             Se=1.0;
 
         if (Se>PC_VG_REG && Se<1-PC_VG_REG) {
-            Evaluation x = Opm::pow(Se,-1/params.vgM()) - 1.0;
-            x = Opm::pow(x, 1 - params.vgM());
+            Evaluation x = pow(Se,-1/params.vgM()) - 1.0;
+            x = pow(x, 1 - params.vgM());
             return x/params.vgAlpha();
         }
 
@@ -201,9 +201,9 @@ public:
             Se_regu = 1.0 - PC_VG_REG;
 
         const Evaluation& x = std::pow(Se_regu,-1/params.vgM())-1;
-        const Evaluation& pc = Opm::pow(x, 1/params.vgN())/params.vgAlpha();
+        const Evaluation& pc = pow(x, 1/params.vgN())/params.vgAlpha();
         const Evaluation& pc_prime =
-            Opm::pow(x,1/params.vgN()-1)
+            pow(x,1/params.vgN()-1)
             * std::pow(Se_regu, -1.0/params.vgM() - 1)
             / (-params.vgM())
             / params.vgAlpha()
@@ -272,7 +272,7 @@ public:
     static Evaluation krw(const Params& params, const FluidState& fluidState)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fluidState.saturation(wettingPhaseIdx));
+            decay<Evaluation>(fluidState.saturation(wettingPhaseIdx));
         // transformation to effective saturation
         const Evaluation& Se = (Sw - params.Swr()) / (1-params.Swr());
 
@@ -280,8 +280,8 @@ public:
         if(Se > 1.0) return 1.;
         if(Se < 0.0) return 0.;
 
-        const Evaluation& r = 1. - Opm::pow(1 - Opm::pow(Se, 1/params.vgM()), params.vgM());
-        return Opm::sqrt(Se)*r*r;
+        const Evaluation& r = 1. - pow(1 - pow(Se, 1/params.vgM()), params.vgM());
+        return sqrt(Se)*r*r;
     }
 
     /*!
@@ -300,11 +300,11 @@ public:
     static Evaluation krn(const Params& params, const FluidState& fluidState)
     {
         const Evaluation& Sn =
-            Opm::decay<Evaluation>(fluidState.saturation(nonWettingPhaseIdx));
+            decay<Evaluation>(fluidState.saturation(nonWettingPhaseIdx));
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fluidState.saturation(wettingPhaseIdx));
-        Evaluation Swe = Opm::min((Sw - params.Swr()) / (1 - params.Swr()), 1.);
-        Evaluation Ste = Opm::min((Sw + Sn - params.Swr()) / (1 - params.Swr()), 1.);
+            decay<Evaluation>(fluidState.saturation(wettingPhaseIdx));
+        Evaluation Swe = min((Sw - params.Swr()) / (1 - params.Swr()), 1.);
+        Evaluation Ste = min((Sw + Sn - params.Swr()) / (1 - params.Swr()), 1.);
 
         // regularization
         if(Swe <= 0.0) Swe = 0.;
@@ -312,8 +312,8 @@ public:
         if(Ste - Swe <= 0.0) return 0.;
 
         Evaluation krn_;
-        krn_ = Opm::pow(1 - Opm::pow(Swe, 1/params.vgM()), params.vgM());
-        krn_ -= Opm::pow(1 - Opm::pow(Ste, 1/params.vgM()), params.vgM());
+        krn_ = pow(1 - pow(Swe, 1/params.vgM()), params.vgM());
+        krn_ -= pow(1 - pow(Ste, 1/params.vgM()), params.vgM());
         krn_ *= krn_;
 
         if (params.krRegardsSnr())
@@ -321,11 +321,11 @@ public:
             // regard Snr in the permeability of the non-wetting
             // phase, see Helmig1997
             const Evaluation& resIncluded =
-                Opm::max(Opm::min(Sw - params.Snr() / (1-params.Swr()), 1.0), 0.0);
-            krn_ *= Opm::sqrt(resIncluded );
+                max(min(Sw - params.Snr() / (1-params.Swr()), 1.0), 0.0);
+            krn_ *= sqrt(resIncluded );
         }
         else
-            krn_ *= Opm::sqrt(Sn / (1 - params.Swr()));
+            krn_ *= sqrt(Sn / (1 - params.Swr()));
 
         return krn_;
     }
@@ -345,8 +345,8 @@ public:
     static Evaluation krg(const Params& params, const FluidState& fluidState)
     {
         const Evaluation& Sg =
-            Opm::decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
-        const Evaluation& Se = Opm::min(((1-Sg) - params.Sgr()) / (1 - params.Sgr()), 1.);
+            decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        const Evaluation& Se = min(((1-Sg) - params.Sgr()) / (1 - params.Sgr()), 1.);
 
         // regularization
         if(Se > 1.0)
@@ -362,8 +362,8 @@ public:
         }
 
         return scaleFactor
-            * Opm::pow(1 - Se, 1.0/3.)
-            * Opm::pow(1 - Opm::pow(Se, 1/params.vgM()), 2*params.vgM());
+            * pow(1 - Se, 1.0/3.)
+            * pow(1 - pow(Se, 1/params.vgM()), 2*params.vgM());
     }
 };
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/VanGenuchten.hpp
+++ b/opm/material/fluidmatrixinteractions/VanGenuchten.hpp
@@ -169,7 +169,7 @@ public:
     static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
         assert(0 <= Sw && Sw <= 1);
 
@@ -193,7 +193,7 @@ public:
     template <class Evaluation>
     static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
-        return Opm::pow(Opm::pow(Sw, -1.0/params.vgM()) - 1, 1.0/params.vgN())/params.vgAlpha();
+        return pow(pow(Sw, -1.0/params.vgM()) - 1, 1.0/params.vgN())/params.vgAlpha();
     }
 
     /*!
@@ -212,8 +212,8 @@ public:
     static Evaluation Sw(const Params& params, const FluidState& fs)
     {
         Evaluation pC =
-            Opm::decay<Evaluation>(fs.pressure(Traits::nonWettingPhaseIdx))
-            - Opm::decay<Evaluation>(fs.pressure(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.pressure(Traits::nonWettingPhaseIdx))
+            - decay<Evaluation>(fs.pressure(Traits::wettingPhaseIdx));
         return twoPhaseSatSw(params, pC);
     }
 
@@ -222,7 +222,7 @@ public:
     {
         assert(pC >= 0);
 
-        return Opm::pow(Opm::pow(params.vgAlpha()*pC, params.vgN()) + 1, -params.vgM());
+        return pow(pow(params.vgAlpha()*pC, params.vgN()) + 1, -params.vgM());
     }
 
     /*!
@@ -251,7 +251,7 @@ public:
     static Evaluation krw(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            Opm::decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
+            decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
         return twoPhaseSatKrw(params, Sw);
     }
@@ -261,8 +261,8 @@ public:
     {
         assert(0.0 <= Sw && Sw <= 1.0);
 
-        Evaluation r = 1.0 - Opm::pow(1.0 - Opm::pow(Sw, 1/params.vgM()), params.vgM());
-        return Opm::sqrt(Sw)*r*r;
+        Evaluation r = 1.0 - pow(1.0 - pow(Sw, 1/params.vgM()), params.vgM());
+        return sqrt(Sw)*r*r;
     }
 
     /*!
@@ -278,7 +278,7 @@ public:
     static Evaluation krn(const Params& params, const FluidState& fs)
     {
         const Evaluation& Sw =
-            1.0 - Opm::decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
+            1.0 - decay<Evaluation>(fs.saturation(Traits::nonWettingPhaseIdx));
 
         return twoPhaseSatKrn(params, Sw);
     }
@@ -289,8 +289,8 @@ public:
         assert(0 <= Sw && Sw <= 1);
 
         return
-            Opm::pow(1 - Sw, 1.0/3) *
-            Opm::pow(1 - Opm::pow(Sw, 1/params.vgM()), 2*params.vgM());
+            pow(1 - Sw, 1.0/3) *
+            pow(1 - pow(Sw, 1/params.vgM()), 2*params.vgM());
     }
 };
 } // namespace Opm

--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -56,8 +56,8 @@ auto getInvB_(typename std::enable_if<HasMember_invB<FluidState>::value,
                                       const FluidState&>::type fluidState,
               unsigned phaseIdx,
               unsigned pvtRegionIdx OPM_UNUSED)
-    -> decltype(Opm::decay<LhsEval>(fluidState.invB(phaseIdx)))
-{ return Opm::decay<LhsEval>(fluidState.invB(phaseIdx)); }
+    -> decltype(decay<LhsEval>(fluidState.invB(phaseIdx)))
+{ return decay<LhsEval>(fluidState.invB(phaseIdx)); }
 
 template <class FluidSystem, class FluidState, class LhsEval>
 LhsEval getInvB_(typename std::enable_if<!HasMember_invB<FluidState>::value,
@@ -70,8 +70,8 @@ LhsEval getInvB_(typename std::enable_if<!HasMember_invB<FluidState>::value,
         fluidState.massFraction(phaseIdx, FluidSystem::solventComponentIndex(phaseIdx));
 
     return
-        Opm::decay<LhsEval>(rho)
-        *Opm::decay<LhsEval>(Xsolvent)
+        decay<LhsEval>(rho)
+        *decay<LhsEval>(Xsolvent)
         /FluidSystem::referenceDensity(phaseIdx, pvtRegionIdx);
 }
 
@@ -127,29 +127,29 @@ public:
     void checkDefined() const
     {
 #ifndef NDEBUG
-        Opm::Valgrind::CheckDefined(pvtRegionIdx_);
+        Valgrind::CheckDefined(pvtRegionIdx_);
 
         for (unsigned storagePhaseIdx = 0; storagePhaseIdx < numStoragePhases; ++ storagePhaseIdx) {
-            Opm::Valgrind::CheckDefined(saturation_[storagePhaseIdx]);
-            Opm::Valgrind::CheckDefined(pressure_[storagePhaseIdx]);
-            Opm::Valgrind::CheckDefined(density_[storagePhaseIdx]);
-            Opm::Valgrind::CheckDefined(invB_[storagePhaseIdx]);
+            Valgrind::CheckDefined(saturation_[storagePhaseIdx]);
+            Valgrind::CheckDefined(pressure_[storagePhaseIdx]);
+            Valgrind::CheckDefined(density_[storagePhaseIdx]);
+            Valgrind::CheckDefined(invB_[storagePhaseIdx]);
 
             if (enableEnergy)
-                Opm::Valgrind::CheckDefined((*enthalpy_)[storagePhaseIdx]);
+                Valgrind::CheckDefined((*enthalpy_)[storagePhaseIdx]);
         }
 
         if (enableDissolution) {
-            Opm::Valgrind::CheckDefined(*Rs_);
-            Opm::Valgrind::CheckDefined(*Rv_);
+            Valgrind::CheckDefined(*Rs_);
+            Valgrind::CheckDefined(*Rv_);
         }
 
         if (enableBrine) {
-            Opm::Valgrind::CheckDefined(*saltConcentration_);
+            Valgrind::CheckDefined(*saltConcentration_);
         }
 
         if (enableTemperature || enableEnergy)
-            Opm::Valgrind::CheckDefined(*temperature_);
+            Valgrind::CheckDefined(*temperature_);
 #endif // NDEBUG
     }
 
@@ -167,12 +167,12 @@ public:
         setPvtRegionIndex(pvtRegionIdx);
 
         if (enableDissolution) {
-            setRs(Opm::BlackOil::getRs_<FluidSystem, FluidState, Scalar>(fs, pvtRegionIdx));
-            setRv(Opm::BlackOil::getRv_<FluidSystem, FluidState, Scalar>(fs, pvtRegionIdx));
+            setRs(BlackOil::getRs_<FluidSystem, FluidState, Scalar>(fs, pvtRegionIdx));
+            setRv(BlackOil::getRv_<FluidSystem, FluidState, Scalar>(fs, pvtRegionIdx));
         }
 
         if (enableBrine){
-            setSaltConcentration(Opm::BlackOil::getSaltConcentration_<FluidSystem, FluidState, Scalar>(fs, pvtRegionIdx));
+            setSaltConcentration(BlackOil::getSaltConcentration_<FluidSystem, FluidState, Scalar>(fs, pvtRegionIdx));
         }
         for (unsigned storagePhaseIdx = 0; storagePhaseIdx < numStoragePhases; ++storagePhaseIdx) {
             unsigned phaseIdx = storageToCanonicalPhaseIndex_(storagePhaseIdx);
@@ -575,17 +575,17 @@ private:
         return FluidSystem::canonicalToActivePhaseIdx(canonicalPhaseIdx);
     }
 
-    Opm::ConditionalStorage<enableTemperature || enableEnergy, Scalar> temperature_;
-    Opm::ConditionalStorage<enableEnergy, std::array<Scalar, numStoragePhases> > enthalpy_;
+    ConditionalStorage<enableTemperature || enableEnergy, Scalar> temperature_;
+    ConditionalStorage<enableEnergy, std::array<Scalar, numStoragePhases> > enthalpy_;
     Scalar totalSaturation_;
     std::array<Scalar, numStoragePhases> pressure_;
     std::array<Scalar, numStoragePhases> pc_;
     std::array<Scalar, numStoragePhases> saturation_;
     std::array<Scalar, numStoragePhases> invB_;
     std::array<Scalar, numStoragePhases> density_;
-    Opm::ConditionalStorage<enableDissolution,Scalar> Rs_;
-    Opm::ConditionalStorage<enableDissolution, Scalar> Rv_;
-    Opm::ConditionalStorage<enableBrine, Scalar> saltConcentration_;
+    ConditionalStorage<enableDissolution,Scalar> Rs_;
+    ConditionalStorage<enableDissolution, Scalar> Rv_;
+    ConditionalStorage<enableBrine, Scalar> saltConcentration_;
     unsigned short pvtRegionIdx_;
 };
 

--- a/opm/material/fluidstates/FluidStateCompositionModules.hpp
+++ b/opm/material/fluidstates/FluidStateCompositionModules.hpp
@@ -73,10 +73,10 @@ public:
     Scalar massFraction(unsigned phaseIdx, unsigned compIdx) const
     {
         return
-            Opm::abs(sumMoleFractions_[phaseIdx])
+            abs(sumMoleFractions_[phaseIdx])
             *moleFraction_[phaseIdx][compIdx]
             *FluidSystem::molarMass(compIdx)
-            / Opm::max(1e-40, Opm::abs(averageMolarMass_[phaseIdx]));
+            / max(1e-40, abs(averageMolarMass_[phaseIdx]));
     }
 
     /*!
@@ -137,7 +137,7 @@ public:
             sumMoleFractions_[phaseIdx] = 0;
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 moleFraction_[phaseIdx][compIdx] =
-                    Opm::decay<Scalar>(fs.moleFraction(phaseIdx, compIdx));
+                    decay<Scalar>(fs.moleFraction(phaseIdx, compIdx));
 
                 averageMolarMass_[phaseIdx] += moleFraction_[phaseIdx][compIdx]*FluidSystem::molarMass(compIdx);
                 sumMoleFractions_[phaseIdx] += moleFraction_[phaseIdx][compIdx];

--- a/opm/material/fluidstates/FluidStateDensityModules.hpp
+++ b/opm/material/fluidstates/FluidStateDensityModules.hpp
@@ -80,7 +80,7 @@ public:
     void assign(const FluidState& fs)
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            density_[phaseIdx] = Opm::decay<Scalar>(fs.density(phaseIdx));
+            density_[phaseIdx] = decay<Scalar>(fs.density(phaseIdx));
         }
     }
 

--- a/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
+++ b/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
@@ -73,7 +73,7 @@ public:
     void assign(const FluidState& fs)
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            enthalpy_[phaseIdx] = Opm::decay<Scalar>(fs.enthalpy(phaseIdx));
+            enthalpy_[phaseIdx] = decay<Scalar>(fs.enthalpy(phaseIdx));
         }
     }
 

--- a/opm/material/fluidstates/FluidStatePressureModules.hpp
+++ b/opm/material/fluidstates/FluidStatePressureModules.hpp
@@ -69,7 +69,7 @@ public:
     void assign(const FluidState& fs)
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            pressure_[phaseIdx] = Opm::decay<Scalar>(fs.pressure(phaseIdx));
+            pressure_[phaseIdx] = decay<Scalar>(fs.pressure(phaseIdx));
         }
     }
 

--- a/opm/material/fluidstates/FluidStateSaturationModules.hpp
+++ b/opm/material/fluidstates/FluidStateSaturationModules.hpp
@@ -68,7 +68,7 @@ public:
     void assign(const FluidState& fs)
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            saturation_[phaseIdx] = Opm::decay<Scalar>(fs.saturation(phaseIdx));
+            saturation_[phaseIdx] = decay<Scalar>(fs.saturation(phaseIdx));
         }
     }
 

--- a/opm/material/fluidstates/FluidStateTemperatureModules.hpp
+++ b/opm/material/fluidstates/FluidStateTemperatureModules.hpp
@@ -123,12 +123,12 @@ public:
     template <class FluidState>
     void assign(const FluidState& fs)
     {
-        temperature_ = Opm::decay<Scalar>(fs.temperature(/*phaseIdx=*/0));
+        temperature_ = decay<Scalar>(fs.temperature(/*phaseIdx=*/0));
 
 #ifndef NDEBUG
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            assert(std::abs(Opm::scalarValue(fs.temperature(phaseIdx))
-                            - Opm::scalarValue(temperature_)) < 1e-30);
+            assert(std::abs(scalarValue(fs.temperature(phaseIdx))
+                            - scalarValue(temperature_)) < 1e-30);
         }
 #endif
     }

--- a/opm/material/fluidstates/FluidStateViscosityModules.hpp
+++ b/opm/material/fluidstates/FluidStateViscosityModules.hpp
@@ -67,7 +67,7 @@ public:
     void assign(const FluidState& fs)
     {
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            viscosity_[phaseIdx] = Opm::decay<Scalar>(fs.viscosity(phaseIdx));
+            viscosity_[phaseIdx] = decay<Scalar>(fs.viscosity(phaseIdx));
         }
     }
 

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -62,30 +62,30 @@ LhsEval getRs_(typename std::enable_if<!HasMember_Rs<FluidState>::value, const F
                unsigned regionIdx)
 {
     const auto& XoG =
-        Opm::decay<LhsEval>(fluidState.massFraction(FluidSystem::oilPhaseIdx, FluidSystem::gasCompIdx));
+        decay<LhsEval>(fluidState.massFraction(FluidSystem::oilPhaseIdx, FluidSystem::gasCompIdx));
     return FluidSystem::convertXoGToRs(XoG, regionIdx);
 }
 
 template <class FluidSystem, class FluidState, class LhsEval>
 auto getRs_(typename std::enable_if<HasMember_Rs<FluidState>::value, const FluidState&>::type fluidState,
             unsigned regionIdx OPM_UNUSED)
-    -> decltype(Opm::decay<LhsEval>(fluidState.Rs()))
-{ return Opm::decay<LhsEval>(fluidState.Rs()); }
+    -> decltype(decay<LhsEval>(fluidState.Rs()))
+{ return decay<LhsEval>(fluidState.Rs()); }
 
 template <class FluidSystem, class FluidState, class LhsEval>
 LhsEval getRv_(typename std::enable_if<!HasMember_Rv<FluidState>::value, const FluidState&>::type fluidState,
                unsigned regionIdx)
 {
     const auto& XgO =
-        Opm::decay<LhsEval>(fluidState.massFraction(FluidSystem::gasPhaseIdx, FluidSystem::oilCompIdx));
+        decay<LhsEval>(fluidState.massFraction(FluidSystem::gasPhaseIdx, FluidSystem::oilCompIdx));
     return FluidSystem::convertXgOToRv(XgO, regionIdx);
 }
 
 template <class FluidSystem, class FluidState, class LhsEval>
 auto getRv_(typename std::enable_if<HasMember_Rv<FluidState>::value, const FluidState&>::type fluidState,
             unsigned regionIdx OPM_UNUSED)
-    -> decltype(Opm::decay<LhsEval>(fluidState.Rv()))
-{ return Opm::decay<LhsEval>(fluidState.Rv()); }
+    -> decltype(decay<LhsEval>(fluidState.Rv()))
+{ return decay<LhsEval>(fluidState.Rv()); }
 
 template <class FluidSystem, class FluidState, class LhsEval>
 LhsEval getSaltConcentration_(typename std::enable_if<!HasMember_saltConcentration<FluidState>::value,
@@ -96,8 +96,8 @@ LhsEval getSaltConcentration_(typename std::enable_if<!HasMember_saltConcentrati
 template <class FluidSystem, class FluidState, class LhsEval>
 auto getSaltConcentration_(typename std::enable_if<HasMember_saltConcentration<FluidState>::value, const FluidState&>::type fluidState,
             unsigned regionIdx OPM_UNUSED)
-    -> decltype(Opm::decay<LhsEval>(fluidState.saltConcentration()))
-{ return Opm::decay<LhsEval>(fluidState.saltConcentration()); }
+    -> decltype(decay<LhsEval>(fluidState.saltConcentration()))
+{ return decay<LhsEval>(fluidState.saltConcentration()); }
 
 }
 
@@ -107,19 +107,19 @@ auto getSaltConcentration_(typename std::enable_if<HasMember_saltConcentration<F
  *
  * \tparam Scalar The type used for scalar floating point values
  */
-template <class Scalar, class IndexTraits = Opm::BlackOilDefaultIndexTraits>
+template <class Scalar, class IndexTraits = BlackOilDefaultIndexTraits>
 class BlackOilFluidSystem : public BaseFluidSystem<Scalar, BlackOilFluidSystem<Scalar, IndexTraits> >
 {
     typedef BlackOilFluidSystem ThisType;
 
 public:
-    typedef Opm::GasPvtMultiplexer<Scalar> GasPvt;
-    typedef Opm::OilPvtMultiplexer<Scalar> OilPvt;
-    typedef Opm::WaterPvtMultiplexer<Scalar> WaterPvt;
+    typedef GasPvtMultiplexer<Scalar> GasPvt;
+    typedef OilPvtMultiplexer<Scalar> OilPvt;
+    typedef WaterPvtMultiplexer<Scalar> WaterPvt;
 
     //! \copydoc BaseFluidSystem::ParameterCache
     template <class EvaluationT>
-    struct ParameterCache : public Opm::NullParameterCache<EvaluationT>
+    struct ParameterCache : public NullParameterCache<EvaluationT>
     {
         typedef EvaluationT Evaluation;
 
@@ -394,7 +394,7 @@ public:
                 Scalar p = surfacePressure;
                 Scalar T = surfaceTemperature;
                 Scalar rho_g = referenceDensity_[/*regionIdx=*/0][gasPhaseIdx];
-                molarMass_[regionIdx][gasCompIdx] = Opm::Constants<Scalar>::R*T*rho_g / p;
+                molarMass_[regionIdx][gasCompIdx] = Constants<Scalar>::R*T*rho_g / p;
             }
             else
                 // hydrogen gas. we just set this do avoid NaNs later
@@ -656,15 +656,15 @@ public:
         assert(0 <= phaseIdx && phaseIdx <= numPhases);
         assert(0 <= regionIdx && regionIdx <= numRegions());
 
-        const LhsEval& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& saltConcentration = Opm::BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& saltConcentration = BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
 
         switch (phaseIdx) {
         case oilPhaseIdx: {
             if (enableDissolvedGas()) {
                 // miscible oil
-                const LhsEval& Rs = Opm::BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& Rs = BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bo = oilPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rs);
 
                 return
@@ -682,7 +682,7 @@ public:
         case gasPhaseIdx: {
             if (enableVaporizedOil()) {
                 // miscible gas
-                const LhsEval& Rv = Opm::BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& Rv = BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv);
 
                 return
@@ -785,16 +785,16 @@ public:
         assert(0 <= phaseIdx && phaseIdx <= numPhases);
         assert(0 <= regionIdx && regionIdx <= numRegions());
 
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& saltConcentration = Opm::decay<LhsEval>(fluidState.saltConcentration());
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& saltConcentration = decay<LhsEval>(fluidState.saltConcentration());
 
         switch (phaseIdx) {
         case oilPhaseIdx: {
             if (enableDissolvedGas()) {
-                const auto& Rs = Opm::BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const auto& Rs = BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (fluidState.saturation(gasPhaseIdx) > 0.0
-                    && Rs >= (1.0 - 1e-10)*oilPvt_->saturatedGasDissolutionFactor(regionIdx, Opm::scalarValue(T), Opm::scalarValue(p)))
+                    && Rs >= (1.0 - 1e-10)*oilPvt_->saturatedGasDissolutionFactor(regionIdx, scalarValue(T), scalarValue(p)))
                 {
                     return oilPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
                 } else {
@@ -807,9 +807,9 @@ public:
         }
         case gasPhaseIdx: {
             if (enableVaporizedOil()) {
-                const auto& Rv = Opm::BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const auto& Rv = BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (fluidState.saturation(oilPhaseIdx) > 0.0
-                    && Rv >= (1.0 - 1e-10)*gasPvt_->saturatedOilVaporizationFactor(regionIdx, Opm::scalarValue(T), Opm::scalarValue(p)))
+                    && Rv >= (1.0 - 1e-10)*gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
                 {
                     return gasPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
                 } else {
@@ -841,9 +841,9 @@ public:
         assert(0 <= phaseIdx && phaseIdx <= numPhases);
         assert(0 <= regionIdx && regionIdx <= numRegions());
 
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& saltConcentration = Opm::decay<LhsEval>(fluidState.saltConcentration());
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& saltConcentration = decay<LhsEval>(fluidState.saltConcentration());
 
         switch (phaseIdx) {
         case oilPhaseIdx: return oilPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
@@ -864,8 +864,8 @@ public:
         assert(0 <= compIdx && compIdx <= numComponents);
         assert(0 <= regionIdx && regionIdx <= numRegions());
 
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
 
         // for the fugacity coefficient of the oil component in the oil phase, we use
         // some pseudo-realistic value for the vapor pressure to ease physical
@@ -904,8 +904,8 @@ public:
                 const auto& x_oGSat = convertXoGToxoG(X_oGSat, regionIdx);
                 const auto& x_oOSat = 1.0 - x_oGSat;
 
-                const auto& p_o = Opm::decay<LhsEval>(fluidState.pressure(oilPhaseIdx));
-                const auto& p_g = Opm::decay<LhsEval>(fluidState.pressure(gasPhaseIdx));
+                const auto& p_o = decay<LhsEval>(fluidState.pressure(oilPhaseIdx));
+                const auto& p_g = decay<LhsEval>(fluidState.pressure(gasPhaseIdx));
 
                 return phi_oO*p_o*x_oOSat / (p_g*x_gOSat);
             }
@@ -940,8 +940,8 @@ public:
                 const auto& X_oGSat = convertRsToXoG(R_sSat, regionIdx);
                 const auto& x_oGSat = convertXoGToxoG(X_oGSat, regionIdx);
 
-                const auto& p_o = Opm::decay<LhsEval>(fluidState.pressure(oilPhaseIdx));
-                const auto& p_g = Opm::decay<LhsEval>(fluidState.pressure(gasPhaseIdx));
+                const auto& p_o = decay<LhsEval>(fluidState.pressure(oilPhaseIdx));
+                const auto& p_g = decay<LhsEval>(fluidState.pressure(gasPhaseIdx));
 
                 return phi_gG*p_g*x_gGSat / (p_o*x_oGSat);
             }
@@ -984,16 +984,16 @@ public:
         assert(0 <= phaseIdx && phaseIdx <= numPhases);
         assert(0 <= regionIdx && regionIdx <= numRegions());
 
-        const LhsEval& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& saltConcentration = Opm::BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& saltConcentration = BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
 
         switch (phaseIdx) {
         case oilPhaseIdx: {
             if (enableDissolvedGas()) {
-                const auto& Rs = Opm::BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const auto& Rs = BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (fluidState.saturation(gasPhaseIdx) > 0.0
-                    && Rs >= (1.0 - 1e-10)*oilPvt_->saturatedGasDissolutionFactor(regionIdx, Opm::scalarValue(T), Opm::scalarValue(p)))
+                    && Rs >= (1.0 - 1e-10)*oilPvt_->saturatedGasDissolutionFactor(regionIdx, scalarValue(T), scalarValue(p)))
                 {
                     return oilPvt_->saturatedViscosity(regionIdx, T, p);
                 } else {
@@ -1007,9 +1007,9 @@ public:
 
         case gasPhaseIdx: {
             if (enableVaporizedOil()) {
-                const auto& Rv = Opm::BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const auto& Rv = BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (fluidState.saturation(oilPhaseIdx) > 0.0
-                    && Rv >= (1.0 - 1e-10)*gasPvt_->saturatedOilVaporizationFactor(regionIdx, Opm::scalarValue(T), Opm::scalarValue(p)))
+                    && Rv >= (1.0 - 1e-10)*gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
                 {
                     return gasPvt_->saturatedViscosity(regionIdx, T, p);
                 } else {
@@ -1039,18 +1039,18 @@ public:
         assert(0 <= phaseIdx && phaseIdx <= numPhases);
         assert(0 <= regionIdx && regionIdx <= numRegions());
 
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
 
         switch (phaseIdx) {
         case oilPhaseIdx:
             return
-                oilPvt_->internalEnergy(regionIdx, T, p, Opm::BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx))
+                oilPvt_->internalEnergy(regionIdx, T, p, BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx))
                 + p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
 
         case gasPhaseIdx:
             return
-                gasPvt_->internalEnergy(regionIdx, T, p, Opm::BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx))
+                gasPvt_->internalEnergy(regionIdx, T, p, BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx))
                 + p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
 
         case waterPhaseIdx:
@@ -1079,9 +1079,9 @@ public:
         assert(0 <= phaseIdx && phaseIdx <= numPhases);
         assert(0 <= regionIdx && regionIdx <= numRegions());
 
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& So = Opm::decay<LhsEval>(fluidState.saturation(oilPhaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& So = decay<LhsEval>(fluidState.saturation(oilPhaseIdx));
 
         switch (phaseIdx) {
         case oilPhaseIdx: return oilPvt_->saturatedGasDissolutionFactor(regionIdx, T, p, So, maxOilSaturation);
@@ -1107,8 +1107,8 @@ public:
         assert(0 <= phaseIdx && phaseIdx <= numPhases);
         assert(0 <= regionIdx && regionIdx <= numRegions());
 
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
 
         switch (phaseIdx) {
         case oilPhaseIdx: return oilPvt_->saturatedGasDissolutionFactor(regionIdx, T, p);
@@ -1157,11 +1157,11 @@ public:
         assert(0 <= phaseIdx && phaseIdx <= numPhases);
         assert(0 <= regionIdx && regionIdx <= numRegions());
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
 
         switch (phaseIdx) {
-        case oilPhaseIdx: return oilPvt_->saturationPressure(regionIdx, T, Opm::BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
-        case gasPhaseIdx: return gasPvt_->saturationPressure(regionIdx, T, Opm::BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+        case oilPhaseIdx: return oilPvt_->saturationPressure(regionIdx, T, BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+        case gasPhaseIdx: return gasPvt_->saturationPressure(regionIdx, T, BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
         case waterPhaseIdx: return 0.0;
         default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
@@ -1355,8 +1355,8 @@ public:
             return diffusionCoefficient(compIdx, phaseIdx, paramCache.regionIndex());
         }
 
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
 
         switch (phaseIdx) {
         case oilPhaseIdx: return oilPvt().diffusionCoefficient(T, p, compIdx);
@@ -1434,7 +1434,7 @@ std::shared_ptr<OilPvtMultiplexer<Scalar> >
 BlackOilFluidSystem<Scalar, IndexTraits>::oilPvt_;
 
 template <class Scalar, class IndexTraits>
-std::shared_ptr<Opm::GasPvtMultiplexer<Scalar> >
+std::shared_ptr<GasPvtMultiplexer<Scalar> >
 BlackOilFluidSystem<Scalar, IndexTraits>::gasPvt_;
 
 template <class Scalar, class IndexTraits>

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -60,25 +60,25 @@ template <class Scalar, class CO2Tables>
 class BrineCO2FluidSystem
     : public BaseFluidSystem<Scalar, BrineCO2FluidSystem<Scalar, CO2Tables> >
 {
-    typedef Opm::H2O<Scalar> H2O_IAPWS;
-    typedef Opm::Brine<Scalar, H2O_IAPWS> Brine_IAPWS;
-    typedef Opm::TabulatedComponent<Scalar, H2O_IAPWS> H2O_Tabulated;
-    typedef Opm::TabulatedComponent<Scalar, Brine_IAPWS> Brine_Tabulated;
+    typedef ::Opm::H2O<Scalar> H2O_IAPWS;
+    typedef ::Opm::Brine<Scalar, H2O_IAPWS> Brine_IAPWS;
+    typedef TabulatedComponent<Scalar, H2O_IAPWS> H2O_Tabulated;
+    typedef TabulatedComponent<Scalar, Brine_IAPWS> Brine_Tabulated;
 
     typedef H2O_Tabulated H2O;
 
 public:
     template <class Evaluation>
-    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    struct ParameterCache : public NullParameterCache<Evaluation>
     {};
 
     //! The type of the component for brine used by the fluid system
     typedef Brine_Tabulated Brine;
     //! The type of the component for pure CO2 used by the fluid system
-    typedef Opm::CO2<Scalar, CO2Tables> CO2;
+    typedef ::Opm::CO2<Scalar, CO2Tables> CO2;
 
     //! The binary coefficients for brine and CO2 used by this fluid system
-    typedef Opm::BinaryCoeff::Brine_CO2<Scalar, H2O, CO2> BinaryCoeffBrineCO2;
+    typedef BinaryCoeff::Brine_CO2<Scalar, H2O, CO2> BinaryCoeffBrineCO2;
 
     /****************************************
      * Fluid phase related static parameters
@@ -235,15 +235,15 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const LhsEval& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         if (phaseIdx == liquidPhaseIdx) {
             // use normalized composition for to calculate the density
             // (the relations don't seem to take non-normalized
             // compositions too well...)
-            LhsEval xlBrine = Opm::min(1.0, Opm::max(0.0, Opm::decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, BrineIdx))));
-            LhsEval xlCO2 = Opm::min(1.0, Opm::max(0.0,  Opm::decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, CO2Idx))));
+            LhsEval xlBrine = min(1.0, max(0.0, decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, BrineIdx))));
+            LhsEval xlCO2 = min(1.0, max(0.0,  decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, CO2Idx))));
             LhsEval sumx = xlBrine + xlCO2;
             xlBrine /= sumx;
             xlCO2 /= sumx;
@@ -262,8 +262,8 @@ public:
         // use normalized composition for to calculate the density
         // (the relations don't seem to take non-normalized
         // compositions too well...)
-        LhsEval xgBrine = Opm::min(1.0, Opm::max(0.0, Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, BrineIdx))));
-        LhsEval xgCO2 = Opm::min(1.0, Opm::max(0.0,  Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, CO2Idx))));
+        LhsEval xgBrine = min(1.0, max(0.0, decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, BrineIdx))));
+        LhsEval xgCO2 = min(1.0, max(0.0,  decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, CO2Idx))));
         LhsEval sumx = xgBrine + xgCO2;
         xgBrine /= sumx;
         xgCO2 /= sumx;
@@ -286,8 +286,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const LhsEval& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         if (phaseIdx == liquidPhaseIdx) {
             // assume pure brine for the liquid phase. TODO: viscosity
@@ -321,8 +321,8 @@ public:
             // as the relative fluid compositions are observed,
             return 1.0;
 
-        const LhsEval& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
         assert(temperature > 0);
         assert(pressure > 0);
 
@@ -339,8 +339,8 @@ public:
                                                     xgH2O);
 
         // normalize the phase compositions
-        xlCO2 = Opm::max(0.0, Opm::min(1.0, xlCO2));
-        xgH2O = Opm::max(0.0, Opm::min(1.0, xgH2O));
+        xlCO2 = max(0.0, min(1.0, xlCO2));
+        xgH2O = max(0.0, min(1.0, xgH2O));
 
         xlH2O = 1.0 - xlCO2;
         xgCO2 = 1.0 - xgH2O;
@@ -366,8 +366,8 @@ public:
                                         unsigned phaseIdx,
                                         unsigned /*compIdx*/)
     {
-        const LhsEval& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
         if (phaseIdx == liquidPhaseIdx)
             return BinaryCoeffBrineCO2::liquidDiffCoeff(temperature, pressure);
 
@@ -385,11 +385,11 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const LhsEval& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         if (phaseIdx == liquidPhaseIdx) {
-            const LhsEval& XlCO2 = Opm::decay<LhsEval>(fluidState.massFraction(phaseIdx, CO2Idx));
+            const LhsEval& XlCO2 = decay<LhsEval>(fluidState.massFraction(phaseIdx, CO2Idx));
             const LhsEval& result = liquidEnthalpyBrineCO2_(temperature,
                                                             pressure,
                                                             Brine_IAPWS::salinity,
@@ -398,8 +398,8 @@ public:
             return result;
         }
         else {
-            const LhsEval& XCO2 = Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, CO2Idx));
-            const LhsEval& XBrine = Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, BrineIdx));
+            const LhsEval& XCO2 = decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, CO2Idx));
+            const LhsEval& XBrine = decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, BrineIdx));
 
             LhsEval result = 0;
             result += XBrine * Brine::gasEnthalpy(temperature, pressure);
@@ -444,8 +444,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const LhsEval& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         if(phaseIdx == liquidPhaseIdx)
             return H2O::liquidHeatCapacity(temperature, pressure);
@@ -561,7 +561,7 @@ private:
         theta = T - 273.15;
 
         // Regularization
-        Scalar scalarTheta = Opm::scalarValue(theta);
+        Scalar scalarTheta = scalarValue(theta);
         Scalar S_lSAT = f[0] + scalarTheta*(f[1] + scalarTheta*(f[2] + scalarTheta*f[3]));
         if (S > S_lSAT)
             S = S_lSAT;
@@ -579,7 +579,7 @@ private:
 
         for (i = 0; i<=3; i++) {
             for (j=0; j<=2; j++) {
-                d_h = d_h + a[i][j] * Opm::pow(theta, static_cast<Scalar>(i)) * std::pow(m, j);
+                d_h = d_h + a[i][j] * pow(theta, static_cast<Scalar>(i)) * std::pow(m, j);
             }
         }
         /* heat of dissolution for halite according to Michaelides 1971 */

--- a/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
@@ -58,19 +58,19 @@ class H2OAirMesityleneFluidSystem
     typedef H2OAirMesityleneFluidSystem<Scalar> ThisType;
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
-    typedef Opm::H2O<Scalar> IapwsH2O;
-    typedef Opm::TabulatedComponent<Scalar, IapwsH2O, /*alongVaporPressure=*/false> TabulatedH2O;
+    typedef ::Opm::H2O<Scalar> IapwsH2O;
+    typedef TabulatedComponent<Scalar, IapwsH2O, /*alongVaporPressure=*/false> TabulatedH2O;
 
 public:
     template <class Evaluation>
-    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    struct ParameterCache : public NullParameterCache<Evaluation>
     {};
 
     //! The type of the mesithylene/napl component
-    typedef Opm::Mesitylene<Scalar> NAPL;
+    typedef Mesitylene<Scalar> NAPL;
 
     //! The type of the air component
-    typedef Opm::Air<Scalar> Air;
+    typedef ::Opm::Air<Scalar> Air;
 
     //! The type of the water component
     //typedef SimpleH2O H2O;
@@ -202,13 +202,13 @@ public:
                            const ParameterCache<ParamCacheEval>& /*paramCache*/,
                            unsigned phaseIdx)
     {
-        const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
 
         if (phaseIdx == waterPhaseIdx) {
             // See: Ochs 2008
             const LhsEval& p =
                 H2O::liquidIsCompressible()
-                ? Opm::decay<LhsEval>(fluidState.pressure(phaseIdx))
+                ? decay<LhsEval>(fluidState.pressure(phaseIdx))
                 : 1e30;
 
             const LhsEval& rholH2O = H2O::liquidDensity(T, p);
@@ -217,24 +217,24 @@ public:
             // this assumes each dissolved molecule displaces exactly one
             // water molecule in the liquid
             return
-                clH2O*(H2O::molarMass()*Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, H2OIdx)) +
-                       Air::molarMass()*Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, airIdx)) +
-                       NAPL::molarMass()*Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, NAPLIdx)));
+                clH2O*(H2O::molarMass()*decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, H2OIdx)) +
+                       Air::molarMass()*decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, airIdx)) +
+                       NAPL::molarMass()*decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, NAPLIdx)));
         }
         else if (phaseIdx == naplPhaseIdx) {
             // assume pure NAPL for the NAPL phase
             const LhsEval& p =
                 NAPL::liquidIsCompressible()
-                ? Opm::decay<LhsEval>(fluidState.pressure(phaseIdx))
+                ? decay<LhsEval>(fluidState.pressure(phaseIdx))
                 : 1e30;
             return NAPL::liquidDensity(T, p);
         }
 
         assert (phaseIdx == gasPhaseIdx);
-        const LhsEval& pg = Opm::decay<LhsEval>(fluidState.pressure(gasPhaseIdx));
-        const LhsEval& pH2O = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx))*pg;
-        const LhsEval& pAir = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx))*pg;
-        const LhsEval& pNAPL = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx))*pg;
+        const LhsEval& pg = decay<LhsEval>(fluidState.pressure(gasPhaseIdx));
+        const LhsEval& pH2O = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx))*pg;
+        const LhsEval& pAir = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx))*pg;
+        const LhsEval& pNAPL = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx))*pg;
         return
             H2O::gasDensity(T, pH2O) +
             Air::gasDensity(T, pAir) +
@@ -247,8 +247,8 @@ public:
                              const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
-        const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         if (phaseIdx == waterPhaseIdx) {
             // assume pure water viscosity
@@ -286,9 +286,9 @@ public:
             NAPL::molarMass()
         };
 
-        const LhsEval& xgAir = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx));
-        const LhsEval& xgH2O = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx));
-        const LhsEval& xgNapl = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx));
+        const LhsEval& xgAir = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx));
+        const LhsEval& xgH2O = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx));
+        const LhsEval& xgNapl = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx));
         const LhsEval& xgAW = xgAir + xgH2O;
         const LhsEval& muAW = (mu[airIdx]*xgAir + mu[H2OIdx]*xgH2O)/xgAW;
         const LhsEval& MAW = (xgAir*Air::molarMass() + xgH2O*H2O::molarMass())/xgAW;
@@ -314,18 +314,18 @@ public:
 #if 0
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
-        const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         LhsEval diffCont;
 
         if (phaseIdx==gasPhaseIdx) {
-            const LhsEval& diffAC = Opm::BinaryCoeff::Air_Mesitylene::gasDiffCoeff(T, p);
-            const LhsEval& diffWC = Opm::BinaryCoeff::H2O_Mesitylene::gasDiffCoeff(T, p);
-            const LhsEval& diffAW = Opm::BinaryCoeff::H2O_Air::gasDiffCoeff(T, p);
+            const LhsEval& diffAC = BinaryCoeff::Air_Mesitylene::gasDiffCoeff(T, p);
+            const LhsEval& diffWC = BinaryCoeff::H2O_Mesitylene::gasDiffCoeff(T, p);
+            const LhsEval& diffAW = BinaryCoeff::H2O_Air::gasDiffCoeff(T, p);
 
-            const LhsEval& xga = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx));
-            const LhsEval& xgw = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx));
-            const LhsEval& xgc = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx));
+            const LhsEval& xga = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx));
+            const LhsEval& xgw = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx));
+            const LhsEval& xgc = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx));
 
             if (compIdx==NAPLIdx) return (1 - xgw)/(xga/diffAW + xgc/diffWC);
             else if (compIdx==H2OIdx) return (1 - xgc)/(xgw/diffWC + xga/diffAC);
@@ -337,9 +337,9 @@ public:
             const LhsEval& diffWCl = 1.e-9; // BinaryCoeff::H2O_Mesitylene::liquidDiffCoeff(temperature, pressure);
             const LhsEval& diffAWl = 1.e-9; // BinaryCoeff::H2O_Air::liquidDiffCoeff(temperature, pressure);
 
-            const LhsEval& xwa = Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, airIdx));
-            const LhsEval& xww = Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, H2OIdx));
-            const LhsEval& xwc = Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, NAPLIdx));
+            const LhsEval& xwa = decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, airIdx));
+            const LhsEval& xww = decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, H2OIdx));
+            const LhsEval& xwc = decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, NAPLIdx));
 
             switch (compIdx) {
             case NAPLIdx:
@@ -371,8 +371,8 @@ public:
         assert(0 <= phaseIdx && phaseIdx < numPhases);
         assert(0 <= compIdx && compIdx < numComponents);
 
-        const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         Valgrind::CheckDefined(T);
         Valgrind::CheckDefined(p);
 
@@ -380,9 +380,9 @@ public:
             if (compIdx == H2OIdx)
                 return H2O::vaporPressure(T)/p;
             else if (compIdx == airIdx)
-                return Opm::BinaryCoeff::H2O_N2::henry(T)/p;
+                return BinaryCoeff::H2O_N2::henry(T)/p;
             else if (compIdx == NAPLIdx)
-                return Opm::BinaryCoeff::H2O_Mesitylene::henry(T)/p;
+                return BinaryCoeff::H2O_Mesitylene::henry(T)/p;
             assert(false);
         }
         // for the NAPL phase, we assume currently that nothing is
@@ -414,8 +414,8 @@ public:
                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
-        const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         if (phaseIdx == waterPhaseIdx) {
             return H2O::liquidEnthalpy(T, p);
@@ -426,9 +426,9 @@ public:
         else if (phaseIdx == gasPhaseIdx) {
             // gas phase enthalpy depends strongly on composition
             LhsEval result = 0;
-            result += H2O::gasEnthalpy(T, p) * Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, H2OIdx));
-            result += NAPL::gasEnthalpy(T, p) * Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, airIdx));
-            result += Air::gasEnthalpy(T, p) * Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, NAPLIdx));
+            result += H2O::gasEnthalpy(T, p) * decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, H2OIdx));
+            result += NAPL::gasEnthalpy(T, p) * decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, airIdx));
+            result += Air::gasEnthalpy(T, p) * decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, NAPLIdx));
 
             return result;
         }
@@ -444,14 +444,14 @@ public:
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
         if (phaseIdx == waterPhaseIdx){ // water phase
-            const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-            const LhsEval& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+            const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+            const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
             return H2O::liquidThermalConductivity(T, p);
         }
         else if (phaseIdx == gasPhaseIdx) { // gas phase
-            const LhsEval& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-            const LhsEval& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+            const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+            const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
             return Air::gasThermalConductivity(T, p);
         }

--- a/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
@@ -56,15 +56,15 @@ class H2OAirXyleneFluidSystem
 
 public:
     template <class Evaluation>
-    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    struct ParameterCache : public NullParameterCache<Evaluation>
     {};
 
     //! The type of the water component
-    typedef Opm::H2O<Scalar> H2O;
+    typedef ::Opm::H2O<Scalar> H2O;
     //! The type of the xylene/napl component
-    typedef Opm::Xylene<Scalar> NAPL;
+    typedef Xylene<Scalar> NAPL;
     //! The type of the air component
-    typedef Opm::Air<Scalar> Air;
+    typedef ::Opm::Air<Scalar> Air;
 
     //! \copydoc BaseFluidSystem::numPhases
     static const int numPhases = 3;
@@ -170,34 +170,34 @@ public:
                            unsigned phaseIdx)
     {
         if (phaseIdx == waterPhaseIdx) {
-            const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-            const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+            const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+            const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
             // See: Ochs 2008
             // \todo: proper citation
             const LhsEval& rholH2O = H2O::liquidDensity(T, p);
             const LhsEval& clH2O = rholH2O/H2O::molarMass();
 
-            const auto& xwH2O = Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, H2OIdx));
-            const auto& xwAir = Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, airIdx));
-            const auto& xwNapl = Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, NAPLIdx));
+            const auto& xwH2O = decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, H2OIdx));
+            const auto& xwAir = decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, airIdx));
+            const auto& xwNapl = decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, NAPLIdx));
             // this assumes each dissolved molecule displaces exactly one
             // water molecule in the liquid
             return clH2O*(H2O::molarMass()*xwH2O + Air::molarMass()*xwAir + NAPL::molarMass()*xwNapl);
         }
         else if (phaseIdx == naplPhaseIdx) {
             // assume pure NAPL for the NAPL phase
-            const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
+            const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
             return NAPL::liquidDensity(T, LhsEval(1e30));
         }
 
         assert (phaseIdx == gasPhaseIdx);
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
-        const LhsEval& pH2O = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx))*p;
-        const LhsEval& pAir = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx))*p;
-        const LhsEval& pNAPL = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx))*p;
+        const LhsEval& pH2O = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx))*p;
+        const LhsEval& pAir = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx))*p;
+        const LhsEval& pNAPL = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx))*p;
         return
             H2O::gasDensity(T, pH2O) +
             Air::gasDensity(T, pAir) +
@@ -210,8 +210,8 @@ public:
                              const ParameterCache<ParamCacheEval>& /*paramCache*/,
                              unsigned phaseIdx)
     {
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         if (phaseIdx == waterPhaseIdx) {
             // assume pure water viscosity
@@ -247,9 +247,9 @@ public:
             NAPL::molarMass()
         };
 
-        const auto& xgAir = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx));
-        const auto& xgH2O = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx));
-        const auto& xgNapl = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx));
+        const auto& xgAir = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx));
+        const auto& xgH2O = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx));
+        const auto& xgNapl = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx));
 
         const LhsEval& xgAW = xgAir + xgH2O;
         const LhsEval& muAW = (mu[airIdx]*xgAir + mu[H2OIdx]*xgH2O)/ xgAW;
@@ -274,16 +274,16 @@ public:
                                         unsigned compIdx)
     {
         if (phaseIdx==gasPhaseIdx) {
-            const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-            const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+            const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+            const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
-            const LhsEval& diffAC = Opm::BinaryCoeff::Air_Xylene::gasDiffCoeff(T, p);
-            const LhsEval& diffWC = Opm::BinaryCoeff::H2O_Xylene::gasDiffCoeff(T, p);
-            const LhsEval& diffAW = Opm::BinaryCoeff::H2O_Air::gasDiffCoeff(T, p);
+            const LhsEval& diffAC = BinaryCoeff::Air_Xylene::gasDiffCoeff(T, p);
+            const LhsEval& diffWC = BinaryCoeff::H2O_Xylene::gasDiffCoeff(T, p);
+            const LhsEval& diffAW = BinaryCoeff::H2O_Air::gasDiffCoeff(T, p);
 
-            const LhsEval& xga = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx));
-            const LhsEval& xgw = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx));
-            const LhsEval& xgc = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx));
+            const LhsEval& xga = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, airIdx));
+            const LhsEval& xgw = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx));
+            const LhsEval& xgc = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, NAPLIdx));
 
             if (compIdx==NAPLIdx) return (1.- xgw)/(xga/diffAW + xgc/diffWC);
             else if (compIdx==H2OIdx) return (1.- xgc)/(xgw/diffWC + xga/diffAC);
@@ -294,9 +294,9 @@ public:
             Scalar diffWCl = 1.e-9; // BinaryCoeff::H2O_Xylene::liquidDiffCoeff(temperature, pressure);
             Scalar diffAWl = 1.e-9; // BinaryCoeff::H2O_Air::liquidDiffCoeff(temperature, pressure);
 
-            const LhsEval& xwa = Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, airIdx));
-            const LhsEval& xww = Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, H2OIdx));
-            const LhsEval& xwc = Opm::decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, NAPLIdx));
+            const LhsEval& xwa = decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, airIdx));
+            const LhsEval& xww = decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, H2OIdx));
+            const LhsEval& xwc = decay<LhsEval>(fluidState.moleFraction(waterPhaseIdx, NAPLIdx));
 
             switch (compIdx) {
             case NAPLIdx:
@@ -325,16 +325,16 @@ public:
         assert(0 <= phaseIdx && phaseIdx < numPhases);
         assert(0 <= compIdx && compIdx < numComponents);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         if (phaseIdx == waterPhaseIdx) {
             if (compIdx == H2OIdx)
                 return H2O::vaporPressure(T)/p;
             else if (compIdx == airIdx)
-                return Opm::BinaryCoeff::H2O_Air::henry(T)/p;
+                return BinaryCoeff::H2O_Air::henry(T)/p;
             else if (compIdx == NAPLIdx)
-                return Opm::BinaryCoeff::H2O_Xylene::henry(T)/p;
+                return BinaryCoeff::H2O_Xylene::henry(T)/p;
         }
 
         // for the NAPL phase, we assume currently that nothing is
@@ -364,8 +364,8 @@ public:
                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         if (phaseIdx == waterPhaseIdx) {
             return H2O::liquidEnthalpy(T, p);
@@ -379,9 +379,9 @@ public:
             const LhsEval& hga = Air::gasEnthalpy(T, p);
 
             LhsEval result = 0;
-            result += hgw * Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, H2OIdx));
-            result += hga * Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, airIdx));
-            result += hgc * Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, NAPLIdx));
+            result += hgw * decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, H2OIdx));
+            result += hga * decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, airIdx));
+            result += hgc * decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, NAPLIdx));
 
             return result;
         }

--- a/opm/material/fluidsystems/H2ON2FluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2FluidSystem.hpp
@@ -56,10 +56,10 @@ class H2ON2FluidSystem
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
     // convenience typedefs
-    typedef Opm::IdealGas<Scalar> IdealGas;
-    typedef Opm::H2O<Scalar> IapwsH2O;
-    typedef Opm::TabulatedComponent<Scalar, IapwsH2O > TabulatedH2O;
-    typedef Opm::N2<Scalar> SimpleN2;
+    typedef ::Opm::IdealGas<Scalar> IdealGas;
+    typedef ::Opm::H2O<Scalar> IapwsH2O;
+    typedef TabulatedComponent<Scalar, IapwsH2O > TabulatedH2O;
+    typedef ::Opm::N2<Scalar> SimpleN2;
 
 public:
     //! \copydoc BaseFluidSystem::ParameterCache
@@ -264,12 +264,12 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         LhsEval sumMoleFrac = 0;
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
-            sumMoleFrac += Opm::decay<LhsEval>(fluidState.moleFraction(phaseIdx, compIdx));
+            sumMoleFrac += decay<LhsEval>(fluidState.moleFraction(phaseIdx, compIdx));
 
         // liquid phase
         if (phaseIdx == liquidPhaseIdx) {
@@ -277,8 +277,8 @@ public:
             // of whether it is water or nitrogen.
             const LhsEval& clH2O = H2O::liquidDensity(T, p)/H2O::molarMass();
 
-            const auto& xlH2O = Opm::decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, H2OIdx));
-            const auto& xlN2 = Opm::decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, N2Idx));
+            const auto& xlH2O = decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, H2OIdx));
+            const auto& xlN2 = decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, N2Idx));
 
             return clH2O*(H2O::molarMass()*xlH2O + N2::molarMass()*xlN2)/sumMoleFrac;
         }
@@ -287,11 +287,11 @@ public:
         assert(phaseIdx == gasPhaseIdx);
 
         // assume ideal mixture: steam and nitrogen don't "distinguish" each other
-        const auto& xgH2O = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx));
-        const auto& xgN2 = Opm::decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, N2Idx));
+        const auto& xgH2O = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, H2OIdx));
+        const auto& xgN2 = decay<LhsEval>(fluidState.moleFraction(gasPhaseIdx, N2Idx));
         const auto& rho_gH2O = H2O::gasDensity(T, p*xgH2O);
         const auto& rho_gN2 = N2::gasDensity(T, p*xgN2);
-        return (rho_gH2O + rho_gN2)/Opm::max(1e-5, sumMoleFrac);
+        return (rho_gH2O + rho_gN2)/max(1e-5, sumMoleFrac);
     }
 
     //! \copydoc BaseFluidSystem::viscosity
@@ -302,8 +302,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         // liquid phase
         if (phaseIdx == liquidPhaseIdx)
@@ -327,21 +327,21 @@ public:
 
         LhsEval sumx = 0.0;
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
-            sumx += Opm::decay<LhsEval>(fluidState.moleFraction(phaseIdx, compIdx));
-        sumx = Opm::max(1e-10, sumx);
+            sumx += decay<LhsEval>(fluidState.moleFraction(phaseIdx, compIdx));
+        sumx = max(1e-10, sumx);
 
         for (unsigned i = 0; i < numComponents; ++i) {
             LhsEval divisor = 0;
             for (unsigned j = 0; j < numComponents; ++j) {
-                LhsEval phiIJ = 1 + Opm::sqrt(mu[i]/mu[j]) * std::pow(molarMass(j)/molarMass(i), 1/4.0);
+                LhsEval phiIJ = 1 + sqrt(mu[i]/mu[j]) * std::pow(molarMass(j)/molarMass(i), 1/4.0);
                 phiIJ *= phiIJ;
                 phiIJ /= std::sqrt(8*(1 + molarMass(i)/molarMass(j)));
                 divisor +=
-                    Opm::decay<LhsEval>(fluidState.moleFraction(phaseIdx, j))
+                    decay<LhsEval>(fluidState.moleFraction(phaseIdx, j))
                     /sumx*phiIJ;
             }
             muResult +=
-                Opm::decay<LhsEval>(fluidState.moleFraction(phaseIdx, i))
+                decay<LhsEval>(fluidState.moleFraction(phaseIdx, i))
                 /sumx*mu[i]/divisor;
         }
         return muResult;
@@ -357,14 +357,14 @@ public:
         assert(0 <= phaseIdx && phaseIdx < numPhases);
         assert(0 <= compIdx && compIdx < numComponents);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         // liquid phase
         if (phaseIdx == liquidPhaseIdx) {
             if (compIdx == H2OIdx)
                 return H2O::vaporPressure(T)/p;
-            return Opm::BinaryCoeff::H2O_N2::henry(T)/p;
+            return BinaryCoeff::H2O_N2::henry(T)/p;
         }
 
         assert(phaseIdx == gasPhaseIdx);
@@ -382,8 +382,8 @@ public:
                                         unsigned /*compIdx*/)
 
     {
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         // liquid phase
         if (phaseIdx == liquidPhaseIdx)
@@ -400,8 +400,8 @@ public:
                             const ParameterCache<ParamCacheEval>& /*paramCache*/,
                             unsigned phaseIdx)
     {
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         Valgrind::CheckDefined(T);
         Valgrind::CheckDefined(p);
 
@@ -416,8 +416,8 @@ public:
 
         // assume ideal mixture: Molecules of one component don't discriminate between
         // their own kind and molecules of the other component.
-        const auto& XgH2O = Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, H2OIdx));
-        const auto& XgN2 = Opm::decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, N2Idx));
+        const auto& XgH2O = decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, H2OIdx));
+        const auto& XgN2 = decay<LhsEval>(fluidState.massFraction(gasPhaseIdx, N2Idx));
 
         LhsEval hH2O = XgH2O*H2O::gasEnthalpy(T, p);
         LhsEval hN2 = XgN2*N2::gasEnthalpy(T, p);
@@ -432,8 +432,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         if (phaseIdx == liquidPhaseIdx) // liquid phase
             return H2O::liquidThermalConductivity(T, p);
 
@@ -441,8 +441,8 @@ public:
         assert(phaseIdx == gasPhaseIdx);
 
         // return the sum of the partial conductivity of Nitrogen and Steam
-        const auto& xH2O = Opm::decay<LhsEval>(fluidState.moleFraction(phaseIdx, H2OIdx));
-        const auto& xN2 = Opm::decay<LhsEval>(fluidState.moleFraction(phaseIdx, N2Idx));
+        const auto& xH2O = decay<LhsEval>(fluidState.moleFraction(phaseIdx, H2OIdx));
+        const auto& xN2 = decay<LhsEval>(fluidState.moleFraction(phaseIdx, N2Idx));
 
         // Assuming Raoult's, Daltons law and ideal gas in order to obtain the
         // partial pressures in the gas phase
@@ -458,12 +458,12 @@ public:
                                 const ParameterCache<ParamCacheEval>& /*paramCache*/,
                                 unsigned phaseIdx)
     {
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const auto& xAlphaH2O = Opm::decay<LhsEval>(fluidState.moleFraction(phaseIdx, H2OIdx));
-        const auto& xAlphaN2 = Opm::decay<LhsEval>(fluidState.moleFraction(phaseIdx, N2Idx));
-        const auto& XAlphaH2O = Opm::decay<LhsEval>(fluidState.massFraction(phaseIdx, H2OIdx));
-        const auto& XAlphaN2 = Opm::decay<LhsEval>(fluidState.massFraction(phaseIdx, N2Idx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& xAlphaH2O = decay<LhsEval>(fluidState.moleFraction(phaseIdx, H2OIdx));
+        const auto& xAlphaN2 = decay<LhsEval>(fluidState.moleFraction(phaseIdx, N2Idx));
+        const auto& XAlphaH2O = decay<LhsEval>(fluidState.massFraction(phaseIdx, H2OIdx));
+        const auto& XAlphaN2 = decay<LhsEval>(fluidState.massFraction(phaseIdx, N2Idx));
 
         if (phaseIdx == liquidPhaseIdx)
             return H2O::liquidHeatCapacity(T, p);

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -57,14 +57,14 @@ class H2ON2LiquidPhaseFluidSystem
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
     // convenience typedefs
-    typedef Opm::H2O<Scalar> IapwsH2O;
-    typedef Opm::TabulatedComponent<Scalar, IapwsH2O > TabulatedH2O;
-    typedef Opm::N2<Scalar> SimpleN2;
+    typedef ::Opm::H2O<Scalar> IapwsH2O;
+    typedef ::Opm::TabulatedComponent<Scalar, IapwsH2O > TabulatedH2O;
+    typedef ::Opm::N2<Scalar> SimpleN2;
 
 public:
     //! \copydoc BaseFluidSystem::ParameterCache
     template <class Evaluation>
-    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    struct ParameterCache : public NullParameterCache<Evaluation>
     {};
 
     /****************************************
@@ -253,12 +253,12 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         LhsEval sumMoleFrac = 0;
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
-            sumMoleFrac += Opm::decay<LhsEval>(fluidState.moleFraction(phaseIdx, compIdx));
+            sumMoleFrac += decay<LhsEval>(fluidState.moleFraction(phaseIdx, compIdx));
 
         assert(phaseIdx == liquidPhaseIdx);
 
@@ -266,8 +266,8 @@ public:
         // of whether it is water or nitrogen.
         const LhsEval& clH2O = H2O::liquidDensity(T, p)/H2O::molarMass();
 
-        const auto& xlH2O = Opm::decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, H2OIdx));
-        const auto& xlN2 = Opm::decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, N2Idx));
+        const auto& xlH2O = decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, H2OIdx));
+        const auto& xlN2 = decay<LhsEval>(fluidState.moleFraction(liquidPhaseIdx, N2Idx));
 
         return clH2O*(H2O::molarMass()*xlH2O + N2::molarMass()*xlN2)/sumMoleFrac;
     }
@@ -280,8 +280,8 @@ public:
     {
         assert(phaseIdx == liquidPhaseIdx);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         // assume pure water for the liquid phase
         return H2O::liquidViscosity(T, p);
@@ -297,12 +297,12 @@ public:
         assert(phaseIdx == liquidPhaseIdx);
         assert(0 <= compIdx && compIdx < numComponents);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         if (compIdx == H2OIdx)
             return H2O::vaporPressure(T)/p;
-        return Opm::BinaryCoeff::H2O_N2::henry(T)/p;
+        return BinaryCoeff::H2O_N2::henry(T)/p;
     }
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
@@ -315,8 +315,8 @@ public:
     {
         assert(phaseIdx == liquidPhaseIdx);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         return BinaryCoeff::H2O_N2::liquidDiffCoeff(T, p);
     }
@@ -329,8 +329,8 @@ public:
     {
         assert (phaseIdx == liquidPhaseIdx);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         Valgrind::CheckDefined(T);
         Valgrind::CheckDefined(p);
 
@@ -346,8 +346,8 @@ public:
     {
         assert(phaseIdx == liquidPhaseIdx);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         return H2O::liquidThermalConductivity(T, p);
     }
 
@@ -359,8 +359,8 @@ public:
     {
         assert (phaseIdx == liquidPhaseIdx);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
 
         return H2O::liquidHeatCapacity(T, p);
     }

--- a/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
@@ -63,7 +63,7 @@ class SinglePhaseFluidSystem
 public:
     //! \copydoc BaseFluidSystem::ParameterCache
     template <class Evaluation>
-    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    struct ParameterCache : public NullParameterCache<Evaluation>
     {};
 
     /****************************************
@@ -191,8 +191,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         return Fluid::density(T, p);
     }
 
@@ -204,8 +204,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         return Fluid::viscosity(T, p);
     }
 
@@ -236,8 +236,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         return Fluid::enthalpy(T, p);
     }
 
@@ -249,8 +249,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         return Fluid::thermalConductivity(T, p);
     }
 
@@ -262,8 +262,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& T = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& p = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         return Fluid::heatCapacity(T, p);
     }
 };

--- a/opm/material/fluidsystems/Spe5FluidSystem.hpp
+++ b/opm/material/fluidsystems/Spe5FluidSystem.hpp
@@ -55,17 +55,17 @@ template <class Scalar>
 class Spe5FluidSystem
     : public BaseFluidSystem<Scalar, Spe5FluidSystem<Scalar> >
 {
-    typedef Opm::Spe5FluidSystem<Scalar> ThisType;
+    typedef Spe5FluidSystem<Scalar> ThisType;
 
-    typedef typename Opm::PengRobinsonMixture<Scalar, ThisType> PengRobinsonMixture;
-    typedef typename Opm::PengRobinson<Scalar> PengRobinson;
+    typedef typename ::Opm::PengRobinsonMixture<Scalar, ThisType> PengRobinsonMixture;
+    typedef typename ::Opm::PengRobinson<Scalar> PengRobinson;
 
     static const Scalar R;
 
 public:
     //! \copydoc BaseFluidSystem::ParameterCache
     template <class Evaluation>
-    struct ParameterCache : public Opm::Spe5ParameterCache<Evaluation, ThisType>
+    struct ParameterCache : public Spe5ParameterCache<Evaluation, ThisType>
     {};
 
     /****************************************
@@ -83,7 +83,7 @@ public:
     static const int oilPhaseIdx = 2;
 
     //! The component for pure water to be used
-    typedef Opm::H2O<Scalar> H2O;
+    typedef ::Opm::H2O<Scalar> H2O;
 
     //! \copydoc BaseFluidSystem::phaseName
     static const char* phaseName(unsigned phaseIdx)
@@ -310,7 +310,7 @@ public:
                      Scalar minP = 1e4,
                      Scalar maxP = 100e6)
     {
-        Opm::PengRobinsonParamsMixture<Scalar, ThisType, gasPhaseIdx, /*useSpe5=*/true> prParams;
+        PengRobinsonParamsMixture<Scalar, ThisType, gasPhaseIdx, /*useSpe5=*/true> prParams;
 
         // find envelopes of the 'a' and 'b' parameters for the range
         // minT <= T <= maxT and minP <= p <= maxP. For
@@ -438,7 +438,7 @@ protected:
 };
 
 template <class Scalar>
-const Scalar Spe5FluidSystem<Scalar>::R = Opm::Constants<Scalar>::R;
+const Scalar Spe5FluidSystem<Scalar>::R = Constants<Scalar>::R;
 
 } // namespace Opm
 

--- a/opm/material/fluidsystems/Spe5ParameterCache.hpp
+++ b/opm/material/fluidsystems/Spe5ParameterCache.hpp
@@ -43,12 +43,12 @@ namespace Opm {
  */
 template <class Scalar, class FluidSystem>
 class Spe5ParameterCache
-    : public Opm::ParameterCacheBase<Spe5ParameterCache<Scalar, FluidSystem> >
+    : public ParameterCacheBase<Spe5ParameterCache<Scalar, FluidSystem> >
 {
     typedef Spe5ParameterCache<Scalar, FluidSystem> ThisType;
-    typedef Opm::ParameterCacheBase<ThisType> ParentType;
+    typedef ParameterCacheBase<ThisType> ParentType;
 
-    typedef Opm::PengRobinson<Scalar> PengRobinson;
+    typedef ::Opm::PengRobinson<Scalar> PengRobinson;
 
     enum { numPhases = FluidSystem::numPhases };
 
@@ -58,9 +58,9 @@ class Spe5ParameterCache
 
 public:
     //! The cached parameters for the oil phase
-    typedef Opm::PengRobinsonParamsMixture<Scalar, FluidSystem, oilPhaseIdx, /*useSpe5=*/true> OilPhaseParams;
+    typedef PengRobinsonParamsMixture<Scalar, FluidSystem, oilPhaseIdx, /*useSpe5=*/true> OilPhaseParams;
     //! The cached parameters for the gas phase
-    typedef Opm::PengRobinsonParamsMixture<Scalar, FluidSystem, gasPhaseIdx, /*useSpe5=*/true> GasPhaseParams;
+    typedef PengRobinsonParamsMixture<Scalar, FluidSystem, gasPhaseIdx, /*useSpe5=*/true> GasPhaseParams;
 
     Spe5ParameterCache()
     {

--- a/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
+++ b/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
@@ -65,7 +65,7 @@ class TwoPhaseImmiscibleFluidSystem
 
 public:
     template <class Evaluation>
-    struct ParameterCache : public Opm::NullParameterCache<Evaluation>
+    struct ParameterCache : public NullParameterCache<Evaluation>
     {};
 
     /****************************************
@@ -227,8 +227,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
         if (phaseIdx == wettingPhaseIdx)
             return WettingPhase::density(temperature, pressure);
         return NonwettingPhase::density(temperature, pressure);
@@ -242,8 +242,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
         if (phaseIdx == wettingPhaseIdx)
             return WettingPhase::viscosity(temperature, pressure);
         return NonwettingPhase::viscosity(temperature, pressure);
@@ -276,8 +276,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
         if (phaseIdx == wettingPhaseIdx)
             return WettingPhase::enthalpy(temperature, pressure);
         return NonwettingPhase::enthalpy(temperature, pressure);
@@ -291,8 +291,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
         if (phaseIdx == wettingPhaseIdx)
             return WettingPhase::thermalConductivity(temperature, pressure);
         return NonwettingPhase::thermalConductivity(temperature, pressure);
@@ -306,8 +306,8 @@ public:
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
-        const auto& temperature = Opm::decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& pressure = Opm::decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& temperature = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const auto& pressure = decay<LhsEval>(fluidState.pressure(phaseIdx));
         if (phaseIdx == wettingPhaseIdx)
             return WettingPhase::heatCapacity(temperature, pressure);
         return NonwettingPhase::heatCapacity(temperature, pressure);

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -58,24 +58,24 @@ class BrineCo2Pvt
 {
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
-    //typedef Opm::H2O<Scalar> H2O_IAPWS;
-    //typedef Opm::Brine<Scalar, H2O_IAPWS> Brine_IAPWS;
-    //typedef Opm::TabulatedComponent<Scalar, H2O_IAPWS> H2O_Tabulated;
-    //typedef Opm::TabulatedComponent<Scalar, Brine_IAPWS> Brine_Tabulated;
+    //typedef H2O<Scalar> H2O_IAPWS;
+    //typedef Brine<Scalar, H2O_IAPWS> Brine_IAPWS;
+    //typedef TabulatedComponent<Scalar, H2O_IAPWS> H2O_Tabulated;
+    //typedef TabulatedComponent<Scalar, Brine_IAPWS> Brine_Tabulated;
 
     //typedef H2O_Tabulated H2O;
     //typedef Brine_Tabulated Brine;
 
 
 public:
-    typedef Opm::SimpleHuDuanH2O<Scalar> H2O;
-    typedef Opm::Brine<Scalar, H2O> Brine;
-    typedef Opm::CO2<Scalar, CO2Tables> CO2;
+    typedef SimpleHuDuanH2O<Scalar> H2O;
+    typedef ::Opm::Brine<Scalar, H2O> Brine;
+    typedef ::Opm::CO2<Scalar, CO2Tables> CO2;
 
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
 
     //! The binary coefficients for brine and CO2 used by this fluid system
-    typedef Opm::BinaryCoeff::Brine_CO2<Scalar, H2O, CO2> BinaryCoeffBrineCO2;
+    typedef BinaryCoeff::Brine_CO2<Scalar, H2O, CO2> BinaryCoeffBrineCO2;
 
     explicit BrineCo2Pvt() = default;
     BrineCo2Pvt(const std::vector<Scalar>& brineReferenceDensity,
@@ -288,9 +288,9 @@ public:
         //Diffusion coefficient of CO2 in the brine phase modified following (Ratcliff and Holdcroft,1963 and Al-Rawajfeh, 2004)
         const Evaluation& mu_H20 = H2O::liquidViscosity(temperature, pressure); // Water viscosity
         const Evaluation& mu_Brine = Brine::liquidViscosity(temperature, pressure); // Brine viscosity
-        const Evaluation log_D_Brine = log_D_H20 - 0.87*Opm::log10(mu_Brine / mu_H20);
+        const Evaluation log_D_Brine = log_D_H20 - 0.87*log10(mu_Brine / mu_H20);
 
-        return Opm::pow(Evaluation(10), log_D_Brine) * 1e-4; // convert from cm2/s to m2/s
+        return pow(Evaluation(10), log_D_Brine) * 1e-4; // convert from cm2/s to m2/s
     }
 
 private:
@@ -438,7 +438,7 @@ private:
                                                     xgH2O);
 
         // normalize the phase compositions
-        xlCO2 = Opm::max(0.0, Opm::min(1.0, xlCO2));
+        xlCO2 = max(0.0, min(1.0, xlCO2));
 
         return convertXoGToRs(convertxoGToXoG(xlCO2), regionIdx);
     }
@@ -474,7 +474,7 @@ private:
         theta = T - 273.15;
 
         // Regularization
-        Scalar scalarTheta = Opm::scalarValue(theta);
+        Scalar scalarTheta = scalarValue(theta);
         Scalar S_lSAT = f[0] + scalarTheta*(f[1] + scalarTheta*(f[2] + scalarTheta*f[3]));
         if (S > S_lSAT)
             S = S_lSAT;
@@ -492,7 +492,7 @@ private:
 
         for (i = 0; i<=3; i++) {
             for (j=0; j<=2; j++) {
-                d_h = d_h + a[i][j] * Opm::pow(theta, static_cast<Scalar>(i)) * std::pow(m, j);
+                d_h = d_h + a[i][j] * pow(theta, static_cast<Scalar>(i)) * std::pow(m, j);
             }
         }
         /* heat of dissolution for halite according to Michaelides 1971 */

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -53,14 +53,14 @@ template <class Scalar>
 class Co2GasPvt
 {
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
-    typedef Opm::CO2<Scalar, CO2Tables> CO2;
-    typedef Opm::SimpleHuDuanH2O<Scalar> H2O;
+    typedef ::Opm::CO2<Scalar, CO2Tables> CO2;
+    typedef SimpleHuDuanH2O<Scalar> H2O;
 
 public:
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
 
     //! The binary coefficients for brine and CO2 used by this fluid system
-    typedef Opm::BinaryCoeff::Brine_CO2<Scalar, H2O, CO2> BinaryCoeffBrineCO2;
+    typedef BinaryCoeff::Brine_CO2<Scalar, H2O, CO2> BinaryCoeffBrineCO2;
 
     explicit Co2GasPvt() = default;
     Co2GasPvt(const std::vector<Scalar>& gasReferenceDensity)

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
@@ -48,7 +48,7 @@ template <class Scalar>
 class ConstantCompressibilityBrinePvt
 {
 public:
-    typedef typename Opm::Tabulated1DFunction<Scalar> TabulatedFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedFunction;
 
     ConstantCompressibilityBrinePvt() = default;
     ConstantCompressibilityBrinePvt(const std::vector<Scalar>& waterReferenceDensity,

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -45,7 +45,7 @@ namespace Opm {
 template <class Scalar>
 class ConstantCompressibilityOilPvt
 {
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
 public:

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -43,7 +43,7 @@ namespace Opm {
 template <class Scalar>
 class ConstantCompressibilityWaterPvt
 {
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
 public:

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -48,7 +48,7 @@ class DeadOilPvt
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
 public:
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
 
     DeadOilPvt() = default;
     DeadOilPvt(const std::vector<Scalar>& oilReferenceDensity,

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -51,7 +51,7 @@ class DryGasPvt
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
 public:
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
 
     explicit DryGasPvt() = default;
     DryGasPvt(const std::vector<Scalar>& gasReferenceDensity,
@@ -91,7 +91,7 @@ public:
             Scalar p = 1.01325e5; // surface pressure, [Pa]
             Scalar T = 273.15 + 15.56; // surface temperature, [K]
             Scalar MO = 175e-3; // [kg/mol]
-            Scalar MG = Opm::Constants<Scalar>::R*T*rhoRefG / p; // [kg/mol], consequence of the ideal gas law
+            Scalar MG = Constants<Scalar>::R*T*rhoRefG / p; // [kg/mol], consequence of the ideal gas law
             Scalar MW = 18.0e-3; // [kg/mol]
             // TODO (?): the molar mass of the components can possibly specified
             // explicitly in the deck.

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -152,19 +152,19 @@ public:
     {
         switch (gasPvtAppr) {
         case GasPvtApproach::DryGasPvt:
-            realGasPvt_ = new Opm::DryGasPvt<Scalar>;
+            realGasPvt_ = new DryGasPvt<Scalar>;
             break;
 
         case GasPvtApproach::WetGasPvt:
-            realGasPvt_ = new Opm::WetGasPvt<Scalar>;
+            realGasPvt_ = new WetGasPvt<Scalar>;
             break;
 
         case GasPvtApproach::ThermalGasPvt:
-            realGasPvt_ = new Opm::GasPvtThermal<Scalar>;
+            realGasPvt_ = new GasPvtThermal<Scalar>;
             break;
 
         case GasPvtApproach::Co2GasPvt:
-            realGasPvt_ = new Opm::Co2GasPvt<Scalar>;
+            realGasPvt_ = new Co2GasPvt<Scalar>;
             break;
 
         case GasPvtApproach::NoGasPvt:
@@ -290,61 +290,61 @@ public:
 
     // get the parameter object for the dry gas case
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::DryGasPvt, Opm::DryGasPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == GasPvtApproach::DryGasPvt, DryGasPvt<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
-        return *static_cast<Opm::DryGasPvt<Scalar>* >(realGasPvt_);
+        return *static_cast<DryGasPvt<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::DryGasPvt, const Opm::DryGasPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == GasPvtApproach::DryGasPvt, const DryGasPvt<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
-        return *static_cast<const Opm::DryGasPvt<Scalar>* >(realGasPvt_);
+        return *static_cast<const DryGasPvt<Scalar>* >(realGasPvt_);
     }
 
     // get the parameter object for the wet gas case
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::WetGasPvt, Opm::WetGasPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == GasPvtApproach::WetGasPvt, WetGasPvt<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
-        return *static_cast<Opm::WetGasPvt<Scalar>* >(realGasPvt_);
+        return *static_cast<WetGasPvt<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::WetGasPvt, const Opm::WetGasPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == GasPvtApproach::WetGasPvt, const WetGasPvt<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
-        return *static_cast<const Opm::WetGasPvt<Scalar>* >(realGasPvt_);
+        return *static_cast<const WetGasPvt<Scalar>* >(realGasPvt_);
     }
 
     // get the parameter object for the thermal gas case
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::ThermalGasPvt, Opm::GasPvtThermal<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == GasPvtApproach::ThermalGasPvt, GasPvtThermal<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
-        return *static_cast<Opm::GasPvtThermal<Scalar>* >(realGasPvt_);
+        return *static_cast<GasPvtThermal<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::ThermalGasPvt, const Opm::GasPvtThermal<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == GasPvtApproach::ThermalGasPvt, const GasPvtThermal<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
-        return *static_cast<const Opm::GasPvtThermal<Scalar>* >(realGasPvt_);
+        return *static_cast<const GasPvtThermal<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::Co2GasPvt, Opm::Co2GasPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == GasPvtApproach::Co2GasPvt, Co2GasPvt<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
-        return *static_cast<Opm::Co2GasPvt<Scalar>* >(realGasPvt_);
+        return *static_cast<Co2GasPvt<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::Co2GasPvt, const Opm::Co2GasPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == GasPvtApproach::Co2GasPvt, const Co2GasPvt<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
-        return *static_cast<const Opm::Co2GasPvt<Scalar>* >(realGasPvt_);
+        return *static_cast<const Co2GasPvt<Scalar>* >(realGasPvt_);
     }
 
     const void* realGasPvt() const { return realGasPvt_; }
@@ -356,17 +356,17 @@ public:
 
         switch (gasPvtApproach_) {
         case GasPvtApproach::DryGasPvt:
-            return *static_cast<const Opm::DryGasPvt<Scalar>*>(realGasPvt_) ==
-                   *static_cast<const Opm::DryGasPvt<Scalar>*>(data.realGasPvt_);
+            return *static_cast<const DryGasPvt<Scalar>*>(realGasPvt_) ==
+                   *static_cast<const DryGasPvt<Scalar>*>(data.realGasPvt_);
         case GasPvtApproach::WetGasPvt:
-            return *static_cast<const Opm::WetGasPvt<Scalar>*>(realGasPvt_) ==
-                   *static_cast<const Opm::WetGasPvt<Scalar>*>(data.realGasPvt_);
+            return *static_cast<const WetGasPvt<Scalar>*>(realGasPvt_) ==
+                   *static_cast<const WetGasPvt<Scalar>*>(data.realGasPvt_);
         case GasPvtApproach::ThermalGasPvt:
-            return *static_cast<const Opm::GasPvtThermal<Scalar>*>(realGasPvt_) ==
-                   *static_cast<const Opm::GasPvtThermal<Scalar>*>(data.realGasPvt_);
+            return *static_cast<const GasPvtThermal<Scalar>*>(realGasPvt_) ==
+                   *static_cast<const GasPvtThermal<Scalar>*>(data.realGasPvt_);
         case GasPvtApproach::Co2GasPvt:
-            return *static_cast<const Opm::Co2GasPvt<Scalar>*>(realGasPvt_) ==
-                    *static_cast<const Opm::Co2GasPvt<Scalar>*>(data.realGasPvt_);
+            return *static_cast<const Co2GasPvt<Scalar>*>(realGasPvt_) ==
+                    *static_cast<const Co2GasPvt<Scalar>*>(data.realGasPvt_);
         default:
             return true;
         }
@@ -377,16 +377,16 @@ public:
         gasPvtApproach_ = data.gasPvtApproach_;
         switch (gasPvtApproach_) {
         case GasPvtApproach::DryGasPvt:
-            realGasPvt_ = new Opm::DryGasPvt<Scalar>(*static_cast<const Opm::DryGasPvt<Scalar>*>(data.realGasPvt_));
+            realGasPvt_ = new DryGasPvt<Scalar>(*static_cast<const DryGasPvt<Scalar>*>(data.realGasPvt_));
             break;
         case GasPvtApproach::WetGasPvt:
-            realGasPvt_ = new Opm::WetGasPvt<Scalar>(*static_cast<const Opm::WetGasPvt<Scalar>*>(data.realGasPvt_));
+            realGasPvt_ = new WetGasPvt<Scalar>(*static_cast<const WetGasPvt<Scalar>*>(data.realGasPvt_));
             break;
         case GasPvtApproach::ThermalGasPvt:
-            realGasPvt_ = new Opm::GasPvtThermal<Scalar>(*static_cast<const Opm::GasPvtThermal<Scalar>*>(data.realGasPvt_));
+            realGasPvt_ = new GasPvtThermal<Scalar>(*static_cast<const GasPvtThermal<Scalar>*>(data.realGasPvt_));
             break;
         case GasPvtApproach::Co2GasPvt:
-            realGasPvt_ = new Opm::Co2GasPvt<Scalar>(*static_cast<const Opm::Co2GasPvt<Scalar>*>(data.realGasPvt_));
+            realGasPvt_ = new Co2GasPvt<Scalar>(*static_cast<const Co2GasPvt<Scalar>*>(data.realGasPvt_));
             break;
         default:
             break;

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -85,8 +85,6 @@ template <class Scalar, bool enableThermal = true>
 class GasPvtMultiplexer
 {
 public:
-    typedef Opm::GasPvtThermal<Scalar> GasPvtThermal;
-
     GasPvtMultiplexer()
     {
         gasPvtApproach_ = GasPvtApproach::NoGasPvt;

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -55,7 +55,7 @@ class GasPvtThermal
 {
 public:
     typedef GasPvtMultiplexer<Scalar, /*enableThermal=*/false> IsothermalPvt;
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
 
     GasPvtThermal()
     {

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -54,8 +54,8 @@ class LiveOilPvt
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
 public:
-    typedef Opm::UniformXTabulated2DFunction<Scalar> TabulatedTwoDFunction;
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef UniformXTabulated2DFunction<Scalar> TabulatedTwoDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
 
     LiveOilPvt()
     {
@@ -531,11 +531,11 @@ public:
 
         // apply the vaporization parameters for the gas phase (cf. the Eclipse VAPPARS
         // keyword)
-        maxOilSaturation = Opm::min(maxOilSaturation, Scalar(1.0));
+        maxOilSaturation = min(maxOilSaturation, Scalar(1.0));
         if (vapPar2_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
             static const Scalar eps = 0.001;
-            const Evaluation& So = Opm::max(oilSaturation, eps);
-            tmp *= Opm::max(1e-3, Opm::pow(So/maxOilSaturation, vapPar2_));
+            const Evaluation& So = max(oilSaturation, eps);
+            tmp *= max(1e-3, pow(So/maxOilSaturation, vapPar2_));
         }
 
         return tmp;
@@ -552,7 +552,7 @@ public:
                                   const Evaluation& temperature OPM_UNUSED,
                                   const Evaluation& Rs) const
     {
-        typedef Opm::MathToolbox<Evaluation> Toolbox;
+        typedef MathToolbox<Evaluation> Toolbox;
 
         const auto& RsTable = saturatedGasDissolutionFactorTable_[regionIdx];
         const Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon()*1e6;
@@ -570,7 +570,7 @@ public:
 
             // If the derivative is "zero" Newton will not converge,
             // so simply return our initial guess.
-            if (std::abs(Opm::scalarValue(fPrime)) < 1.0e-30) {
+            if (std::abs(scalarValue(fPrime)) < 1.0e-30) {
                 return pSat;
             }
 
@@ -588,7 +588,7 @@ public:
                 pSat = 0.0;
             }
 
-            if (std::abs(Opm::scalarValue(delta)) < std::abs(Opm::scalarValue(pSat))*eps)
+            if (std::abs(scalarValue(delta)) < std::abs(scalarValue(pSat))*eps)
                 return pSat;
         }
 

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -39,36 +39,45 @@
 #endif
 
 namespace Opm {
-#define OPM_OIL_PVT_MULTIPLEXER_CALL(codeToCall)                        \
-    switch (approach_) {                                                \
-    case ConstantCompressibilityOilPvt: {                               \
-        auto& pvtImpl = getRealPvt<ConstantCompressibilityOilPvt>();    \
-        codeToCall;                                                     \
-        break;                                                          \
-    }                                                                   \
-    case DeadOilPvt: {                                                  \
-        auto& pvtImpl = getRealPvt<DeadOilPvt>();                       \
-        codeToCall;                                                     \
-        break;                                                          \
-    }                                                                   \
-    case LiveOilPvt: {                                                  \
-        auto& pvtImpl = getRealPvt<LiveOilPvt>();                       \
-        codeToCall;                                                     \
-        break;                                                          \
-    }                                                                   \
-    case ThermalOilPvt: {                                               \
-        auto& pvtImpl = getRealPvt<ThermalOilPvt>();                    \
-        codeToCall;                                                     \
-        break;                                                          \
-    }                                                                   \
-    case BrineCo2Pvt: {                                                 \
-        auto& pvtImpl = getRealPvt<BrineCo2Pvt>();                      \
-        codeToCall;                                                     \
-        break;                                                          \
-    }                                                                   \
-    case NoOilPvt:                                                      \
-        throw std::logic_error("Not implemented: Oil PVT of this deck!"); \
-    }                                                                     \
+#define OPM_OIL_PVT_MULTIPLEXER_CALL(codeToCall)                                     \
+    switch (approach_) {                                                             \
+    case OilPvtApproach::ConstantCompressibilityOilPvt: {                            \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::ConstantCompressibilityOilPvt>(); \
+        codeToCall;                                                                  \
+        break;                                                                       \
+    }                                                                                \
+    case OilPvtApproach::DeadOilPvt: {                                               \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::DeadOilPvt>();                    \
+        codeToCall;                                                                  \
+        break;                                                                       \
+    }                                                                                \
+    case OilPvtApproach::LiveOilPvt: {                                               \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::LiveOilPvt>();                    \
+        codeToCall;                                                                  \
+        break;                                                                       \
+    }                                                                                \
+    case OilPvtApproach::ThermalOilPvt: {                                            \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::ThermalOilPvt>();                 \
+        codeToCall;                                                                  \
+        break;                                                                       \
+    }                                                                                \
+    case OilPvtApproach::BrineCo2Pvt: {                                              \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::BrineCo2Pvt>();                   \
+        codeToCall;                                                                  \
+        break;                                                                       \
+    }                                                                                \
+    case OilPvtApproach::NoOilPvt:                                                   \
+        throw std::logic_error("Not implemented: Oil PVT of this deck!");            \
+    }                                                                                \
+
+enum class OilPvtApproach {
+    NoOilPvt,
+    LiveOilPvt,
+    DeadOilPvt,
+    ConstantCompressibilityOilPvt,
+    ThermalOilPvt,
+    BrineCo2Pvt
+};
 
 /*!
  * \brief This class represents the Pressure-Volume-Temperature relations of the oil
@@ -88,18 +97,9 @@ class OilPvtMultiplexer
 public:
     typedef Opm::OilPvtThermal<Scalar> OilPvtThermal;
 
-    enum OilPvtApproach {
-        NoOilPvt,
-        LiveOilPvt,
-        DeadOilPvt,
-        ConstantCompressibilityOilPvt,
-        ThermalOilPvt,
-        BrineCo2Pvt
-    };
-
     OilPvtMultiplexer()
     {
-        approach_ = NoOilPvt;
+        approach_ = OilPvtApproach::NoOilPvt;
         realOilPvt_ = nullptr;
     }
 
@@ -116,28 +116,28 @@ public:
     ~OilPvtMultiplexer()
     {
         switch (approach_) {
-        case LiveOilPvt: {
-            delete &getRealPvt<LiveOilPvt>();
+        case OilPvtApproach::LiveOilPvt: {
+            delete &getRealPvt<OilPvtApproach::LiveOilPvt>();
             break;
         }
-        case DeadOilPvt: {
-            delete &getRealPvt<DeadOilPvt>();
+        case OilPvtApproach::DeadOilPvt: {
+            delete &getRealPvt<OilPvtApproach::DeadOilPvt>();
             break;
         }
-        case ConstantCompressibilityOilPvt: {
-            delete &getRealPvt<ConstantCompressibilityOilPvt>();
+        case OilPvtApproach::ConstantCompressibilityOilPvt: {
+            delete &getRealPvt<OilPvtApproach::ConstantCompressibilityOilPvt>();
             break;
         }
-        case ThermalOilPvt: {
-            delete &getRealPvt<ThermalOilPvt>();
+        case OilPvtApproach::ThermalOilPvt: {
+            delete &getRealPvt<OilPvtApproach::ThermalOilPvt>();
             break;
         }
-        case BrineCo2Pvt: {
-            delete &getRealPvt<BrineCo2Pvt>();
+        case OilPvtApproach::BrineCo2Pvt: {
+            delete &getRealPvt<OilPvtApproach::BrineCo2Pvt>();
             break;
         }
 
-        case NoOilPvt:
+        case OilPvtApproach::NoOilPvt:
             break;
         }
     }
@@ -155,15 +155,15 @@ public:
         // TODO move the BrineCo2 approach to the waterPvtMultiplexer
         // when a proper gas-water simulator is supported
         if (eclState.runspec().co2Storage())
-            setApproach(BrineCo2Pvt);
+            setApproach(OilPvtApproach::BrineCo2Pvt);
         else if (enableThermal && eclState.getSimulationConfig().isThermal())
-            setApproach(ThermalOilPvt);
+            setApproach(OilPvtApproach::ThermalOilPvt);
         else if (!eclState.getTableManager().getPvcdoTable().empty())
-            setApproach(ConstantCompressibilityOilPvt);
+            setApproach(OilPvtApproach::ConstantCompressibilityOilPvt);
         else if (eclState.getTableManager().hasTables("PVDO"))
-            setApproach(DeadOilPvt);
+            setApproach(OilPvtApproach::DeadOilPvt);
         else if (!eclState.getTableManager().getPvtoTables().empty())
-            setApproach(LiveOilPvt);
+            setApproach(OilPvtApproach::LiveOilPvt);
 
         OPM_OIL_PVT_MULTIPLEXER_CALL(pvtImpl.initFromState(eclState, schedule));
     }
@@ -280,27 +280,27 @@ public:
     void setApproach(OilPvtApproach appr)
     {
         switch (appr) {
-        case LiveOilPvt:
+        case OilPvtApproach::LiveOilPvt:
             realOilPvt_ = new Opm::LiveOilPvt<Scalar>;
             break;
 
-        case DeadOilPvt:
+        case OilPvtApproach::DeadOilPvt:
             realOilPvt_ = new Opm::DeadOilPvt<Scalar>;
             break;
 
-        case ConstantCompressibilityOilPvt:
+        case OilPvtApproach::ConstantCompressibilityOilPvt:
             realOilPvt_ = new Opm::ConstantCompressibilityOilPvt<Scalar>;
             break;
 
-        case ThermalOilPvt:
+        case OilPvtApproach::ThermalOilPvt:
             realOilPvt_ = new Opm::OilPvtThermal<Scalar>;
             break;
 
-        case BrineCo2Pvt:
+        case OilPvtApproach::BrineCo2Pvt:
             realOilPvt_ = new Opm::BrineCo2Pvt<Scalar>;
             break;
 
-        case NoOilPvt:
+        case OilPvtApproach::NoOilPvt:
             throw std::logic_error("Not implemented: Oil PVT of this deck!");
         }
 
@@ -317,70 +317,70 @@ public:
 
     // get the concrete parameter object for the oil phase
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == LiveOilPvt, Opm::LiveOilPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::LiveOilPvt, Opm::LiveOilPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<Opm::LiveOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == LiveOilPvt, const Opm::LiveOilPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::LiveOilPvt, const Opm::LiveOilPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<Opm::LiveOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == DeadOilPvt, Opm::DeadOilPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::DeadOilPvt, Opm::DeadOilPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<Opm::DeadOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == DeadOilPvt, const Opm::DeadOilPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::DeadOilPvt, const Opm::DeadOilPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<Opm::DeadOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == ConstantCompressibilityOilPvt, Opm::ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::ConstantCompressibilityOilPvt, Opm::ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<Opm::ConstantCompressibilityOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == ConstantCompressibilityOilPvt, const Opm::ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::ConstantCompressibilityOilPvt, const Opm::ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<Opm::ConstantCompressibilityOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == ThermalOilPvt, Opm::OilPvtThermal<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::ThermalOilPvt, Opm::OilPvtThermal<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<Opm::OilPvtThermal<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == ThermalOilPvt, const Opm::OilPvtThermal<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::ThermalOilPvt, const Opm::OilPvtThermal<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<const Opm::OilPvtThermal<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == BrineCo2Pvt, Opm::BrineCo2Pvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::BrineCo2Pvt, Opm::BrineCo2Pvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<Opm::BrineCo2Pvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == BrineCo2Pvt, const Opm::BrineCo2Pvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::BrineCo2Pvt, const Opm::BrineCo2Pvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<const Opm::BrineCo2Pvt<Scalar>* >(realOilPvt_);
@@ -394,19 +394,19 @@ public:
             return false;
 
         switch (approach_) {
-        case ConstantCompressibilityOilPvt:
+        case OilPvtApproach::ConstantCompressibilityOilPvt:
             return *static_cast<const Opm::ConstantCompressibilityOilPvt<Scalar>*>(realOilPvt_) ==
                    *static_cast<const Opm::ConstantCompressibilityOilPvt<Scalar>*>(data.realOilPvt_);
-        case DeadOilPvt:
+        case OilPvtApproach::DeadOilPvt:
             return *static_cast<const Opm::DeadOilPvt<Scalar>*>(realOilPvt_) ==
                    *static_cast<const Opm::DeadOilPvt<Scalar>*>(data.realOilPvt_);
-        case LiveOilPvt:
+        case OilPvtApproach::LiveOilPvt:
             return *static_cast<const Opm::LiveOilPvt<Scalar>*>(realOilPvt_) ==
                    *static_cast<const Opm::LiveOilPvt<Scalar>*>(data.realOilPvt_);
-        case ThermalOilPvt:
+        case OilPvtApproach::ThermalOilPvt:
             return *static_cast<const Opm::OilPvtThermal<Scalar>*>(realOilPvt_) ==
                    *static_cast<const Opm::OilPvtThermal<Scalar>*>(data.realOilPvt_);
-        case BrineCo2Pvt:
+        case OilPvtApproach::BrineCo2Pvt:
             return *static_cast<const Opm::BrineCo2Pvt<Scalar>*>(realOilPvt_) ==
                     *static_cast<const Opm::BrineCo2Pvt<Scalar>*>(data.realOilPvt_);
         default:
@@ -418,19 +418,19 @@ public:
     {
         approach_ = data.approach_;
         switch (approach_) {
-        case ConstantCompressibilityOilPvt:
+        case OilPvtApproach::ConstantCompressibilityOilPvt:
             realOilPvt_ = new Opm::ConstantCompressibilityOilPvt<Scalar>(*static_cast<const Opm::ConstantCompressibilityOilPvt<Scalar>*>(data.realOilPvt_));
             break;
-        case DeadOilPvt:
+        case OilPvtApproach::DeadOilPvt:
             realOilPvt_ = new Opm::DeadOilPvt<Scalar>(*static_cast<const Opm::DeadOilPvt<Scalar>*>(data.realOilPvt_));
             break;
-        case LiveOilPvt:
+        case OilPvtApproach::LiveOilPvt:
             realOilPvt_ = new Opm::LiveOilPvt<Scalar>(*static_cast<const Opm::LiveOilPvt<Scalar>*>(data.realOilPvt_));
             break;
-        case ThermalOilPvt:
+        case OilPvtApproach::ThermalOilPvt:
             realOilPvt_ = new Opm::OilPvtThermal<Scalar>(*static_cast<const Opm::OilPvtThermal<Scalar>*>(data.realOilPvt_));
             break;
-        case BrineCo2Pvt:
+        case OilPvtApproach::BrineCo2Pvt:
             realOilPvt_ = new Opm::BrineCo2Pvt<Scalar>(*static_cast<const Opm::BrineCo2Pvt<Scalar>*>(data.realOilPvt_));
             break;
         default:

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -279,23 +279,23 @@ public:
     {
         switch (appr) {
         case OilPvtApproach::LiveOilPvt:
-            realOilPvt_ = new Opm::LiveOilPvt<Scalar>;
+            realOilPvt_ = new LiveOilPvt<Scalar>;
             break;
 
         case OilPvtApproach::DeadOilPvt:
-            realOilPvt_ = new Opm::DeadOilPvt<Scalar>;
+            realOilPvt_ = new DeadOilPvt<Scalar>;
             break;
 
         case OilPvtApproach::ConstantCompressibilityOilPvt:
-            realOilPvt_ = new Opm::ConstantCompressibilityOilPvt<Scalar>;
+            realOilPvt_ = new ConstantCompressibilityOilPvt<Scalar>;
             break;
 
         case OilPvtApproach::ThermalOilPvt:
-            realOilPvt_ = new Opm::OilPvtThermal<Scalar>;
+            realOilPvt_ = new OilPvtThermal<Scalar>;
             break;
 
         case OilPvtApproach::BrineCo2Pvt:
-            realOilPvt_ = new Opm::BrineCo2Pvt<Scalar>;
+            realOilPvt_ = new BrineCo2Pvt<Scalar>;
             break;
 
         case OilPvtApproach::NoOilPvt:
@@ -315,73 +315,73 @@ public:
 
     // get the concrete parameter object for the oil phase
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::LiveOilPvt, Opm::LiveOilPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::LiveOilPvt, LiveOilPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::LiveOilPvt<Scalar>* >(realOilPvt_);
+        return *static_cast<LiveOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::LiveOilPvt, const Opm::LiveOilPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::LiveOilPvt, const LiveOilPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::LiveOilPvt<Scalar>* >(realOilPvt_);
+        return *static_cast<LiveOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::DeadOilPvt, Opm::DeadOilPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::DeadOilPvt, DeadOilPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::DeadOilPvt<Scalar>* >(realOilPvt_);
+        return *static_cast<DeadOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::DeadOilPvt, const Opm::DeadOilPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::DeadOilPvt, const DeadOilPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::DeadOilPvt<Scalar>* >(realOilPvt_);
+        return *static_cast<DeadOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::ConstantCompressibilityOilPvt, Opm::ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::ConstantCompressibilityOilPvt, ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::ConstantCompressibilityOilPvt<Scalar>* >(realOilPvt_);
+        return *static_cast<ConstantCompressibilityOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::ConstantCompressibilityOilPvt, const Opm::ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::ConstantCompressibilityOilPvt, const ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::ConstantCompressibilityOilPvt<Scalar>* >(realOilPvt_);
+        return *static_cast<ConstantCompressibilityOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::ThermalOilPvt, Opm::OilPvtThermal<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::ThermalOilPvt, OilPvtThermal<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::OilPvtThermal<Scalar>* >(realOilPvt_);
+        return *static_cast<OilPvtThermal<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::ThermalOilPvt, const Opm::OilPvtThermal<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::ThermalOilPvt, const OilPvtThermal<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
-        return *static_cast<const Opm::OilPvtThermal<Scalar>* >(realOilPvt_);
+        return *static_cast<const OilPvtThermal<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::BrineCo2Pvt, Opm::BrineCo2Pvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::BrineCo2Pvt, BrineCo2Pvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::BrineCo2Pvt<Scalar>* >(realOilPvt_);
+        return *static_cast<BrineCo2Pvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::BrineCo2Pvt, const Opm::BrineCo2Pvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::BrineCo2Pvt, const BrineCo2Pvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
-        return *static_cast<const Opm::BrineCo2Pvt<Scalar>* >(realOilPvt_);
+        return *static_cast<const BrineCo2Pvt<Scalar>* >(realOilPvt_);
     }
 
     const void* realOilPvt() const { return realOilPvt_; }
@@ -393,20 +393,20 @@ public:
 
         switch (approach_) {
         case OilPvtApproach::ConstantCompressibilityOilPvt:
-            return *static_cast<const Opm::ConstantCompressibilityOilPvt<Scalar>*>(realOilPvt_) ==
-                   *static_cast<const Opm::ConstantCompressibilityOilPvt<Scalar>*>(data.realOilPvt_);
+            return *static_cast<const ConstantCompressibilityOilPvt<Scalar>*>(realOilPvt_) ==
+                   *static_cast<const ConstantCompressibilityOilPvt<Scalar>*>(data.realOilPvt_);
         case OilPvtApproach::DeadOilPvt:
-            return *static_cast<const Opm::DeadOilPvt<Scalar>*>(realOilPvt_) ==
-                   *static_cast<const Opm::DeadOilPvt<Scalar>*>(data.realOilPvt_);
+            return *static_cast<const DeadOilPvt<Scalar>*>(realOilPvt_) ==
+                   *static_cast<const DeadOilPvt<Scalar>*>(data.realOilPvt_);
         case OilPvtApproach::LiveOilPvt:
-            return *static_cast<const Opm::LiveOilPvt<Scalar>*>(realOilPvt_) ==
-                   *static_cast<const Opm::LiveOilPvt<Scalar>*>(data.realOilPvt_);
+            return *static_cast<const LiveOilPvt<Scalar>*>(realOilPvt_) ==
+                   *static_cast<const LiveOilPvt<Scalar>*>(data.realOilPvt_);
         case OilPvtApproach::ThermalOilPvt:
-            return *static_cast<const Opm::OilPvtThermal<Scalar>*>(realOilPvt_) ==
-                   *static_cast<const Opm::OilPvtThermal<Scalar>*>(data.realOilPvt_);
+            return *static_cast<const OilPvtThermal<Scalar>*>(realOilPvt_) ==
+                   *static_cast<const OilPvtThermal<Scalar>*>(data.realOilPvt_);
         case OilPvtApproach::BrineCo2Pvt:
-            return *static_cast<const Opm::BrineCo2Pvt<Scalar>*>(realOilPvt_) ==
-                    *static_cast<const Opm::BrineCo2Pvt<Scalar>*>(data.realOilPvt_);
+            return *static_cast<const BrineCo2Pvt<Scalar>*>(realOilPvt_) ==
+                    *static_cast<const BrineCo2Pvt<Scalar>*>(data.realOilPvt_);
         default:
             return true;
         }
@@ -417,19 +417,19 @@ public:
         approach_ = data.approach_;
         switch (approach_) {
         case OilPvtApproach::ConstantCompressibilityOilPvt:
-            realOilPvt_ = new Opm::ConstantCompressibilityOilPvt<Scalar>(*static_cast<const Opm::ConstantCompressibilityOilPvt<Scalar>*>(data.realOilPvt_));
+            realOilPvt_ = new ConstantCompressibilityOilPvt<Scalar>(*static_cast<const ConstantCompressibilityOilPvt<Scalar>*>(data.realOilPvt_));
             break;
         case OilPvtApproach::DeadOilPvt:
-            realOilPvt_ = new Opm::DeadOilPvt<Scalar>(*static_cast<const Opm::DeadOilPvt<Scalar>*>(data.realOilPvt_));
+            realOilPvt_ = new DeadOilPvt<Scalar>(*static_cast<const DeadOilPvt<Scalar>*>(data.realOilPvt_));
             break;
         case OilPvtApproach::LiveOilPvt:
-            realOilPvt_ = new Opm::LiveOilPvt<Scalar>(*static_cast<const Opm::LiveOilPvt<Scalar>*>(data.realOilPvt_));
+            realOilPvt_ = new LiveOilPvt<Scalar>(*static_cast<const LiveOilPvt<Scalar>*>(data.realOilPvt_));
             break;
         case OilPvtApproach::ThermalOilPvt:
-            realOilPvt_ = new Opm::OilPvtThermal<Scalar>(*static_cast<const Opm::OilPvtThermal<Scalar>*>(data.realOilPvt_));
+            realOilPvt_ = new OilPvtThermal<Scalar>(*static_cast<const OilPvtThermal<Scalar>*>(data.realOilPvt_));
             break;
         case OilPvtApproach::BrineCo2Pvt:
-            realOilPvt_ = new Opm::BrineCo2Pvt<Scalar>(*static_cast<const Opm::BrineCo2Pvt<Scalar>*>(data.realOilPvt_));
+            realOilPvt_ = new BrineCo2Pvt<Scalar>(*static_cast<const BrineCo2Pvt<Scalar>*>(data.realOilPvt_));
             break;
         default:
             break;

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -95,8 +95,6 @@ template <class Scalar, bool enableThermal = true>
 class OilPvtMultiplexer
 {
 public:
-    typedef Opm::OilPvtThermal<Scalar> OilPvtThermal;
-
     OilPvtMultiplexer()
     {
         approach_ = OilPvtApproach::NoOilPvt;

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -54,7 +54,7 @@ template <class Scalar>
 class OilPvtThermal
 {
 public:
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
     typedef OilPvtMultiplexer<Scalar, /*enableThermal=*/false> IsothermalPvt;
 
     OilPvtThermal()

--- a/opm/material/fluidsystems/blackoilpvt/SolventPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/SolventPvt.hpp
@@ -51,7 +51,7 @@ class SolventPvt
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
 public:
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
 
     explicit SolventPvt() = default;
     SolventPvt(const std::vector<Scalar>& solventReferenceDensity,

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -185,15 +185,15 @@ public:
     {
         switch (appr) {
         case WaterPvtApproach::ConstantCompressibilityWaterPvt:
-            realWaterPvt_ = new Opm::ConstantCompressibilityWaterPvt<Scalar>;
+            realWaterPvt_ = new ConstantCompressibilityWaterPvt<Scalar>;
             break;
 
         case WaterPvtApproach::ConstantCompressibilityBrinePvt:
-            realWaterPvt_ = new Opm::ConstantCompressibilityBrinePvt<Scalar>;
+            realWaterPvt_ = new ConstantCompressibilityBrinePvt<Scalar>;
             break;
 
         case WaterPvtApproach::ThermalWaterPvt:
-            realWaterPvt_ = new Opm::WaterPvtThermal<Scalar>;
+            realWaterPvt_ = new WaterPvtThermal<Scalar>;
             break;
 
         case WaterPvtApproach::NoWaterPvt:
@@ -213,45 +213,45 @@ public:
 
     // get the concrete parameter object for the water phase
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityWaterPvt, Opm::ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityWaterPvt, ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::ConstantCompressibilityWaterPvt<Scalar>* >(realWaterPvt_);
+        return *static_cast<ConstantCompressibilityWaterPvt<Scalar>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityWaterPvt, const Opm::ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityWaterPvt, const ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::ConstantCompressibilityWaterPvt<Scalar>* >(realWaterPvt_);
+        return *static_cast<ConstantCompressibilityWaterPvt<Scalar>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityBrinePvt, Opm::ConstantCompressibilityBrinePvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityBrinePvt, ConstantCompressibilityBrinePvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::ConstantCompressibilityBrinePvt<Scalar>* >(realWaterPvt_);
+        return *static_cast<ConstantCompressibilityBrinePvt<Scalar>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityBrinePvt, const Opm::ConstantCompressibilityBrinePvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityBrinePvt, const ConstantCompressibilityBrinePvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::ConstantCompressibilityBrinePvt<Scalar>* >(realWaterPvt_);
+        return *static_cast<ConstantCompressibilityBrinePvt<Scalar>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ThermalWaterPvt, Opm::WaterPvtThermal<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == WaterPvtApproach::ThermalWaterPvt, WaterPvtThermal<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::WaterPvtThermal<Scalar>* >(realWaterPvt_);
+        return *static_cast<WaterPvtThermal<Scalar>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ThermalWaterPvt, const Opm::WaterPvtThermal<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == WaterPvtApproach::ThermalWaterPvt, const WaterPvtThermal<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
-        return *static_cast<Opm::WaterPvtThermal<Scalar>* >(realWaterPvt_);
+        return *static_cast<WaterPvtThermal<Scalar>* >(realWaterPvt_);
     }
 
     const void* realWaterPvt() const { return realWaterPvt_; }
@@ -263,14 +263,14 @@ public:
 
         switch (approach_) {
         case WaterPvtApproach::ConstantCompressibilityWaterPvt:
-            return *static_cast<const Opm::ConstantCompressibilityWaterPvt<Scalar>*>(realWaterPvt_) ==
-                   *static_cast<const Opm::ConstantCompressibilityWaterPvt<Scalar>*>(data.realWaterPvt_);
+            return *static_cast<const ConstantCompressibilityWaterPvt<Scalar>*>(realWaterPvt_) ==
+                   *static_cast<const ConstantCompressibilityWaterPvt<Scalar>*>(data.realWaterPvt_);
         case WaterPvtApproach::ConstantCompressibilityBrinePvt:
-            return *static_cast<const Opm::ConstantCompressibilityBrinePvt<Scalar>*>(realWaterPvt_) ==
-                   *static_cast<const Opm::ConstantCompressibilityBrinePvt<Scalar>*>(data.realWaterPvt_);
+            return *static_cast<const ConstantCompressibilityBrinePvt<Scalar>*>(realWaterPvt_) ==
+                   *static_cast<const ConstantCompressibilityBrinePvt<Scalar>*>(data.realWaterPvt_);
         case WaterPvtApproach::ThermalWaterPvt:
-            return *static_cast<const Opm::WaterPvtThermal<Scalar>*>(realWaterPvt_) ==
-                   *static_cast<const Opm::WaterPvtThermal<Scalar>*>(data.realWaterPvt_);
+            return *static_cast<const WaterPvtThermal<Scalar>*>(realWaterPvt_) ==
+                   *static_cast<const WaterPvtThermal<Scalar>*>(data.realWaterPvt_);
         default:
             return true;
         }
@@ -281,13 +281,13 @@ public:
         approach_ = data.approach_;
         switch (approach_) {
         case WaterPvtApproach::ConstantCompressibilityWaterPvt:
-            realWaterPvt_ = new Opm::ConstantCompressibilityWaterPvt<Scalar>(*static_cast<const Opm::ConstantCompressibilityWaterPvt<Scalar>*>(data.realWaterPvt_));
+            realWaterPvt_ = new ConstantCompressibilityWaterPvt<Scalar>(*static_cast<const ConstantCompressibilityWaterPvt<Scalar>*>(data.realWaterPvt_));
             break;
         case WaterPvtApproach::ConstantCompressibilityBrinePvt:
-            realWaterPvt_ = new Opm::ConstantCompressibilityBrinePvt<Scalar>(*static_cast<const Opm::ConstantCompressibilityBrinePvt<Scalar>*>(data.realWaterPvt_));
+            realWaterPvt_ = new ConstantCompressibilityBrinePvt<Scalar>(*static_cast<const ConstantCompressibilityBrinePvt<Scalar>*>(data.realWaterPvt_));
             break;
         case WaterPvtApproach::ThermalWaterPvt:
-            realWaterPvt_ = new Opm::WaterPvtThermal<Scalar>(*static_cast<const Opm::WaterPvtThermal<Scalar>*>(data.realWaterPvt_));
+            realWaterPvt_ = new WaterPvtThermal<Scalar>(*static_cast<const WaterPvtThermal<Scalar>*>(data.realWaterPvt_));
             break;
         default:
             break;

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -74,8 +74,6 @@ template <class Scalar, bool enableThermal = true, bool enableBrine = true>
 class WaterPvtMultiplexer
 {
 public:
-    typedef Opm::WaterPvtThermal<Scalar> WaterPvtThermal;
-
     WaterPvtMultiplexer()
     {
         approach_ = WaterPvtApproach::NoWaterPvt;

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -54,7 +54,7 @@ template <class Scalar>
 class WaterPvtThermal
 {
 public:
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
     typedef WaterPvtMultiplexer<Scalar, /*enableThermal=*/false, false> IsothermalPvt;
 
     WaterPvtThermal()

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -50,8 +50,8 @@ class WetGasPvt
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
 public:
-    typedef Opm::UniformXTabulated2DFunction<Scalar> TabulatedTwoDFunction;
-    typedef Opm::Tabulated1DFunction<Scalar> TabulatedOneDFunction;
+    typedef UniformXTabulated2DFunction<Scalar> TabulatedTwoDFunction;
+    typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
 
     WetGasPvt()
     {
@@ -553,11 +553,11 @@ public:
 
         // apply the vaporization parameters for the gas phase (cf. the Eclipse VAPPARS
         // keyword)
-        maxOilSaturation = Opm::min(maxOilSaturation, Scalar(1.0));
+        maxOilSaturation = min(maxOilSaturation, Scalar(1.0));
         if (vapPar1_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
             static const Scalar eps = 0.001;
-            const Evaluation& So = Opm::max(oilSaturation, eps);
-            tmp *= Opm::max(1e-3, Opm::pow(So/maxOilSaturation, vapPar1_));
+            const Evaluation& So = max(oilSaturation, eps);
+            tmp *= max(1e-3, pow(So/maxOilSaturation, vapPar1_));
         }
 
         return tmp;
@@ -578,7 +578,7 @@ public:
                                   const Evaluation& temperature OPM_UNUSED,
                                   const Evaluation& Rv) const
     {
-        typedef Opm::MathToolbox<Evaluation> Toolbox;
+        typedef MathToolbox<Evaluation> Toolbox;
 
         const auto& RvTable = saturatedOilVaporizationFactorTable_[regionIdx];
         const Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon()*1e6;
@@ -596,7 +596,7 @@ public:
 
             // If the derivative is "zero" Newton will not converge,
             // so simply return our initial guess.
-            if (std::abs(Opm::scalarValue(fPrime)) < 1.0e-30) {
+            if (std::abs(scalarValue(fPrime)) < 1.0e-30) {
                 return pSat;
             }
 
@@ -614,7 +614,7 @@ public:
                 pSat = 0.0;
             }
 
-            if (std::abs(Opm::scalarValue(delta)) < std::abs(Opm::scalarValue(pSat))*eps)
+            if (std::abs(scalarValue(delta)) < std::abs(scalarValue(pSat))*eps)
                 return pSat;
         }
 

--- a/opm/material/thermal/SomertonThermalConductionLaw.hpp
+++ b/opm/material/thermal/SomertonThermalConductionLaw.hpp
@@ -97,9 +97,9 @@ public:
             Valgrind::CheckDefined(params.fullySaturatedLambda(phaseIdx));
 
             if (FluidSystem::isLiquid(phaseIdx)) {
-                const auto& sat = Opm::decay<Evaluation>(fluidState.saturation(phaseIdx));
+                const auto& sat = decay<Evaluation>(fluidState.saturation(phaseIdx));
                 lambda +=
-                    regularizedSqrt_(Opm::max(0.0, Opm::min(1.0, sat)))
+                    regularizedSqrt_(max(0.0, min(1.0, sat)))
                     * (params.fullySaturatedLambda(phaseIdx) - params.vacuumLambda());
             }
             else { // gas phase
@@ -116,7 +116,7 @@ protected:
     template <class Evaluation>
     static Evaluation regularizedSqrt_(const Evaluation& x)
     {
-        typedef Opm::Spline<Scalar> Spline;
+        typedef Spline<Scalar> Spline;
 
         static const Scalar xMin = 1e-2;
         static const Scalar sqrtXMin = std::sqrt(xMin);
@@ -127,7 +127,7 @@ protected:
                                           fPrime0, fPrimeXMin); // m0, m1
 
         if (x > xMin)
-            return Opm::sqrt(x);
+            return sqrt(x);
         else if (x <= 0)
             return fPrime0 * x;
         else


### PR DESCRIPTION
have to use anchoring to root namespace in some places due
to overlapping namespace and class type names.

while at it fix some annoying issues in the pvt multiplexer classes.