### PR TITLE
[Release 2022.04] Fix bug WATDENT 

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -138,6 +138,14 @@ public:
                 watdentCT1_[regionIdx] = record.C1;
                 watdentCT2_[regionIdx] = record.C2;
             }
+          
+            const auto& pvtwTables = tables.getPvtwTable();
+          
+            assert(pvtwTables.size() == numRegions);       
+            for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
+                pvtwRefPress_[regionIdx] = pvtwTables[regionIdx].reference_pressure;
+                pvtwRefB_[regionIdx] = pvtwTables[regionIdx].volume_factor;
+            }
         }
 
         if (enableThermalViscosity_) {


### PR DESCRIPTION
The implementation of WATDENT is not retrieving the values for Pref and Bw from the PVTW table, making a division by zero in the inverseFormationVolumeFactor() computation:
return 1.0/(((1 - X)*(1 + cT1*Y + cT2*Y*Y))*BwRef);
and breaking the simulation run.