### PR TITLE
Adding PVT for gas without oil-vapor (dry) and  with vaporized water (humid)

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -800,6 +800,7 @@ public:
                     bg*referenceDensity(gasPhaseIdx, regionIdx)
                     + Rv*bg*referenceDensity(oilPhaseIdx, regionIdx);
             }
+            //PJPE: need to consider water evaporization
 
             // immiscible gas
             const LhsEval Rv(0.0);
@@ -1111,6 +1112,31 @@ public:
         }
 
         throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+    }
+
+    /*!
+     * \brief Returns the water vaporization factor \f$R_\alpha\f$ of saturated phase
+     *
+     * For the gas phase, this means the R_vw factor, for the water and oil phase,
+     * it is always 0.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    static LhsEval saturatedWaterVaporationFactor(const FluidState& fluidState,
+                                              unsigned phaseIdx,
+                                              unsigned regionIdx)
+    {
+        assert(phaseIdx <= numPhases);
+        assert(regionIdx <= numRegions());
+
+        const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+
+        switch (phaseIdx) {
+        case oilPhaseIdx: return 0.0;
+        case gasPhaseIdx: return gasPvt_->saturatedWaterVaporizationFactor(regionIdx, T, p);
+        case waterPhaseIdx: return 0.0;
+        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        }
     }
 
     /*!

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -738,6 +738,16 @@ public:
                     bg*referenceDensity(gasPhaseIdx, regionIdx)
                     + Rv*bg*referenceDensity(oilPhaseIdx, regionIdx);
             }
+            //vaporized oil simultaneous with vaporized water is not yet supported
+            if (enableVaporizedWater()) {
+                // gas containing vaporized water
+                const LhsEval& Rvw = BlackOil::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rvw);
+
+                return
+                    bg*referenceDensity(gasPhaseIdx, regionIdx)
+                    + Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx);
+            }
 
             // immiscible gas
             const LhsEval Rv(0.0);
@@ -800,7 +810,16 @@ public:
                     bg*referenceDensity(gasPhaseIdx, regionIdx)
                     + Rv*bg*referenceDensity(oilPhaseIdx, regionIdx);
             }
-            //PJPE: need to consider water evaporization
+            //vaporized oil simultaneous with vaporized water is not yet supported
+            if (enableVaporizedWater()) {
+                // gas containing vaporized water
+                const LhsEval& Rvw = saturatedVaporizationFactor<FluidState, LhsEval>(fluidState, gasPhaseIdx, regionIdx);
+                const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rvw);
+
+                return
+                    bg*referenceDensity(gasPhaseIdx, regionIdx)
+                    + Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx);
+            }
 
             // immiscible gas
             const LhsEval Rv(0.0);
@@ -1121,7 +1140,7 @@ public:
      * it is always 0.
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    static LhsEval saturatedWaterVaporationFactor(const FluidState& fluidState,
+    static LhsEval saturatedVaporizationFactor(const FluidState& fluidState,
                                               unsigned phaseIdx,
                                               unsigned regionIdx)
     {

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -124,7 +124,7 @@ LhsEval getSaltSaturation_(typename std::enable_if<!HasMember_saltSaturation<Flu
 
 template <class FluidSystem, class FluidState, class LhsEval>
 auto getSaltSaturation_(typename std::enable_if<HasMember_saltSaturation<FluidState>::value, const FluidState&>::type fluidState,
-            unsigned regionIdx OPM_UNUSED)
+            unsigned)
     -> decltype(decay<LhsEval>(fluidState.saltSaturation()))
 { return decay<LhsEval>(fluidState.saltSaturation()); }
 

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -192,6 +192,23 @@ public:
                                   const Evaluation& /*Rv*/) const
     { return 0.0; /* this is dry gas! */ }
 
+    // template <class Evaluation>
+    // Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
+    //                                           const Evaluation& /*temperature*/,
+    //                                           const Evaluation& /*pressure*/,
+    //                                           const Evaluation& /*oilSaturation*/,
+    //                                           const Evaluation& /*maxOilSaturation*/) const
+    // { return 0.0; /* this is dry gas! */ }
+
+    /*!
+     * \brief Returns the water vaporization factor \f$R_vw\f$ [m^3/m^3] of the water phase.
+     */
+    template <class Evaluation>
+    Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
+                                              const Evaluation& /*temperature*/,
+                                              const Evaluation& /*pressure*/) const
+    { return 0.0; /* this is non-humid gas! */ }
+
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the oil phase.
      */

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -192,14 +192,6 @@ public:
                                   const Evaluation& /*Rv*/) const
     { return 0.0; /* this is dry gas! */ }
 
-    // template <class Evaluation>
-    // Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
-    //                                           const Evaluation& /*temperature*/,
-    //                                           const Evaluation& /*pressure*/,
-    //                                           const Evaluation& /*oilSaturation*/,
-    //                                           const Evaluation& /*maxOilSaturation*/) const
-    // { return 0.0; /* this is dry gas! */ }
-
     /*!
      * \brief Returns the water vaporization factor \f$R_vw\f$ [m^3/m^3] of the water phase.
      */

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -271,17 +271,6 @@ public:
     /*!
      * \brief Returns the water vaporization factor \f$R_v\f$ [m^3/m^3] of the water phase.
      */
-    // template <class Evaluation>
-    // Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
-    //                                           const Evaluation& /*temperature*/,
-    //                                           const Evaluation& /*pressure*/,
-    //                                           const Evaluation& /*oilSaturation*/,
-    //                                           const Evaluation& /*maxOilSaturation*/) const
-    // { return 0.0; /* this is  non-humid gas! */ }
-
-    /*!
-     * \brief Returns the water vaporization factor \f$R_v\f$ [m^3/m^3] of the water phase.
-     */
     template <class Evaluation>
     Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
                                               const Evaluation& /*temperature*/,

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -269,6 +269,26 @@ public:
     { return 0.0; /* this is dry gas! */ }
 
     /*!
+     * \brief Returns the water vaporization factor \f$R_v\f$ [m^3/m^3] of the water phase.
+     */
+    // template <class Evaluation>
+    // Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
+    //                                           const Evaluation& /*temperature*/,
+    //                                           const Evaluation& /*pressure*/,
+    //                                           const Evaluation& /*oilSaturation*/,
+    //                                           const Evaluation& /*maxOilSaturation*/) const
+    // { return 0.0; /* this is  non-humid gas! */ }
+
+    /*!
+     * \brief Returns the water vaporization factor \f$R_v\f$ [m^3/m^3] of the water phase.
+     */
+    template <class Evaluation>
+    Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
+                                              const Evaluation& /*temperature*/,
+                                              const Evaluation& /*pressure*/) const
+    { return 0.0; /* this is non-humid gas! */ }
+
+    /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the oil phase.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp
@@ -93,7 +93,7 @@ public:
      *
      * This method assumes that the deck features valid DENSITY and PVTG keywords.
      */
-    void initFromState(const EclipseState& eclState, const Schedule& schedule)
+    void initFromState(const EclipseState& eclState, const Schedule&)
     {
         const auto& pvtgwTables = eclState.getTableManager().getPvtgwTables();
         const auto& densityTable = eclState.getTableManager().getDensityTable();

--- a/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp
@@ -36,7 +36,7 @@
 #if HAVE_ECL_INPUT
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
-//#include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
+
 #endif
 
 #if HAVE_OPM_COMMON
@@ -476,19 +476,6 @@ public:
     {
         return saturatedWaterVaporizationFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true);
     }
-
-    // /*!
-    //  * \brief Returns the water vaporization factor \f$R_v\f$ [m^3/m^3] of the gas phase.
-    //  */
-    // template <class Evaluation>
-    // Evaluation saturatedWaterVaporizationFactor(unsigned regionIdx,
-    //                                           const Evaluation& /*temperature*/,
-    //                                           const Evaluation& pressure,
-    //                                           const Evaluation& waterSaturation,
-    //                                           Evaluation maxWaterSaturation) const
-    // {
-    //     return saturatedWaterVaporizationFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true);;
-    // }
 
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the oil phase.

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -152,7 +152,7 @@ public:
             setApproach(GasPvtApproach::ThermalGasPvt);
         else if (!eclState.getTableManager().getPvtgTables().empty())
             setApproach(GasPvtApproach::WetGasPvt);
-        else if (eclState.getTableManager().hasTables("PVDG")) //PJPE:for simple table
+        else if (eclState.getTableManager().hasTables("PVDG"))
             setApproach(GasPvtApproach::DryGasPvt);
         else if (!eclState.getTableManager().getPvtgwTables().empty())
             setApproach(GasPvtApproach::DryHumidGasPvt);
@@ -282,17 +282,6 @@ public:
                                               const Evaluation& temperature,
                                               const Evaluation& pressure) const
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedWaterVaporizationFactor(regionIdx, temperature, pressure)); return 0; }
-
-    // /*!
-    //  * \brief Returns the water vaporization factor \f$R_v\f$ [m^3/m^3] of water saturated gas.
-    //  */
-    // template <class Evaluation = Scalar>
-    // Evaluation saturatedWaterVaporizationFactor(unsigned regionIdx,
-    //                                           const Evaluation& temperature,
-    //                                           const Evaluation& pressure,
-    //                                           const Evaluation& waterSaturation,
-    //                                           const Evaluation& maxWaterSaturation) const
-    // { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedWaterVaporizationFactor(regionIdx, temperature, pressure, waterSaturation, maxWaterSaturation)); return 0; }
 
     /*!
      * \brief Returns the saturation pressure of the gas phase [Pa]

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -326,14 +326,6 @@ public:
         return b/(1 + (cT1 + cT2*Y)*Y);
     }
 
-    // template <class Evaluation>
-    // Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
-    //                                           const Evaluation& /*temperature*/,
-    //                                           const Evaluation& /*pressure*/,
-    //                                           const Evaluation& /*oilSaturation*/,
-    //                                           const Evaluation& /*maxOilSaturation*/) const
-    // { return 0.0; }
-
     /*!
      * \brief Returns the water vaporization factor \f$R_v\f$ [m^3/m^3] of the water phase.
      */

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -326,6 +326,24 @@ public:
         return b/(1 + (cT1 + cT2*Y)*Y);
     }
 
+    // template <class Evaluation>
+    // Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
+    //                                           const Evaluation& /*temperature*/,
+    //                                           const Evaluation& /*pressure*/,
+    //                                           const Evaluation& /*oilSaturation*/,
+    //                                           const Evaluation& /*maxOilSaturation*/) const
+    // { return 0.0; }
+
+    /*!
+     * \brief Returns the water vaporization factor \f$R_v\f$ [m^3/m^3] of the water phase.
+     */
+    template <class Evaluation>
+    Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
+                                              const Evaluation& /*temperature*/,
+                                              const Evaluation& /*pressure*/) const
+    { return 0.0; }
+    
+
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the gas phase.
      *

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -527,14 +527,6 @@ public:
                                                      const Evaluation& pressure) const
     { return inverseSaturatedGasB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
-    // template <class Evaluation>
-    // Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
-    //                                           const Evaluation& /*temperature*/,
-    //                                           const Evaluation& /*pressure*/,
-    //                                           const Evaluation& /*oilSaturation*/,
-    //                                           const Evaluation& /*maxOilSaturation*/) const
-    // { return 0.0; /* this is non-humid gas! */ }
-
     /*!
      * \brief Returns the water vaporization factor \f$R_vw\f$ [m^3/m^3] of the gasphase.
      */


### PR DESCRIPTION
The new PVT approach for dry-humid gas makes use of the OPM-flow specific PVT table `PVTGW`