### PR TITLE
extrapolate co2, brine and h2O properties only when called via CO2STORE  module

### DIFF
--- a/opm/material/components/Brine.hpp
+++ b/opm/material/components/Brine.hpp
@@ -247,12 +247,12 @@ public:
      * - cited by: Adams & Bachu in Geofluids (2002) 2, 257-271
      */
     template <class Evaluation>
-    static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure, bool extrapolate = false)
     {
         Evaluation tempC = temperature - 273.15;
         Evaluation pMPa = pressure/1.0E6;
 
-        const Evaluation rhow = H2O::liquidDensity(temperature, pressure, true);
+        const Evaluation rhow = H2O::liquidDensity(temperature, pressure, extrapolate);
         return
             rhow +
             1000*salinity*(

--- a/opm/material/components/CO2.hpp
+++ b/opm/material/components/CO2.hpp
@@ -162,10 +162,10 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& temperature,
-                                  const Evaluation& pressure)
+                                  const Evaluation& pressure,
+                                  bool extrapolate = false)
     {
-        return CO2Tables::tabulatedEnthalpy.eval(temperature, pressure,
-                                                 /* extrapolate = */ true);
+        return CO2Tables::tabulatedEnthalpy.eval(temperature, pressure, extrapolate);
     }
 
     /*!
@@ -173,10 +173,11 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasInternalEnergy(const Evaluation& temperature,
-                                        const Evaluation& pressure)
+                                        const Evaluation& pressure,
+                                        bool extrapolate = false)
     {
-        const Evaluation& h = gasEnthalpy(temperature, pressure);
-        const Evaluation& rho = gasDensity(temperature, pressure);
+        const Evaluation& h = gasEnthalpy(temperature, pressure, extrapolate);
+        const Evaluation& rho = gasDensity(temperature, pressure, extrapolate);
 
         return h - (pressure / rho);
     }
@@ -185,10 +186,11 @@ public:
      * \brief The density of CO2 at a given pressure and temperature [kg/m^3].
      */
     template <class Evaluation>
-    static Evaluation gasDensity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation gasDensity(const Evaluation& temperature,
+                                 const Evaluation& pressure,
+                                 bool extrapolate = false)
     {
-        return CO2Tables::tabulatedDensity.eval(temperature, pressure,
-                                                /* extrapolate = */ true);
+        return CO2Tables::tabulatedDensity.eval(temperature, pressure, extrapolate);
     }
 
     /*!
@@ -198,7 +200,9 @@ public:
      *                        - Fenhour etl al., 1998
      */
     template <class Evaluation>
-    static Evaluation gasViscosity(Evaluation temperature, const Evaluation& pressure)
+    static Evaluation gasViscosity(Evaluation temperature,
+                                   const Evaluation& pressure,
+                                   bool extrapolate = false)
     {
         const Scalar a0 = 0.235156;
         const Scalar a1 = -0.491266;
@@ -224,7 +228,7 @@ public:
 
         Evaluation mu0 = 1.00697*sqrt(temperature) / SigmaStar;
 
-        const Evaluation& rho = gasDensity(temperature, pressure); // CO2 mass density [kg/m^3]
+        const Evaluation& rho = gasDensity(temperature, pressure, extrapolate); // CO2 mass density [kg/m^3]
 
         // dmu : excess viscosity at elevated density
         Evaluation dmu =

--- a/opm/material/components/H2O.hpp
+++ b/opm/material/components/H2O.hpp
@@ -689,9 +689,11 @@ public:
      * \param pressure Phase pressure in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure, bool = false)
+    static Evaluation liquidDensity(const Evaluation& temperature,
+                                    const Evaluation& pressure,
+                                    bool extrapolate = false)
     {
-        if (!Region1::isValid(temperature, pressure))
+        if (!extrapolate && !Region1::isValid(temperature, pressure))
         {
             std::ostringstream oss;
             oss << "Density of water is only implemented for temperatures below 623.15K and "
@@ -817,9 +819,11 @@ public:
      * \param pressure Phase pressure in \f$\mathrm{[Pa]}\f$
      */
     template <class Evaluation>
-    static Evaluation liquidViscosity(const Evaluation& temperature, const Evaluation& pressure)
+    static Evaluation liquidViscosity(const Evaluation& temperature,
+                                      const Evaluation& pressure,
+                                      bool extrapolate = false)
     {
-        if (!Region1::isValid(temperature, pressure))
+        if (!extrapolate && !Region1::isValid(temperature, pressure))
         {
             std::ostringstream oss;
             oss << "Viscosity of water is only implemented for temperatures below 623.15K and "
@@ -827,7 +831,7 @@ public:
             throw NumericalIssue(oss.str());
         };
 
-        const Evaluation& rho = liquidDensity(temperature, pressure);
+        const Evaluation& rho = liquidDensity(temperature, pressure, extrapolate);
         return Common::viscosity(temperature, rho);
     }
 

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -55,6 +55,7 @@ class Co2GasPvt
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
     typedef ::Opm::CO2<Scalar, CO2Tables> CO2;
     typedef SimpleHuDuanH2O<Scalar> H2O;
+    static const bool extrapolate = true;
 
 public:
     typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
@@ -89,7 +90,7 @@ public:
         size_t regionIdx = 0;
         Scalar T_ref = eclState.getTableManager().stCond().temperature;
         Scalar P_ref = eclState.getTableManager().stCond().pressure;
-        gasReferenceDensity_[regionIdx] = CO2::gasDensity(T_ref, P_ref);
+        gasReferenceDensity_[regionIdx] = CO2::gasDensity(T_ref, P_ref, extrapolate);
         initEnd();
     }
 #endif
@@ -134,7 +135,7 @@ public:
                         const Evaluation& pressure,
                         const Evaluation&) const
     {
-        return CO2::gasInternalEnergy(temperature, pressure);
+        return CO2::gasInternalEnergy(temperature, pressure, extrapolate);
     }
 
     /*!
@@ -155,7 +156,7 @@ public:
                                   const Evaluation& temperature,
                                   const Evaluation& pressure) const
     {
-        return CO2::gasViscosity(temperature, pressure);
+        return CO2::gasViscosity(temperature, pressure, extrapolate);
     }
 
     /*!
@@ -176,7 +177,7 @@ public:
                                                      const Evaluation& temperature,
                                                      const Evaluation& pressure) const
     {
-        return CO2::gasDensity(temperature, pressure)/gasReferenceDensity_[regionIdx];
+        return CO2::gasDensity(temperature, pressure, extrapolate)/gasReferenceDensity_[regionIdx];
     }
 
     /*!


### PR DESCRIPTION
This will leave the behavior unchanged for other co2-brine usage in opm-models.  