### PR TITLE
Extrapolate for values not in domain (UniformTabulated2DFunction).

### DIFF
--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -198,7 +198,6 @@ public:
     template <class Evaluation>
     Evaluation eval(const Evaluation& x, const Evaluation& y) const
     {
-#ifndef NDEBUG
         if (!applies(x,y))
         {
             std::string msg = "Attempt to get tabulated value for ("
@@ -216,7 +215,6 @@ public:
                 OpmLog::warning("PVT Table evaluation:" + msg + ". Will use extrapolation");
             }
         };
-#endif
 
         Evaluation alpha = xToI(x);
         Evaluation beta = yToJ(y);

--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -297,7 +297,7 @@ private:
 };
 
 template<class Scalar>
-bool UniformTabulated2DFunction<Scalar>::throwUntabulated = false;
+bool UniformTabulated2DFunction<Scalar>::throwUntabulated = true;
 } // namespace Opm
 
 #endif

--- a/opm/material/components/CO2.hpp
+++ b/opm/material/components/CO2.hpp
@@ -52,7 +52,6 @@ template <class Scalar, class CO2Tables>
 class CO2 : public Component<Scalar, CO2<Scalar, CO2Tables> >
 {
     static const Scalar R;
-    static bool warningPrinted;
 
 public:
     /*!
@@ -261,8 +260,6 @@ public:
     }
 };
 
-template <class Scalar, class CO2Tables>
-bool CO2<Scalar, CO2Tables>::warningPrinted = false;
 
 template <class Scalar, class CO2Tables>
 const Scalar CO2<Scalar, CO2Tables>::R = Constants<Scalar>::R;


### PR DESCRIPTION
In the current code the interpolation actually already works if the values are outside of the tabulated region.

With this change there is now a static variable throwUntabulated (default: false) that we can set in opm-simulators. If it is false we will interpolate for every value instead of throwing and aborting (was the case always before).