### PR TITLE
Explicitly check for a == b before creating scale_factor = a/b

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -482,7 +482,15 @@ private:
             return unscaledPcnw*alpha;
         }
         else if (params.config().enablePcScaling()) {
-            Scalar alpha = params.scaledPoints().maxPcnw()/params.unscaledPoints().maxPcnw();
+            const auto& scaled_maxPcnw = params.scaledPoints().maxPcnw();
+            const auto& unscaled_maxPcnw = params.unscaledPoints().maxPcnw();
+
+            Scalar alpha;
+            if (scaled_maxPcnw == unscaled_maxPcnw)
+                alpha = 1.0;
+            else
+                alpha = params.scaledPoints().maxPcnw()/params.unscaledPoints().maxPcnw();
+
             return unscaledPcnw*alpha;
         }
 
@@ -497,7 +505,15 @@ private:
             return scaledPcnw/alpha;
         }
         else if (params.config().enablePcScaling()) {
-            Scalar alpha = params.unscaledPoints().maxPcnw()/params.scaledPoints().maxPcnw();
+            const auto& scaled_maxPcnw = params.scaledPoints().maxPcnw();
+            const auto& unscaled_maxPcnw = params.unscaledPoints().maxPcnw();
+
+            Scalar alpha;
+            if (scaled_maxPcnw == unscaled_maxPcnw)
+                alpha = 1.0;
+            else
+                alpha = params.scaledPoints().maxPcnw()/params.unscaledPoints().maxPcnw();
+
             return scaledPcnw/alpha;
         }
 


### PR DESCRIPTION
We have a case where the run halts with the following [assert](https://github.com/OPM/opm-simulators/blob/master/ebos/equil/equilibrationhelpers.hh#L834):
```C++
const PcEq<FluidSystem, MaterialLaw, MaterialLawManager> f(materialLawManager, phase, cell, targetPc);
double f0 = f(s0);
double f1 = f(s1);
if (f0 <= 0.0)
    return s0;
else if (f1 >= 0.0)
    return s1;
assert(f0 > 0 && f1 < 0);
```
the seemingly impossible assert triggers because `f0` and `f1` are both `nan`. The `nan` comes about due to the scaling function `EclEpsTwoPhaseLaw::unscaledToScaledPcnw_()` where the offending code is essentially:
```C++
double scaled_value = 0;
double unscaled_value = 0;
double alpha = scaled_value / unscaled_value;
```
The "fix" in this PR just recognizes the situation where `scaled_value == unsaled_value` and uses the value `alpha = 1` without actually evaluating the fraction. That is obviously a symptom fix, but I do not know enough about the domain here to evaluate whether there is an underlying bug to address here. For all it is worth this PR is enough to get the model to run through.