### PR TITLE
changed: avoid long vectors of shared ptrs

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
@@ -106,8 +106,8 @@ public:
     /*!
      * \brief Set the scaling points which are seen by the physical model
      */
-    void setScaledPoints(std::shared_ptr<ScalingPoints> value)
-    { scaledPoints_ = *value; }
+    void setScaledPoints(const ScalingPoints& value)
+    { scaledPoints_ = value; }
 
     /*!
      * \brief Returns the scaling points which are seen by the physical model

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -101,12 +101,9 @@ public:
     /*!
      * \brief Sets the parameters used for the drainage curve
      */
-    void setDrainageParams(std::shared_ptr<EffLawParams> value,
-                           const EclEpsScalingPointsInfo<Scalar>& /* info */,
-                           EclTwoPhaseSystemType /* twoPhaseSystem */)
-
+    void setDrainageParams(const EffLawParams& value)
     {
-        drainageParams_ = *value;
+        drainageParams_ = value;
     }
 
     /*!
@@ -121,11 +118,11 @@ public:
     /*!
      * \brief Sets the parameters used for the imbibition curve
      */
-    void setImbibitionParams(std::shared_ptr<EffLawParams> value,
+    void setImbibitionParams(const EffLawParams& value,
                              const EclEpsScalingPointsInfo<Scalar>& /* info */,
                              EclTwoPhaseSystemType /* twoPhaseSystem */)
     {
-        imbibitionParams_ = *value;
+        imbibitionParams_ = value;
 
 /*
         if (twoPhaseSystem == EclGasOilSystem) {

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -118,7 +118,7 @@ private:
     typedef std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar> > > GasOilScalingPointsVector;
     typedef std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar> > > OilWaterScalingPointsVector;
     typedef std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar> > > GasWaterScalingPointsVector;
-    typedef std::vector<std::shared_ptr<EclEpsScalingPointsInfo<Scalar> > > OilWaterScalingInfoVector;
+    typedef std::vector<EclEpsScalingPointsInfo<Scalar>> OilWaterScalingInfoVector;
     typedef std::vector<std::shared_ptr<GasOilTwoPhaseHystParams> > GasOilParamVector;
     typedef std::vector<std::shared_ptr<OilWaterTwoPhaseHystParams> > OilWaterParamVector;
     typedef std::vector<std::shared_ptr<GasWaterTwoPhaseHystParams> > GasWaterParamVector;
@@ -272,8 +272,7 @@ public:
                                   epsGridProperties,
                                   elemIdx,
                                   EclOilWaterSystem);
-            oilWaterScaledEpsInfoDrainage_[elemIdx] =
-                std::make_shared<EclEpsScalingPointsInfo<Scalar>>(owinfo);
+            oilWaterScaledEpsInfoDrainage_[elemIdx] = owinfo;
 
             auto [gasWaterScaledInfo, gasWaterScaledPoint] =
                 readScaledPoints_(*gasWaterConfig,
@@ -392,7 +391,7 @@ public:
             initThreePhaseParams_(eclState,
                                   *materialLawParams_[elemIdx],
                                   satRegionIdx,
-                                  *oilWaterScaledEpsInfoDrainage_[elemIdx],
+                                  oilWaterScaledEpsInfoDrainage_[elemIdx],
                                   oilWaterParams,
                                   gasOilParams,
                                   gasWaterParams);
@@ -414,7 +413,7 @@ public:
                          Scalar pcow,
                          Scalar Sw)
     {
-        auto& elemScaledEpsInfo = *oilWaterScaledEpsInfoDrainage_[elemIdx];
+        auto& elemScaledEpsInfo = oilWaterScaledEpsInfoDrainage_[elemIdx];
 
         // TODO: Mixed wettability systems - see ecl kw OPTIONS switch 74
 
@@ -660,9 +659,6 @@ public:
     }
 
     const EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(size_t elemIdx) const
-    { return *oilWaterScaledEpsInfoDrainage_[elemIdx]; }
-
-    std::shared_ptr<EclEpsScalingPointsInfo<Scalar> >& oilWaterScaledEpsInfoDrainagePointerReferenceHack(unsigned elemIdx)
     { return oilWaterScaledEpsInfoDrainage_[elemIdx]; }
 
 private:

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -118,9 +118,7 @@ private:
     typedef std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar> > > GasOilScalingPointsVector;
     typedef std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar> > > OilWaterScalingPointsVector;
     typedef std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar> > > GasWaterScalingPointsVector;
-    typedef std::vector<std::shared_ptr<EclEpsScalingPointsInfo<Scalar> > > GasOilScalingInfoVector;
     typedef std::vector<std::shared_ptr<EclEpsScalingPointsInfo<Scalar> > > OilWaterScalingInfoVector;
-    typedef std::vector<std::shared_ptr<EclEpsScalingPointsInfo<Scalar> > > GasWaterScalingInfoVector;
     typedef std::vector<std::shared_ptr<GasOilTwoPhaseHystParams> > GasOilParamVector;
     typedef std::vector<std::shared_ptr<OilWaterTwoPhaseHystParams> > OilWaterParamVector;
     typedef std::vector<std::shared_ptr<GasWaterTwoPhaseHystParams> > GasWaterParamVector;
@@ -1102,7 +1100,6 @@ private:
     OilWaterScalingInfoVector oilWaterScaledEpsInfoDrainage_;
 
     std::shared_ptr<EclEpsConfig> gasWaterEclEpsConfig_;
-    GasWaterScalingInfoVector gasWaterScaledEpsInfoDrainage_;
 
     GasOilScalingPointsVector gasOilUnscaledPointsVector_;
     OilWaterScalingPointsVector oilWaterUnscaledPointsVector_;

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -360,7 +360,7 @@ public:
 
                     oilWaterParams->setImbibitionParams(oilWaterImbParamsHyst,
                                                         gasOilScaledImbInfo,
-                                                        EclGasOilSystem);
+                                                        EclOilWaterSystem);
                 }
 
                 if (hasGas && hasWater && !hasOil) {

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -386,17 +386,15 @@ public:
             if (hasGas && hasWater && !hasOil)
                 gasWaterParams->finalize();
 
-            materialLawParams_[elemIdx] = std::make_shared<MaterialLawParams>();
-
             initThreePhaseParams_(eclState,
-                                  *materialLawParams_[elemIdx],
+                                  materialLawParams_[elemIdx],
                                   satRegionIdx,
                                   oilWaterScaledEpsInfoDrainage_[elemIdx],
                                   oilWaterParams,
                                   gasOilParams,
                                   gasWaterParams);
 
-            materialLawParams_[elemIdx]->finalize();
+            materialLawParams_[elemIdx].finalize();
         }
     }
 
@@ -466,13 +464,13 @@ public:
     MaterialLawParams& materialLawParams(unsigned elemIdx)
     {
         assert(elemIdx <  materialLawParams_.size());
-        return *materialLawParams_[elemIdx];
+        return materialLawParams_[elemIdx];
     }
 
     const MaterialLawParams& materialLawParams(unsigned elemIdx) const
     {
         assert(elemIdx <  materialLawParams_.size());
-        return *materialLawParams_[elemIdx];
+        return materialLawParams_[elemIdx];
     }
 
     /*!
@@ -485,7 +483,7 @@ public:
      */
     const MaterialLawParams& connectionMaterialLawParams(unsigned satRegionIdx, unsigned elemIdx) const
     {
-        MaterialLawParams& mlp = *materialLawParams_[elemIdx];
+        MaterialLawParams& mlp = const_cast<MaterialLawParams&>(materialLawParams_[elemIdx]);
 
 #if HAVE_OPM_COMMON
         if (enableHysteresis())
@@ -582,8 +580,7 @@ public:
         if (!enableHysteresis())
             return;
 
-        auto threePhaseParams = materialLawParams_[elemIdx];
-        MaterialLaw::updateHysteresis(*threePhaseParams, fluidState);
+        MaterialLaw::updateHysteresis(materialLawParams_[elemIdx], fluidState);
     }
 
     void oilWaterHysteresisParams(Scalar& pcSwMdc,
@@ -632,7 +629,7 @@ public:
 
     EclEpsScalingPoints<Scalar>& oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
     {
-        auto& materialParams = *materialLawParams_[elemIdx];
+        auto& materialParams = materialLawParams_[elemIdx];
         switch (materialParams.approach()) {
         case EclMultiplexerApproach::EclStone1Approach: {
             auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::EclStone1Approach>();
@@ -1109,7 +1106,7 @@ private:
     // this attribute only makes sense for twophase simulations!
     enum EclTwoPhaseApproach twoPhaseApproach_ = EclTwoPhaseApproach::EclTwoPhaseGasOil;
 
-    std::vector<std::shared_ptr<MaterialLawParams> > materialLawParams_;
+    std::vector<MaterialLawParams> materialLawParams_;
 
     std::vector<int> satnumRegionArray_;
     std::vector<int> imbnumRegionArray_;


### PR DESCRIPTION
this use a lot of memory with many elements.

For a case I'm looking at this brought memory usage down from
58.9GB (61GB peak) to 47.3GB (which is also the peak).