### PR TITLE
Fix installation of man page.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,5 +111,5 @@ opm_add_test(test_components)
 opm_add_test(test_fluidsystems)
 opm_add_test(test_immiscibleflash)
 
-install(DIRECTORY docs/man1 DESTINATION ${CMAKE_INSTALL_MANDIR}
+install(DIRECTORY doc/man1 DESTINATION ${CMAKE_INSTALL_MANDIR}
   FILES_MATCHING PATTERN "*.1")


### PR DESCRIPTION
The documentation directory is called doc here, not docs (likein another module).