### PR TITLE
changed: consistently use stack/C arrays

### DIFF
--- a/opm/material/constraintsolvers/ImmiscibleFlash.hpp
+++ b/opm/material/constraintsolvers/ImmiscibleFlash.hpp
@@ -287,7 +287,7 @@ protected:
         FlashEval p0 = inputFluidState.pressure(0);
         p0.setDerivative(p0PvIdx, 1.0);
 
-        std::array<FlashEval, numPhases> pc;
+        FlashEval pc[numPhases];
         MaterialLaw::capillaryPressures(pc, matParams, flashFluidState);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             flashFluidState.setPressure(phaseIdx, p0 + (pc[phaseIdx] - pc[0]));
@@ -418,7 +418,7 @@ protected:
         // update the pressures using the material law (saturations
         // and first pressure are already set because it is implicitly
         // solved for.)
-        Dune::FieldVector<FlashEval, numPhases> pC;
+        FlashEval pC[numPhases];
         MaterialLaw::capillaryPressures(pC, matParams, flashFluidState);
         for (unsigned phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
             flashFluidState.setPressure(phaseIdx,

--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -342,7 +342,7 @@ protected:
         FlashEval p0 = inputFluidState.pressure(0);
         p0.setDerivative(p0PvIdx, 1.0);
 
-        std::array<FlashEval, numPhases> pc;
+        FlashEval pc[numPhases];
         MaterialLaw::capillaryPressures(pc, matParams, flashFluidState);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             flashFluidState.setPressure(phaseIdx, p0 + (pc[phaseIdx] - pc[0]));
@@ -523,7 +523,7 @@ protected:
         // update the pressures using the material law (saturations
         // and first pressure are already set because it is implicitly
         // solved for.)
-        Dune::FieldVector<FlashEval, numPhases> pC;
+        FlashEval pC[numPhases];
         MaterialLaw::capillaryPressures(pC, matParams, flashFluidState);
         for (unsigned phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx)
             flashFluidState.setPressure(phaseIdx,


### PR DESCRIPTION
This is something I found while doing my private templates experiments.

Stack arrays are used in most of the code. Not using them here means we are instancing potentially hundreds of extra templates for very little reason.