### PR TITLE
Add PVT for combined wet (vaporized oil)  and humid (vaporized water) gas

### DIFF
--- a/examples/co2brinepvt.cpp
+++ b/examples/co2brinepvt.cpp
@@ -38,7 +38,8 @@ double densityGas(const Co2Pvt& co2Pvt, const double p, const double T, const do
     return co2Pvt.inverseFormationVolumeFactor(/*regionIdx=*/0,
                                                   T,
                                                   p,
-                                                  Rv) * co2Pvt.gasReferenceDensity(0);
+                                                  Rv,
+                                                  /*Rvw=*/0.0) * co2Pvt.gasReferenceDensity(0);
 }
 
 template <class BrinePvt>
@@ -118,7 +119,8 @@ int main(int argc, char **argv)
             value = co2Pvt.inverseFormationVolumeFactor(/*regionIdx=*/0,
                                                    T,
                                                    p,
-                                                   rv);
+                                                   rv,
+                                                   /*Rvw=*/0.0);
         } else if (phase == "brine") {
             value = brineCo2Pvt.inverseFormationVolumeFactor(/*regionIdx=*/0,
                                                    T,
@@ -132,7 +134,8 @@ int main(int argc, char **argv)
             value = co2Pvt.viscosity(/*regionIdx=*/0,
                                                    T,
                                                    p,
-                                                   rv);
+                                                   rv,
+                                                   /*Rvw=*/0.0);
         } else if (phase == "brine") {
             value = brineCo2Pvt.viscosity(/*regionIdx=*/0,
                                                    T,

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -145,7 +145,8 @@ public:
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& temperature,
                          const Evaluation& pressure,
-                         const Evaluation& /*Rv*/) const
+                         const Evaluation& /*Rv*/,
+                         const Evaluation& /*Rvw*/) const
     { return saturatedViscosity(regionIdx, temperature, pressure); }
 
     /*!
@@ -166,7 +167,8 @@ public:
     Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
                                             const Evaluation& temperature,
                                             const Evaluation& pressure,
-                                            const Evaluation& /*Rv*/) const
+                                            const Evaluation& /*Rv*/,
+                                            const Evaluation& /*Rvw*/) const
     { return saturatedInverseFormationVolumeFactor(regionIdx, temperature, pressure); }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -11,7 +11,6 @@
   OPM is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
@@ -220,7 +219,8 @@ public:
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& temperature,
                          const Evaluation& pressure,
-                         const Evaluation& /*Rv*/) const
+                         const Evaluation& /*Rv*/,
+                         const Evaluation& /*Rvw*/) const
     { return saturatedViscosity(regionIdx, temperature, pressure); }
 
     /*!
@@ -244,7 +244,8 @@ public:
     Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
                                             const Evaluation& temperature,
                                             const Evaluation& pressure,
-                                            const Evaluation& /*Rv*/) const
+                                            const Evaluation& /*Rv*/,
+                                            const Evaluation& /*Rvw*/) const
     { return saturatedInverseFormationVolumeFactor(regionIdx, temperature, pressure); }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -11,6 +11,7 @@
   OPM is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.

--- a/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp
@@ -425,10 +425,11 @@ public:
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& /*temperature*/,
                          const Evaluation& pressure,
-                         const Evaluation& Rw) const
+                         const Evaluation& /*Rv*/,
+                         const Evaluation& Rvw) const
     {
-        const Evaluation& invBg = inverseGasB_[regionIdx].eval(pressure, Rw, /*extrapolate=*/true);
-        const Evaluation& invMugBg = inverseGasBMu_[regionIdx].eval(pressure, Rw, /*extrapolate=*/true);
+        const Evaluation& invBg = inverseGasB_[regionIdx].eval(pressure, Rvw, /*extrapolate=*/true);
+        const Evaluation& invMugBg = inverseGasBMu_[regionIdx].eval(pressure, Rvw, /*extrapolate=*/true);
 
         return invBg/invMugBg;
     }
@@ -454,8 +455,9 @@ public:
     Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
                                             const Evaluation& /*temperature*/,
                                             const Evaluation& pressure,
-                                            const Evaluation& Rw) const
-    { return inverseGasB_[regionIdx].eval(pressure, Rw, /*extrapolate=*/true); }
+                                            const Evaluation& /*Rv*/,
+                                            const Evaluation& Rvw) const
+    { return inverseGasB_[regionIdx].eval(pressure, Rvw, /*extrapolate=*/true); }
 
     /*!
      * \brief Returns the formation volume factor [-] of water saturated gas at a given pressure.
@@ -608,7 +610,7 @@ public:
     bool operator==(const DryHumidGasPvt<Scalar>& data) const
     {
         return this->gasReferenceDensity_ == data.gasReferenceDensity_ &&
-               this->oilReferenceDensity_ == data.waterReferenceDensity_ &&
+               this->waterReferenceDensity_ == data.waterReferenceDensity_ &&
                this->inverseGasB() == data.inverseGasB() &&
                this->inverseSaturatedGasB() == data.inverseSaturatedGasB() &&
                this->gasMu() == data.gasMu() &&

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -241,10 +241,11 @@ public:
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& temperature,
                          const Evaluation& pressure,
-                         const Evaluation& Rv) const
+                         const Evaluation& Rv,
+                         const Evaluation& Rvw) const
     {
         if (!enableThermalViscosity())
-            return isothermalPvt_->viscosity(regionIdx, temperature, pressure, Rv);
+            return isothermalPvt_->viscosity(regionIdx, temperature, pressure, Rv, Rvw);
 
         // compute the viscosity deviation due to temperature
         const auto& muGasvisct = gasvisctCurves_[regionIdx].eval(temperature);
@@ -274,10 +275,12 @@ public:
     Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
                                             const Evaluation& temperature,
                                             const Evaluation& pressure,
-                                            const Evaluation& Rv) const
+                                            const Evaluation& Rv,
+                                            const Evaluation& /*Rvw*/) const
     {
+        const Evaluation& Rvw = 0.0;
         const auto& b =
-            isothermalPvt_->inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rv);
+            isothermalPvt_->inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rv, Rvw);
 
         if (!enableThermalDensity())
             return b;

--- a/opm/material/fluidsystems/blackoilpvt/WetHumidGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetHumidGasPvt.hpp
@@ -22,10 +22,10 @@
 */
 /*!
  * \file
- * \copydoc Opm::WetGasPvt
+ * \copydoc Opm::WetHumidGasPvt
  */
-#ifndef OPM_WET_GAS_PVT_HPP
-#define OPM_WET_GAS_PVT_HPP
+#ifndef OPM_WET_HUMID_GAS_PVT_HPP
+#define OPM_WET_HUMID_GAS_PVT_HPP
 
 #include <opm/material/Constants.hpp>
 #include <opm/material/common/MathToolbox.hpp>
@@ -36,7 +36,7 @@
 #if HAVE_ECL_INPUT
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
-#include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
+
 #endif
 
 #if HAVE_OPM_COMMON
@@ -46,11 +46,11 @@
 namespace Opm {
 
 /*!
- * \brief This class represents the Pressure-Volume-Temperature relations of the gas phas
- *        with vaporized oil.
+ * \brief This class represents the Pressure-Volume-Temperature relations of the gas phase
+ *        with vaporized oil and vaporized water.
  */
 template <class Scalar>
-class WetGasPvt
+class WetHumidGasPvt
 {
     typedef std::vector<std::pair<Scalar, Scalar> > SamplingPoints;
 
@@ -58,29 +58,39 @@ public:
     typedef UniformXTabulated2DFunction<Scalar> TabulatedTwoDFunction;
     typedef Tabulated1DFunction<Scalar> TabulatedOneDFunction;
 
-    WetGasPvt()
+    WetHumidGasPvt()
     {
         vapPar1_ = 0.0;
     }
 
-    WetGasPvt(const std::vector<Scalar>& gasReferenceDensity,
+    WetHumidGasPvt(const std::vector<Scalar>& gasReferenceDensity,
               const std::vector<Scalar>& oilReferenceDensity,
-              const std::vector<TabulatedTwoDFunction>& inverseGasB,
+              const std::vector<Scalar>& waterReferenceDensity,
+              const std::vector<TabulatedTwoDFunction>& inverseGasBRvwSat,
+              const std::vector<TabulatedTwoDFunction>& inverseGasBRvSat,
               const std::vector<TabulatedOneDFunction>& inverseSaturatedGasB,
-              const std::vector<TabulatedTwoDFunction>& gasMu,
-              const std::vector<TabulatedTwoDFunction>& inverseGasBMu,
+              const std::vector<TabulatedTwoDFunction>& gasMuRvwSat,
+              const std::vector<TabulatedTwoDFunction>& gasMuRvSat,
+              const std::vector<TabulatedTwoDFunction>& inverseGasBMuRvwSat,
+              const std::vector<TabulatedTwoDFunction>& inverseGasBMuRvSat,
               const std::vector<TabulatedOneDFunction>& inverseSaturatedGasBMu,
+              const std::vector<TabulatedOneDFunction>& saturatedWaterVaporizationFactorTable,
               const std::vector<TabulatedOneDFunction>& saturatedOilVaporizationFactorTable,
               const std::vector<TabulatedOneDFunction>& saturationPressure,
               Scalar vapPar1)
         : gasReferenceDensity_(gasReferenceDensity)
         , oilReferenceDensity_(oilReferenceDensity)
-        , inverseGasB_(inverseGasB)
-        , inverseSaturatedGasB_(inverseSaturatedGasB)
-        , gasMu_(gasMu)
-        , inverseGasBMu_(inverseGasBMu)
-        , inverseSaturatedGasBMu_(inverseSaturatedGasBMu)
-        , saturatedOilVaporizationFactorTable_(saturatedOilVaporizationFactorTable)
+        , waterReferenceDensity_(waterReferenceDensity)
+        , inverseGasBRvwSat_(inverseGasBRvwSat) // inverse of Bg evaluated at saturated water-gas ratio (Rvw) values; pvtg
+        , inverseGasBRvSat_(inverseGasBRvwSat) // inverse of Bg evaluated at saturated oil-gas ratio (Rv) values; pvtgw
+        , inverseSaturatedGasB_(inverseSaturatedGasB) // evaluated at saturated water-gas ratio (Rvw) and oil-gas ratio (Rv) values; pvtgw
+        , gasMuRvwSat_(gasMuRvwSat) // Mug evaluated at saturated water-gas ratio (Rvw) values; pvtg
+        , gasMuRvSat_(gasMuRvSat) // Mug evaluated at saturated oil-gas ratio (Rv) values; pvtgw
+        , inverseGasBMuRvwSat_(inverseGasBMuRvwSat) // Bg^-1*Mug evaluated at saturated water-gas ratio (Rvw) values; pvtg
+        , inverseGasBMuRvSat_(inverseGasBMuRvSat) // Bg^-1*Mug evaluated at saturated oil-gas ratio (Rv) values; pvtgw
+        , inverseSaturatedGasBMu_(inverseSaturatedGasBMu) //pvtgw
+        , saturatedWaterVaporizationFactorTable_(saturatedWaterVaporizationFactorTable) //pvtgw
+        , saturatedOilVaporizationFactorTable_(saturatedOilVaporizationFactorTable) //pvtg
         , saturationPressure_(saturationPressure)
         , vapPar1_(vapPar1)
     {
@@ -95,12 +105,14 @@ public:
      */
     void initFromState(const EclipseState& eclState, const Schedule& schedule)
     {
+        const auto& pvtgwTables = eclState.getTableManager().getPvtgwTables();
         const auto& pvtgTables = eclState.getTableManager().getPvtgTables();
         const auto& densityTable = eclState.getTableManager().getDensityTable();
 
+        assert(pvtgwTables.size() == densityTable.size());
         assert(pvtgTables.size() == densityTable.size());
 
-        size_t numRegions = pvtgTables.size();
+        size_t numRegions = pvtgwTables.size();
         setNumRegions(numRegions);
 
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
@@ -110,50 +122,51 @@ public:
 
             setReferenceDensities(regionIdx, rhoRefO, rhoRefG, rhoRefW);
         }
-
+        // Table PVTGW
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
-            const auto& pvtgTable = pvtgTables[regionIdx];
+            const auto& pvtgwTable = pvtgwTables[regionIdx];
 
-            const auto& saturatedTable = pvtgTable.getSaturatedTable();
+            const auto& saturatedTable = pvtgwTable.getSaturatedTable();
             assert(saturatedTable.numRows() > 1);
 
-            auto& gasMu = gasMu_[regionIdx];
-            auto& invGasB = inverseGasB_[regionIdx];
+            // PVTGW table contains values at saturated Rv 
+            auto& gasMuRvSat = gasMuRvSat_[regionIdx];
+            auto& invGasBRvSat = inverseGasBRvSat_[regionIdx];
             auto& invSatGasB = inverseSaturatedGasB_[regionIdx];
             auto& invSatGasBMu = inverseSaturatedGasBMu_[regionIdx];
-            auto& oilVaporizationFac = saturatedOilVaporizationFactorTable_[regionIdx];
+            auto& waterVaporizationFac = saturatedWaterVaporizationFactorTable_[regionIdx];
 
-            oilVaporizationFac.setXYArrays(saturatedTable.numRows(),
+            waterVaporizationFac.setXYArrays(saturatedTable.numRows(),
                                            saturatedTable.getColumn("PG"),
-                                           saturatedTable.getColumn("RV"));
+                                           saturatedTable.getColumn("RW"));
 
             std::vector<Scalar> invSatGasBArray;
             std::vector<Scalar> invSatGasBMuArray;
 
-            // extract the table for the gas dissolution and the oil formation volume factors
+            // extract the table for the gas viscosity and formation volume factors
             for (unsigned outerIdx = 0; outerIdx < saturatedTable.numRows(); ++ outerIdx) {
                 Scalar pg = saturatedTable.get("PG" , outerIdx);
                 Scalar B = saturatedTable.get("BG" , outerIdx);
                 Scalar mu = saturatedTable.get("MUG" , outerIdx);
 
-                invGasB.appendXPos(pg);
-                gasMu.appendXPos(pg);
+                invGasBRvSat.appendXPos(pg);
+                gasMuRvSat.appendXPos(pg);
 
                 invSatGasBArray.push_back(1.0/B);
                 invSatGasBMuArray.push_back(1.0/(mu*B));
 
-                assert(invGasB.numX() == outerIdx + 1);
-                assert(gasMu.numX() == outerIdx + 1);
+                assert(invGasBRvSat.numX() == outerIdx + 1);
+                assert(gasMuRvSat.numX() == outerIdx + 1);
 
-                const auto& underSaturatedTable = pvtgTable.getUnderSaturatedTable(outerIdx);
+                const auto& underSaturatedTable = pvtgwTable.getUnderSaturatedTable(outerIdx);
                 size_t numRows = underSaturatedTable.numRows();
                 for (size_t innerIdx = 0; innerIdx < numRows; ++ innerIdx) {
-                    Scalar Rv = underSaturatedTable.get("RV" , innerIdx);
+                    Scalar Rw = underSaturatedTable.get("RW" , innerIdx);
                     Scalar Bg = underSaturatedTable.get("BG" , innerIdx);
                     Scalar mug = underSaturatedTable.get("MUG" , innerIdx);
 
-                    invGasB.appendSamplePoint(outerIdx, Rv, 1.0/Bg);
-                    gasMu.appendSamplePoint(outerIdx, Rv, mug);
+                    invGasBRvSat.appendSamplePoint(outerIdx, Rw, 1.0/Bg);
+                    gasMuRvSat.appendSamplePoint(outerIdx, Rw, mug);
                 }
             }
 
@@ -165,13 +178,100 @@ public:
             }
 
             // make sure to have at least two sample points per gas pressure value
-            for (unsigned xIdx = 0; xIdx < invGasB.numX(); ++xIdx) {
+            for (unsigned xIdx = 0; xIdx < invGasBRvSat.numX(); ++xIdx) {
                // a single sample point is definitely needed
-                assert(invGasB.numY(xIdx) > 0);
+                assert(invGasBRvSat.numY(xIdx) > 0);
 
                 // everything is fine if the current table has two or more sampling points
                 // for a given mole fraction
-                if (invGasB.numY(xIdx) > 1)
+                if (invGasBRvSat.numY(xIdx) > 1)
+                    continue;
+
+                // find the master table which will be used as a template to extend the
+                // current line. We define master table as the first table which has values
+                // for undersaturated gas...
+                size_t masterTableIdx = xIdx + 1;
+                for (; masterTableIdx < saturatedTable.numRows(); ++masterTableIdx)
+                {
+                    if (pvtgwTable.getUnderSaturatedTable(masterTableIdx).numRows() > 1)
+                        break;
+                }
+
+                if (masterTableIdx >= saturatedTable.numRows())
+                    throw std::runtime_error("PVTGW tables are invalid: The last table must exhibit at least one "
+                              "entry for undersaturated gas!");
+
+
+                // extend the current table using the master table.
+                extendPvtgwTable_(regionIdx,
+                                 xIdx,
+                                 pvtgwTable.getUnderSaturatedTable(xIdx),
+                                 pvtgwTable.getUnderSaturatedTable(masterTableIdx));
+            }
+        }
+
+        // Table PVTG
+        for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
+            const auto& pvtgTable = pvtgTables[regionIdx];
+
+            const auto& saturatedTable = pvtgTable.getSaturatedTable();
+            assert(saturatedTable.numRows() > 1);
+            // PVTG table contains values at saturated Rvw
+            auto& gasMuRvwSat = gasMuRvwSat_[regionIdx];
+            auto& invGasBRvwSat = inverseGasBRvwSat_[regionIdx];
+            auto& invSatGasB = inverseSaturatedGasB_[regionIdx];
+            auto& invSatGasBMu = inverseSaturatedGasBMu_[regionIdx];
+            auto& oilVaporizationFac = saturatedOilVaporizationFactorTable_[regionIdx];
+
+            oilVaporizationFac.setXYArrays(saturatedTable.numRows(),
+                                           saturatedTable.getColumn("PG"),
+                                           saturatedTable.getColumn("RV"));
+
+            std::vector<Scalar> invSatGasBArray;
+            std::vector<Scalar> invSatGasBMuArray;
+
+            //// extract the table for the gas viscosity and formation volume factors
+            for (unsigned outerIdx = 0; outerIdx < saturatedTable.numRows(); ++ outerIdx) {
+                Scalar pg = saturatedTable.get("PG" , outerIdx);
+                Scalar B = saturatedTable.get("BG" , outerIdx);
+                Scalar mu = saturatedTable.get("MUG" , outerIdx);
+
+                invGasBRvwSat.appendXPos(pg);
+                gasMuRvwSat.appendXPos(pg);
+
+                invSatGasBArray.push_back(1.0/B);
+                invSatGasBMuArray.push_back(1.0/(mu*B));
+
+                assert(invGasBRvwSat.numX() == outerIdx + 1);
+                assert(gasMuRvwSat.numX() == outerIdx + 1);
+
+                const auto& underSaturatedTable = pvtgTable.getUnderSaturatedTable(outerIdx);
+                size_t numRows = underSaturatedTable.numRows();
+                for (size_t innerIdx = 0; innerIdx < numRows; ++ innerIdx) {
+                    Scalar Rv = underSaturatedTable.get("RV" , innerIdx);
+                    Scalar Bg = underSaturatedTable.get("BG" , innerIdx);
+                    Scalar mug = underSaturatedTable.get("MUG" , innerIdx);
+
+                    invGasBRvwSat.appendSamplePoint(outerIdx, Rv, 1.0/Bg);
+                    gasMuRvwSat.appendSamplePoint(outerIdx, Rv, mug);
+                }
+            }
+
+            {
+                std::vector<double> tmpPressure =  saturatedTable.getColumn("PG").vectorCopy( );
+
+                invSatGasB.setXYContainers(tmpPressure, invSatGasBArray);
+                invSatGasBMu.setXYContainers(tmpPressure, invSatGasBMuArray);
+            }
+
+            // make sure to have at least two sample points per gas pressure value
+            for (unsigned xIdx = 0; xIdx < invGasBRvwSat.numX(); ++xIdx) {
+               // a single sample point is definitely needed
+                assert(invGasBRvwSat.numY(xIdx) > 0);
+
+                // everything is fine if the current table has two or more sampling points
+                // for a given mole fraction
+                if (invGasBRvwSat.numY(xIdx) > 1)
                     continue;
 
                 // find the master table which will be used as a template to extend the
@@ -195,18 +295,67 @@ public:
                                  pvtgTable.getUnderSaturatedTable(xIdx),
                                  pvtgTable.getUnderSaturatedTable(masterTableIdx));
             }
-        }
-
+        } //end PVTGW
         vapPar1_ = 0.0;
         const auto& oilVap = schedule[0].oilvap();
         if (oilVap.getType() == OilVaporizationProperties::OilVaporization::VAPPARS) {
             vapPar1_ = oilVap.vap1();
         }
-
+        
         initEnd();
     }
 
 private:
+    void extendPvtgwTable_(unsigned regionIdx,
+                          unsigned xIdx,
+                          const SimpleTable& curTable,
+                          const SimpleTable& masterTable)
+    {
+        std::vector<double> RvArray = curTable.getColumn("RW").vectorCopy();
+        std::vector<double> gasBArray = curTable.getColumn("BG").vectorCopy();
+        std::vector<double> gasMuArray = curTable.getColumn("MUG").vectorCopy();
+
+        auto& invGasBRvSat = inverseGasBRvSat_[regionIdx];
+        auto& gasMuRvSat = gasMuRvSat_[regionIdx];
+
+        for (size_t newRowIdx = 1; newRowIdx < masterTable.numRows(); ++ newRowIdx) {
+            const auto& RVColumn = masterTable.getColumn("RW");
+            const auto& BGColumn = masterTable.getColumn("BG");
+            const auto& viscosityColumn = masterTable.getColumn("MUG");
+
+            // compute the gas pressure for the new entry
+            Scalar diffRv = RVColumn[newRowIdx] - RVColumn[newRowIdx - 1];
+            Scalar newRv = RvArray.back() + diffRv;
+
+            // calculate the compressibility of the master table
+            Scalar B1 = BGColumn[newRowIdx];
+            Scalar B2 = BGColumn[newRowIdx - 1];
+            Scalar x = (B1 - B2)/( (B1 + B2)/2.0 );
+
+            // calculate the gas formation volume factor which exhibits the same
+            // "compressibility" for the new value of Rv
+            Scalar newBg = gasBArray.back()*(1.0 + x/2.0)/(1.0 - x/2.0);
+
+            // calculate the "viscosibility" of the master table
+            Scalar mu1 = viscosityColumn[newRowIdx];
+            Scalar mu2 = viscosityColumn[newRowIdx - 1];
+            Scalar xMu = (mu1 - mu2)/( (mu1 + mu2)/2.0 );
+
+            // calculate the gas formation volume factor which exhibits the same
+            // compressibility for the new pressure
+            Scalar newMug = gasMuArray.back()*(1.0 + xMu/2)/(1.0 - xMu/2.0);
+
+            // append the new values to the arrays which we use to compute the additional
+            // values ...
+            RvArray.push_back(newRv);
+            gasBArray.push_back(newBg);
+            gasMuArray.push_back(newMug);
+
+            // ... and register them with the internal table objects
+            invGasBRvSat.appendSamplePoint(xIdx, newRv, 1.0/newBg);
+            gasMuRvSat.appendSamplePoint(xIdx, newRv, newMug);
+        }
+    }
     void extendPvtgTable_(unsigned regionIdx,
                           unsigned xIdx,
                           const SimpleTable& curTable,
@@ -216,8 +365,8 @@ private:
         std::vector<double> gasBArray = curTable.getColumn("BG").vectorCopy();
         std::vector<double> gasMuArray = curTable.getColumn("MUG").vectorCopy();
 
-        auto& invGasB = inverseGasB_[regionIdx];
-        auto& gasMu = gasMu_[regionIdx];
+        auto& invGasBRvwSat= inverseGasBRvwSat_[regionIdx];
+        auto& gasMuRvwSat = gasMuRvwSat_[regionIdx];
 
         for (size_t newRowIdx = 1; newRowIdx < masterTable.numRows(); ++ newRowIdx) {
             const auto& RVColumn = masterTable.getColumn("RV");
@@ -253,8 +402,8 @@ private:
             gasMuArray.push_back(newMug);
 
             // ... and register them with the internal table objects
-            invGasB.appendSamplePoint(xIdx, newRv, 1.0/newBg);
-            gasMu.appendSamplePoint(xIdx, newRv, newMug);
+            invGasBRvwSat.appendSamplePoint(xIdx, newRv, 1.0/newBg);
+            gasMuRvwSat.appendSamplePoint(xIdx, newRv, newMug);
         }
     }
 
@@ -263,13 +412,18 @@ public:
 
     void setNumRegions(size_t numRegions)
     {
+        waterReferenceDensity_.resize(numRegions);
         oilReferenceDensity_.resize(numRegions);
         gasReferenceDensity_.resize(numRegions);
-        inverseGasB_.resize(numRegions, TabulatedTwoDFunction{TabulatedTwoDFunction::InterpolationPolicy::RightExtreme});
-        inverseGasBMu_.resize(numRegions, TabulatedTwoDFunction{TabulatedTwoDFunction::InterpolationPolicy::RightExtreme});
+        inverseGasBRvwSat_.resize(numRegions, TabulatedTwoDFunction{TabulatedTwoDFunction::InterpolationPolicy::RightExtreme});
+        inverseGasBRvSat_.resize(numRegions, TabulatedTwoDFunction{TabulatedTwoDFunction::InterpolationPolicy::RightExtreme});
+        inverseGasBMuRvwSat_.resize(numRegions, TabulatedTwoDFunction{TabulatedTwoDFunction::InterpolationPolicy::RightExtreme});
+        inverseGasBMuRvSat_.resize(numRegions, TabulatedTwoDFunction{TabulatedTwoDFunction::InterpolationPolicy::RightExtreme});
         inverseSaturatedGasB_.resize(numRegions);
         inverseSaturatedGasBMu_.resize(numRegions);
-        gasMu_.resize(numRegions, TabulatedTwoDFunction{TabulatedTwoDFunction::InterpolationPolicy::RightExtreme});
+        gasMuRvwSat_.resize(numRegions, TabulatedTwoDFunction{TabulatedTwoDFunction::InterpolationPolicy::RightExtreme});
+        gasMuRvSat_.resize(numRegions, TabulatedTwoDFunction{TabulatedTwoDFunction::InterpolationPolicy::RightExtreme});
+        saturatedWaterVaporizationFactorTable_.resize(numRegions);
         saturatedOilVaporizationFactorTable_.resize(numRegions);
         saturationPressure_.resize(numRegions);
     }
@@ -280,11 +434,20 @@ public:
     void setReferenceDensities(unsigned regionIdx,
                                Scalar rhoRefOil,
                                Scalar rhoRefGas,
-                               Scalar /*rhoRefWater*/)
+                               Scalar rhoRefWater)
     {
+        waterReferenceDensity_[regionIdx] = rhoRefWater;
         oilReferenceDensity_[regionIdx] = rhoRefOil;
         gasReferenceDensity_[regionIdx] = rhoRefGas;
     }
+
+    /*!
+     * \brief Initialize the function for the water vaporization factor \f$R_v\f$
+     *
+     * \param samplePoints A container of (x,y) values.
+     */
+    void setSaturatedGasWaterVaporizationFactor(unsigned regionIdx, const SamplingPoints& samplePoints)
+    { saturatedWaterVaporizationFactorTable_[regionIdx].setContainerOfTuples(samplePoints); }
 
     /*!
      * \brief Initialize the function for the oil vaporization factor \f$R_v\f$
@@ -294,169 +457,94 @@ public:
     void setSaturatedGasOilVaporizationFactor(unsigned regionIdx, const SamplingPoints& samplePoints)
     { saturatedOilVaporizationFactorTable_[regionIdx].setContainerOfTuples(samplePoints); }
 
-    /*!
-     * \brief Initialize the function for the gas formation volume factor
-     *
-     * The gas formation volume factor \f$B_g\f$ is a function of \f$(p_g, X_g^O)\f$ and
-     * represents the partial density of the oil component in the gas phase at a given
-     * pressure. This method only requires the volume factor of oil-saturated gas (which
-     * only depends on pressure) while the dependence on the oil mass fraction is
-     * guesstimated...
-     */
-    void setSaturatedGasFormationVolumeFactor(unsigned regionIdx, const SamplingPoints& samplePoints)
-    {
-        auto& invGasB = inverseGasB_[regionIdx];
-
-        const auto& RvTable = saturatedOilVaporizationFactorTable_[regionIdx];
-
-        Scalar T = 273.15 + 15.56; // [K]
-
-        Scalar RvMin = 0.0;
-        Scalar RvMax = RvTable.eval(saturatedOilVaporizationFactorTable_[regionIdx].xMax(), /*extrapolate=*/true);
-
-        Scalar poMin = samplePoints.front().first;
-        Scalar poMax = samplePoints.back().first;
-
-        size_t nRv = 20;
-        size_t nP = samplePoints.size()*2;
-
-        Scalar rhooRef = oilReferenceDensity_[regionIdx];
-
-        TabulatedOneDFunction gasFormationVolumeFactor;
-        gasFormationVolumeFactor.setContainerOfTuples(samplePoints);
-
-        updateSaturationPressure_(regionIdx);
-
-        // calculate a table of estimated densities depending on pressure and gas mass
-        // fraction. note that this assumes oil of constant compressibility. (having said
-        // that, if only the saturated gas densities are available, there's not much
-        // choice.)
-        for (size_t RvIdx = 0; RvIdx < nRv; ++RvIdx) {
-            Scalar Rv = RvMin + (RvMax - RvMin)*RvIdx/nRv;
-
-            invGasB.appendXPos(Rv);
-
-            for (size_t pIdx = 0; pIdx < nP; ++pIdx) {
-                Scalar pg = poMin + (poMax - poMin)*pIdx/nP;
-
-                Scalar poSat = saturationPressure(regionIdx, T, Rv);
-                Scalar BgSat = gasFormationVolumeFactor.eval(poSat, /*extrapolate=*/true);
-                Scalar drhoo_dp = (1.1200 - 1.1189)/((5000 - 4000)*6894.76);
-                Scalar rhoo = rhooRef/BgSat*(1 + drhoo_dp*(pg - poSat));
-
-                Scalar Bg = rhooRef/rhoo;
-
-                invGasB.appendSamplePoint(RvIdx, pg, 1.0/Bg);
-            }
-        }
-    }
-
-    /*!
-     * \brief Initialize the function for the gas formation volume factor
-     *
-     * The gas formation volume factor \f$B_g\f$ is a function of \f$(p_g, X_g^O)\f$ and
-     * represents the partial density of the oil component in the gas phase at a given
-     * pressure.
-     *
-     * This method sets \f$1/B_g(R_v, p_g)\f$. Note that instead of the mass fraction of
-     * the oil component in the gas phase, this function depends on the gas dissolution
-     * factor. Also note, that the order of the arguments needs to be \f$(R_s, p_o)\f$
-     * and not the other way around.
-     */
-    void setInverseGasFormationVolumeFactor(unsigned regionIdx, const TabulatedTwoDFunction& invBg)
-    { inverseGasB_[regionIdx] = invBg; }
-
-    /*!
-     * \brief Initialize the viscosity of the gas phase.
-     *
-     * This is a function of \f$(R_s, p_o)\f$...
-     */
-    void setGasViscosity(unsigned regionIdx, const TabulatedTwoDFunction& mug)
-    { gasMu_[regionIdx] = mug; }
-
-    /*!
-     * \brief Initialize the phase viscosity for oil saturated gas
-     *
-     * The gas viscosity is a function of \f$(p_g, X_g^O)\f$, but this method only
-     * requires the viscosity of oil-saturated gas (which only depends on pressure) while
-     * there is assumed to be no dependence on the gas mass fraction...
-     */
-    void setSaturatedGasViscosity(unsigned regionIdx, const SamplingPoints& samplePoints  )
-    {
-        auto& oilVaporizationFac = saturatedOilVaporizationFactorTable_[regionIdx];
-
-        Scalar RvMin = 0.0;
-        Scalar RvMax = oilVaporizationFac.eval(saturatedOilVaporizationFactorTable_[regionIdx].xMax(), /*extrapolate=*/true);
-
-        Scalar poMin = samplePoints.front().first;
-        Scalar poMax = samplePoints.back().first;
-
-        size_t nRv = 20;
-        size_t nP = samplePoints.size()*2;
-
-        TabulatedOneDFunction mugTable;
-        mugTable.setContainerOfTuples(samplePoints);
-
-        // calculate a table of estimated densities depending on pressure and gas mass
-        // fraction
-        for (size_t RvIdx = 0; RvIdx < nRv; ++RvIdx) {
-            Scalar Rv = RvMin + (RvMax - RvMin)*RvIdx/nRv;
-
-            gasMu_[regionIdx].appendXPos(Rv);
-
-            for (size_t pIdx = 0; pIdx < nP; ++pIdx) {
-                Scalar pg = poMin + (poMax - poMin)*pIdx/nP;
-                Scalar mug = mugTable.eval(pg, /*extrapolate=*/true);
-
-                gasMu_[regionIdx].appendSamplePoint(RvIdx, pg, mug);
-            }
-        }
-    }
 
     /*!
      * \brief Finish initializing the gas phase PVT properties.
      */
     void initEnd()
     {
+
+        //PVTGW
         // calculate the final 2D functions which are used for interpolation.
-        size_t numRegions = gasMu_.size();
+        size_t numRegions = gasMuRvSat_.size();
         for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
             // calculate the table which stores the inverse of the product of the gas
             // formation volume factor and the gas viscosity
-            const auto& gasMu = gasMu_[regionIdx];
-            const auto& invGasB = inverseGasB_[regionIdx];
-            assert(gasMu.numX() == invGasB.numX());
+            const auto& gasMuRvSat = gasMuRvSat_[regionIdx];
+            const auto& invGasBRvSat = inverseGasBRvSat_[regionIdx];
+            assert(gasMuRvSat.numX() == invGasBRvSat.numX());
 
-            auto& invGasBMu = inverseGasBMu_[regionIdx];
+            auto& invGasBMuRvSat = inverseGasBMuRvSat_[regionIdx];
             auto& invSatGasB = inverseSaturatedGasB_[regionIdx];
             auto& invSatGasBMu = inverseSaturatedGasBMu_[regionIdx];
 
             std::vector<Scalar> satPressuresArray;
             std::vector<Scalar> invSatGasBArray;
             std::vector<Scalar> invSatGasBMuArray;
-            for (size_t pIdx = 0; pIdx < gasMu.numX(); ++pIdx) {
-                invGasBMu.appendXPos(gasMu.xAt(pIdx));
+            for (size_t pIdx = 0; pIdx < gasMuRvSat.numX(); ++pIdx) {
+                invGasBMuRvSat.appendXPos(gasMuRvSat.xAt(pIdx));
 
-                assert(gasMu.numY(pIdx) == invGasB.numY(pIdx));
+                assert(gasMuRvSat.numY(pIdx) == invGasBRvSat.numY(pIdx));
 
-                size_t numRv = gasMu.numY(pIdx);
-                for (size_t rvIdx = 0; rvIdx < numRv; ++rvIdx)
-                    invGasBMu.appendSamplePoint(pIdx,
-                                                gasMu.yAt(pIdx, rvIdx),
-                                                invGasB.valueAt(pIdx, rvIdx)
-                                                / gasMu.valueAt(pIdx, rvIdx));
+                size_t numRw = gasMuRvSat.numY(pIdx);
+                for (size_t RwIdx = 0; RwIdx < numRw; ++RwIdx)
+                    invGasBMuRvSat.appendSamplePoint(pIdx,
+                                                gasMuRvSat.yAt(pIdx, RwIdx),
+                                                invGasBRvSat.valueAt(pIdx, RwIdx)
+                                                / gasMuRvSat.valueAt(pIdx, RwIdx));
 
                 // the sampling points in UniformXTabulated2DFunction are always sorted
                 // in ascending order. Thus, the value for saturated gas is the last one
-                // (i.e., the one with the largest Rv value)
-                satPressuresArray.push_back(gasMu.xAt(pIdx));
-                invSatGasBArray.push_back(invGasB.valueAt(pIdx, numRv - 1));
-                invSatGasBMuArray.push_back(invGasBMu.valueAt(pIdx, numRv - 1));
+                // (i.e., the one with the largest Rw value)
+                satPressuresArray.push_back(gasMuRvSat.xAt(pIdx));
+                invSatGasBArray.push_back(invGasBRvSat.valueAt(pIdx, numRw - 1));
+                invSatGasBMuArray.push_back(invGasBMuRvSat.valueAt(pIdx, numRw - 1));
             }
 
             invSatGasB.setXYContainers(satPressuresArray, invSatGasBArray);
             invSatGasBMu.setXYContainers(satPressuresArray, invSatGasBMuArray);
+        }
 
+        //PVTG
+        // calculate the final 2D functions which are used for interpolation.
+        //size_t numRegions = gasMuRvwSat_.size();
+        for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
+            // calculate the table which stores the inverse of the product of the gas
+            // formation volume factor and the gas viscosity
+            const auto& gasMuRvwSat = gasMuRvwSat_[regionIdx];
+            const auto& invGasBRvwSat = inverseGasBRvwSat_[regionIdx];
+            assert(gasMuRvwSat.numX() == invGasBRvwSat.numX());
+
+            auto& invGasBMuRvwSat = inverseGasBMuRvwSat_[regionIdx];
+            auto& invSatGasB = inverseSaturatedGasB_[regionIdx];
+            auto& invSatGasBMu = inverseSaturatedGasBMu_[regionIdx];
+
+            std::vector<Scalar> satPressuresArray;
+            std::vector<Scalar> invSatGasBArray;
+            std::vector<Scalar> invSatGasBMuArray;
+            for (size_t pIdx = 0; pIdx < gasMuRvwSat.numX(); ++pIdx) {
+                invGasBMuRvwSat.appendXPos(gasMuRvwSat.xAt(pIdx));
+
+                assert(gasMuRvwSat.numY(pIdx) == invGasBRvwSat.numY(pIdx));
+
+                size_t numRw = gasMuRvwSat.numY(pIdx);
+                for (size_t RwIdx = 0; RwIdx < numRw; ++RwIdx)
+                    invGasBMuRvwSat.appendSamplePoint(pIdx,
+                                                gasMuRvwSat.yAt(pIdx, RwIdx),
+                                                invGasBRvwSat.valueAt(pIdx, RwIdx)
+                                                / gasMuRvwSat.valueAt(pIdx, RwIdx));
+
+                // the sampling points in UniformXTabulated2DFunction are always sorted
+                // in ascending order. Thus, the value for saturated gas is the last one
+                // (i.e., the one with the largest Rw value)
+                satPressuresArray.push_back(gasMuRvwSat.xAt(pIdx));
+                invSatGasBArray.push_back(invGasBRvwSat.valueAt(pIdx, numRw - 1));
+                invSatGasBMuArray.push_back(invGasBMuRvwSat.valueAt(pIdx, numRw - 1));
+            }
+
+            invSatGasB.setXYContainers(satPressuresArray, invSatGasBArray);
+            invSatGasBMu.setXYContainers(satPressuresArray, invSatGasBMuArray);
+            
             updateSaturationPressure_(regionIdx);
         }
     }
@@ -487,12 +575,21 @@ public:
                          const Evaluation& /*temperature*/,
                          const Evaluation& pressure,
                          const Evaluation& Rv,
-                         const Evaluation& /*Rvw*/) const
+                         const Evaluation& Rvw) const
     {
-        const Evaluation& invBg = inverseGasB_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true);
-        const Evaluation& invMugBg = inverseGasBMu_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true);
+        const Evaluation& temperature = 1E30;
 
-        return invBg/invMugBg;
+        if (Rv >= (1.0 - 1e-10)*saturatedOilVaporizationFactor(regionIdx, temperature, pressure)) {
+            const Evaluation& invBg = inverseGasBRvSat_[regionIdx].eval(pressure, Rvw, /*extrapolate=*/true);
+            const Evaluation& invMugBg = inverseGasBMuRvSat_[regionIdx].eval(pressure, Rvw, /*extrapolate=*/true);
+            return invBg/invMugBg;
+        }
+        else {
+            // for Rv undersaturated viscosity is evaluated at saturated Rvw values
+            const Evaluation& invBg = inverseGasBRvwSat_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true);
+            const Evaluation& invMugBg = inverseGasBMuRvwSat_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true);
+            return invBg/invMugBg;
+        }
     }
 
     /*!
@@ -512,16 +609,35 @@ public:
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */
+    // template <class Evaluation>
+    // Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
+    //                                         const Evaluation& /*temperature*/,
+    //                                         const Evaluation& pressure,
+    //                                         const Evaluation& Rw) const
+    // { return inverseGasB_[regionIdx].eval(pressure, Rw, /*extrapolate=*/true); }
+
     template <class Evaluation>
     Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
                                             const Evaluation& /*temperature*/,
                                             const Evaluation& pressure,
                                             const Evaluation& Rv,
-                                            const Evaluation& /*Rvw*/) const
-    { return inverseGasB_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true); }
+                                            const Evaluation& Rvw) const
+    {
+        const Evaluation& temperature = 1E30;
+        
+        if (Rv >= (1.0 - 1e-10)*saturatedOilVaporizationFactor(regionIdx, temperature, pressure)) {
+            return inverseGasBRvSat_[regionIdx].eval(pressure, Rvw, /*extrapolate=*/true);
+        }
+        else {
+            // for Rv undersaturated Bg^-1 is evaluated at saturated Rvw values
+            return inverseGasBRvwSat_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true);
+        }
+
+    }
+
 
     /*!
-     * \brief Returns the formation volume factor [-] of oil saturated gas at a given pressure.
+     * \brief Returns the formation volume factor [-] of water saturated gas at a given pressure.
      */
     template <class Evaluation>
     Evaluation saturatedInverseFormationVolumeFactor(unsigned regionIdx,
@@ -530,18 +646,17 @@ public:
     { return inverseSaturatedGasB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
-     * \brief Returns the water vaporization factor \f$R_vw\f$ [m^3/m^3] of the gasphase.
+     * \brief Returns the water vaporization factor \f$R_vw\f$ [m^3/m^3] of the water phase.
      */
     template <class Evaluation>
-    Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
+    Evaluation saturatedWaterVaporizationFactor(unsigned regionIdx,
                                               const Evaluation& /*temperature*/,
-                                              const Evaluation& /*pressure*/) const
-    { return 0.0; /* this is non-humid gas! */ }
-    
-    /*!
-     * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the gas phase.
-     */
-    template <class Evaluation>
+                                              const Evaluation& pressure) const
+    {
+        return saturatedWaterVaporizationFactorTable_[regionIdx].eval(pressure, /*extrapolate=*/true);
+    }
+
+   template <class Evaluation>
     Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
                                               const Evaluation& /*temperature*/,
                                               const Evaluation& pressure) const
@@ -580,34 +695,32 @@ public:
 
     /*!
      * \brief Returns the saturation pressure of the gas phase [Pa]
-     *        depending on its mass fraction of the oil component
+     *        depending on its mass fraction of the water component
      *
-     * This method uses the standard blackoil assumptions: This means that the Rv value
-     * does not depend on the saturation of oil. (cf. the Eclipse VAPPARS keyword.)
-     *
-     * \param Rv The surface volume of oil component dissolved in what will yield one
+     * \param Rw The surface volume of water component dissolved in what will yield one
      *           cubic meter of gas at the surface [-]
      */
+    //PJPE assume dependence on Rv
     template <class Evaluation>
     Evaluation saturationPressure(unsigned regionIdx,
                                   const Evaluation&,
-                                  const Evaluation& Rv) const
+                                  const Evaluation& Rw) const
     {
         typedef MathToolbox<Evaluation> Toolbox;
 
-        const auto& RvTable = saturatedOilVaporizationFactorTable_[regionIdx];
+        const auto& RwTable = saturatedWaterVaporizationFactorTable_[regionIdx];
         const Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon()*1e6;
 
         // use the tabulated saturation pressure function to get a pretty good initial value
-        Evaluation pSat = saturationPressure_[regionIdx].eval(Rv, /*extrapolate=*/true);
+        Evaluation pSat = saturationPressure_[regionIdx].eval(Rw, /*extrapolate=*/true);
 
         // Newton method to do the remaining work. If the initial
         // value is good, this should only take two to three
         // iterations...
         bool onProbation = false;
         for (unsigned i = 0; i < 20; ++i) {
-            const Evaluation& f = RvTable.eval(pSat, /*extrapolate=*/true) - Rv;
-            const Evaluation& fPrime = RvTable.evalDerivative(pSat, /*extrapolate=*/true);
+            const Evaluation& f = RwTable.eval(pSat, /*extrapolate=*/true) - Rw;
+            const Evaluation& fPrime = RwTable.evalDerivative(pSat, /*extrapolate=*/true);
 
             // If the derivative is "zero" Newton will not converge,
             // so simply return our initial guess.
@@ -636,7 +749,7 @@ public:
         std::stringstream errlog;
         errlog << "Finding saturation pressure did not converge:"
                << " pSat = " << pSat
-               << ", Rv = " << Rv;
+               << ", Rw = " << Rw;
 #if HAVE_OPM_COMMON
         OpmLog::debug("Wet gas saturation pressure", errlog.str());
 #endif
@@ -654,11 +767,14 @@ public:
     const Scalar gasReferenceDensity(unsigned regionIdx) const
     { return gasReferenceDensity_[regionIdx]; }
 
-    const Scalar oilReferenceDensity(unsigned regionIdx) const
+     const Scalar oilReferenceDensity(unsigned regionIdx) const
     { return oilReferenceDensity_[regionIdx]; }
 
+    const Scalar waterReferenceDensity(unsigned regionIdx) const
+    { return waterReferenceDensity_[regionIdx]; }
+
     const std::vector<TabulatedTwoDFunction>& inverseGasB() const {
-        return inverseGasB_;
+        return inverseGasBRvSat_;
     }
 
     const std::vector<TabulatedOneDFunction>& inverseSaturatedGasB() const {
@@ -666,20 +782,25 @@ public:
     }
 
     const std::vector<TabulatedTwoDFunction>& gasMu() const {
-        return gasMu_;
+        return gasMuRvSat_;
     }
 
     const std::vector<TabulatedTwoDFunction>& inverseGasBMu() const {
-        return inverseGasBMu_;
+        return inverseGasBMuRvSat_;
     }
 
     const std::vector<TabulatedOneDFunction>& inverseSaturatedGasBMu() const {
         return inverseSaturatedGasBMu_;
     }
 
+    const std::vector<TabulatedOneDFunction>& saturatedWaterVaporizationFactorTable() const {
+        return saturatedWaterVaporizationFactorTable_;
+    }
+     
     const std::vector<TabulatedOneDFunction>& saturatedOilVaporizationFactorTable() const {
         return saturatedOilVaporizationFactorTable_;
     }
+
 
     const std::vector<TabulatedOneDFunction>& saturationPressure() const {
         return saturationPressure_;
@@ -689,16 +810,17 @@ public:
         return vapPar1_;
     }
 
-    bool operator==(const WetGasPvt<Scalar>& data) const
+    bool operator==(const WetHumidGasPvt<Scalar>& data) const
     {
         return this->gasReferenceDensity_ == data.gasReferenceDensity_ &&
                this->oilReferenceDensity_ == data.oilReferenceDensity_ &&
+               this->waterReferenceDensity_ == data.waterReferenceDensity_ &&
                this->inverseGasB() == data.inverseGasB() &&
                this->inverseSaturatedGasB() == data.inverseSaturatedGasB() &&
                this->gasMu() == data.gasMu() &&
                this->inverseGasBMu() == data.inverseGasBMu() &&
                this->inverseSaturatedGasBMu() == data.inverseSaturatedGasBMu() &&
-               this->saturatedOilVaporizationFactorTable() == data.saturatedOilVaporizationFactorTable() &&
+               this->saturatedWaterVaporizationFactorTable() == data.saturatedWaterVaporizationFactorTable() &&
                this->saturationPressure() == data.saturationPressure() &&
                this->vapPar1() == data.vapPar1();
     }
@@ -733,12 +855,17 @@ private:
     }
 
     std::vector<Scalar> gasReferenceDensity_;
+    std::vector<Scalar> waterReferenceDensity_;
     std::vector<Scalar> oilReferenceDensity_;
-    std::vector<TabulatedTwoDFunction> inverseGasB_;
+    std::vector<TabulatedTwoDFunction> inverseGasBRvwSat_;
+    std::vector<TabulatedTwoDFunction> inverseGasBRvSat_;
     std::vector<TabulatedOneDFunction> inverseSaturatedGasB_;
-    std::vector<TabulatedTwoDFunction> gasMu_;
-    std::vector<TabulatedTwoDFunction> inverseGasBMu_;
+    std::vector<TabulatedTwoDFunction> gasMuRvwSat_;
+    std::vector<TabulatedTwoDFunction> gasMuRvSat_;
+    std::vector<TabulatedTwoDFunction> inverseGasBMuRvwSat_;
+    std::vector<TabulatedTwoDFunction> inverseGasBMuRvSat_;
     std::vector<TabulatedOneDFunction> inverseSaturatedGasBMu_;
+    std::vector<TabulatedOneDFunction> saturatedWaterVaporizationFactorTable_;
     std::vector<TabulatedOneDFunction> saturatedOilVaporizationFactorTable_;
     std::vector<TabulatedOneDFunction> saturationPressure_;
 

--- a/tests/test_co2brinepvt.cpp
+++ b/tests/test_co2brinepvt.cpp
@@ -96,6 +96,7 @@ void ensurePvtApi(const BrinePvt& brinePvt, const Co2Pvt& co2Pvt)
         Evaluation pressure = 1e5;
         Evaluation Rs = 0.0;
         Evaluation Rv = 0.0;
+        Evaluation Rvw = 0.0;
         Evaluation So = 0.5;
         Evaluation maxSo = 1.0;
         Evaluation tmp;
@@ -135,11 +136,13 @@ void ensurePvtApi(const BrinePvt& brinePvt, const Co2Pvt& co2Pvt)
         tmp = co2Pvt.viscosity(/*regionIdx=*/0,
                                temperature,
                                pressure,
-                               Rv);
+                               Rv,
+                               Rvw);
         tmp = co2Pvt.inverseFormationVolumeFactor(/*regionIdx=*/0,
                                                   temperature,
                                                   pressure,
-                                                  Rv);
+                                                  Rv,
+                                                  Rvw);
         tmp = co2Pvt.saturatedViscosity(/*regionIdx=*/0,
                                         temperature,
                                         pressure);

--- a/tests/test_eclblackoilpvt.cpp
+++ b/tests/test_eclblackoilpvt.cpp
@@ -142,6 +142,7 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         Evaluation saltconcentration = 0.0;
         Evaluation Rs = 0.0;
         Evaluation Rv = 0.0;
+        Evaluation Rvw = 0.0;
         Evaluation So = 0.5;
         Evaluation maxSo = 1.0;
         Evaluation tmp;
@@ -193,11 +194,13 @@ void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& wa
         tmp = gasPvt.viscosity(/*regionIdx=*/0,
                                temperature,
                                pressure,
-                               Rv);
+                               Rv,
+                               Rvw);
         tmp = gasPvt.inverseFormationVolumeFactor(/*regionIdx=*/0,
                                                   temperature,
                                                   pressure,
-                                                  Rv);
+                                                  Rv,
+                                                  Rvw);
         tmp = gasPvt.saturatedViscosity(/*regionIdx=*/0,
                                         temperature,
                                         pressure);


### PR DESCRIPTION
Both PVT tables `PVTG `and `PVTGW` are used to specify the pvt for wet&humid gas with the assumption that the properties (viscosity `mu` and formation volume factor `Bg`) are evaluated for table  
- PVTG at saturated water-gas ratios (`Rvw_sat`)
- PVTGW at saturated oil-gas ratios (`Rv_sat`)

For example in case gas-oil co-exist and water has disappeared  the propertie values can be retrieved from the PVTGW table that contains data for saturated Rv (i.e. `Rv_sat`) and undersaturated Rvw

For the special case that only gas is present and hence `Rvw` and `Rv` are undersaturated we use the approximation `Bg(Rv,Rvw,p) = Bg(Rv,Rvw_sat,p)`, (and similar for `mu`) for which the values are then retrieved from the `PVTG` table.