### PR TITLE
Killough's hysteresis model for relperm and cap-pressure.

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -439,7 +439,7 @@ public:
             //
             // Though be aware that from a physical perspective this is definitively
             // incorrect!
-            params.oilWaterParams().update(/*pcSw=*/  1.0 - So,
+            params.oilWaterParams().update(/*pcSw=*/  Sw, //1.0 - So, (Effect is significant vs benchmark.)
                                            /*krwSw=*/ 1.0 - So,
                                            /*krnSw=*/ 1.0 - So);
 

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -43,8 +43,8 @@ public:
     EclHysteresisConfig()
     {
         enableHysteresis_ = false;
-        pcHysteresisModel_ = 0;
-        krHysteresisModel_ = 0;
+        pcHysteresisModel_ = -1;
+        krHysteresisModel_ = -1;
     }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -85,6 +85,10 @@ public:
      *    phase and the drainage curve for the relperm of the wetting phase
      * 1: use the Carlson model for relative permeability hysteresis of the non-wetting
      *    phase and the imbibition curve for the relperm of the wetting phase
+     * 2: use the Killough model for relative permeability hysteresis of the non-wetting
+     *    phase and the drainage curve for the relperm of the wetting phase
+     * 3: use the Killough model for relative permeability hysteresis of the non-wetting
+     *    phase and the imbibition curve for the relperm of the wetting phase
      */
     void setKrHysteresisModel(int value)
     { krHysteresisModel_ = value; }
@@ -93,10 +97,27 @@ public:
      * \brief Return the type of the hysteresis model which is used for relative permeability.
      *
      * -1: relperm hysteresis is disabled
-     * 0: use the Carlson model for relative permeability hysteresis
+     * 0/1: use the Carlson model for relative permeability hysteresis
+     * 2/3: use the Killough model for relative permeability hysteresis
      */
     int krHysteresisModel() const
     { return krHysteresisModel_; }
+
+    /*!
+     * \brief Regularisation parameter used for Killough model.
+     *
+     * default: 0.1
+     */
+    double modParamTrapped() const
+    { return modParamTrapped_; }
+
+    /*!
+     * \brief Curvature parameter used for capillary pressure hysteresis.
+     *
+     * default: 0.1
+     */
+    double curvatureCapPrs() const
+    { return curvatureCapPrs_; }
 
 #if HAVE_ECL_INPUT
     /*!
@@ -115,6 +136,8 @@ public:
 
         krHysteresisModel_ = runspec.hysterPar().krHysteresisModel();
         pcHysteresisModel_ = runspec.hysterPar().pcHysteresisModel();
+        modParamTrapped_ = runspec.hysterPar().modParamTrapped();
+        curvatureCapPrs_ = runspec.hysterPar().curvatureCapPrs();
     }
 #endif
 
@@ -125,6 +148,8 @@ private:
     // the capillary pressure and the relperm hysteresis models to be used
     int pcHysteresisModel_;
     int krHysteresisModel_;
+    double modParamTrapped_;
+    double curvatureCapPrs_;
 };
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -116,6 +116,9 @@ public:
 
         oilWaterSystem_ = (twoPhaseSystem == EclOilWaterSystem);
 
+        if (!config().enableHysteresis())
+            return;
+
         if (config().krHysteresisModel() == 2 || config().krHysteresisModel() == 3 || config().pcHysteresisModel() == 0) {
             if (twoPhaseSystem == EclGasOilSystem) {
                 Sncrd_ = info.Sgcr+info.Swl;
@@ -161,6 +164,9 @@ public:
                              EclTwoPhaseSystemType twoPhaseSystem)
     {
         imbibitionParams_ = value;
+
+        if (!config().enableHysteresis())
+            return;
 
         // Killough hysteresis model for nonw kr
         if (config().krHysteresisModel() == 2 || config().krHysteresisModel() == 3 || config().pcHysteresisModel() == 0) {
@@ -470,7 +476,7 @@ private:
     Scalar pcmaxd_;  // max pc for drain
     Scalar pcmaxi_;  // max pc for imb
 
-    Scalar curvatureCapPrs_; // curvature parameter used for capillary pressure hysteresis 
+    Scalar curvatureCapPrs_; // curvature parameter used for capillary pressure hysteresis
 };
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -65,6 +65,12 @@ public:
         krnSwMdc_ = 2.0;
         // krwSwMdc_ = 2.0;
 
+        pcSwMic_ = -1.0;
+        initialImb_ = false;
+        oilWaterSystem_ = false;
+        pcmaxd_ = 0.0;
+        pcmaxi_ = 0.0;
+
         deltaSwImbKrn_ = 0.0;
         // deltaSwImbKrw_ = 0.0;
     }
@@ -76,7 +82,10 @@ public:
     void finalize()
     {
         if (config().enableHysteresis()) {
-            //C_ = 1.0/(Sncri_ - Sncrd_) + 1.0/(Snmaxd_ - Sncrd_);
+            if (config().krHysteresisModel() == 2 || config().krHysteresisModel() == 3 || config().pcHysteresisModel() == 0) {
+                C_ = 1.0/(Sncri_ - Sncrd_ + 1.0e-12) - 1.0/(Snmaxd_ - Sncrd_);
+                curvatureCapPrs_ =  config().curvatureCapPrs();
+            }
 
             updateDynamicParams_();
         }
@@ -99,9 +108,40 @@ public:
     /*!
      * \brief Sets the parameters used for the drainage curve
      */
-    void setDrainageParams(const EffLawParams& value)
+    void setDrainageParams(const EffLawParams& value,
+                           const EclEpsScalingPointsInfo<Scalar>& info,
+                           EclTwoPhaseSystemType twoPhaseSystem)
     {
         drainageParams_ = value;
+
+        oilWaterSystem_ = (twoPhaseSystem == EclOilWaterSystem);
+
+        if (config().krHysteresisModel() == 2 || config().krHysteresisModel() == 3 || config().pcHysteresisModel() == 0) {
+            if (twoPhaseSystem == EclGasOilSystem) {
+                Sncrd_ = info.Sgcr+info.Swl;
+                Snmaxd_ = info.Sgu+info.Swl;
+                KrndMax_ = EffLawT::twoPhaseSatKrn(drainageParams(), 1.0-Snmaxd_);
+            }
+            else {
+                assert(twoPhaseSystem == EclOilWaterSystem);
+                Sncrd_ = info.Sowcr;
+                Snmaxd_ = 1.0 - info.Swl - info.Sgl;
+                KrndMax_ = EffLawT::twoPhaseSatKrn(drainageParams(), 1.0-Snmaxd_);
+            }
+        }
+
+        // Additional Killough hysteresis model for pc
+        if (config().pcHysteresisModel() == 0) {
+            if (twoPhaseSystem == EclGasOilSystem) {
+                Swcrd_ = info.Sogcr;
+                pcmaxd_ = info.maxPcgo;
+            }
+            else {
+                assert(twoPhaseSystem == EclOilWaterSystem);
+                Swcrd_ = info.Swcr;
+                pcmaxd_ = -17.0; // At this point 'info.maxPcow' holds pre-swatinit value ...;
+            }
+        }
     }
 
     /*!
@@ -117,20 +157,36 @@ public:
      * \brief Sets the parameters used for the imbibition curve
      */
     void setImbibitionParams(const EffLawParams& value,
-                             const EclEpsScalingPointsInfo<Scalar>& /* info */,
-                             EclTwoPhaseSystemType /* twoPhaseSystem */)
+                             const EclEpsScalingPointsInfo<Scalar>& info,
+                             EclTwoPhaseSystemType twoPhaseSystem)
     {
         imbibitionParams_ = value;
 
-/*
-        if (twoPhaseSystem == EclGasOilSystem) {
-            Sncri_ = info.Sgcr;
+        // Killough hysteresis model for nonw kr
+        if (config().krHysteresisModel() == 2 || config().krHysteresisModel() == 3 || config().pcHysteresisModel() == 0) {
+            if (twoPhaseSystem == EclGasOilSystem) {
+                Sncri_ = info.Sgcr+info.Swl;
+            }
+            else {
+                assert(twoPhaseSystem == EclOilWaterSystem);
+                Sncri_ = info.Sowcr;
+            }
         }
-        else {
-            assert(twoPhaseSystem == EclOilWaterSystem);
-            Sncri_ = info.Sowcr;
+
+        // Killough hysteresis model for pc
+        if (config().pcHysteresisModel() == 0) {
+            if (twoPhaseSystem == EclGasOilSystem) {
+                Swcri_ = info.Sogcr;
+                Swmaxi_ = 1.0 - info.Sgl - info.Swl;
+                pcmaxi_ = info.maxPcgo;
+            }
+            else {
+                assert(twoPhaseSystem == EclOilWaterSystem);
+                Swcri_ = info.Swcr;
+                Swmaxi_ = info.Swu;
+                pcmaxi_ = info.maxPcow;
+            }
         }
-*/
     }
 
     /*!
@@ -143,18 +199,20 @@ public:
     { return imbibitionParams_; }
 
     /*!
-     * \brief Set the saturation of the wetting phase where the last switch from the main
-     *        drainage curve (MDC) to imbibition happend on the capillary pressure curve.
-     */
-    void setPcSwMdc(Scalar value)
-    { pcSwMdc_ = value; }
-
-    /*!
      * \brief Get the saturation of the wetting phase where the last switch from the main
      *        drainage curve to imbibition happend on the capillary pressure curve.
      */
     Scalar pcSwMdc() const
     { return pcSwMdc_; }
+
+    Scalar pcSwMic() const
+    { return pcSwMic_; }
+
+    /*!
+     * \brief Status of initial process.
+     */
+    bool initialImb() const
+    { return initialImb_; }
 
     /*!
      * \brief Set the saturation of the wetting phase where the last switch from the main
@@ -232,6 +290,46 @@ public:
     Scalar deltaSwImbKrn() const
     { return deltaSwImbKrn_; }
 
+
+    Scalar Swcri() const
+    { return Swcri_; }
+
+    Scalar Swcrd() const
+    { return Swcrd_; }
+
+    Scalar Swmaxi() const
+    { return Swmaxi_; }
+
+    Scalar Sncri() const
+    { return Sncri_; }
+
+    Scalar Sncrd() const
+    { return Sncrd_; }
+
+    Scalar Sncrt() const
+    { return Sncrt_; }
+
+    Scalar Snmaxd() const
+    { return Snmaxd_; }
+
+    Scalar Snhy() const
+    { return 1.0 - krnSwMdc_; }
+
+    Scalar krnWght() const
+    { return KrndHy_/KrndMax_; }
+
+    Scalar pcWght() const // Aligning pci and pcd at Swir
+    {
+        if (pcmaxd_ < 0.0)
+            return EffLawT::twoPhaseSatPcnw(drainageParams(), 0.0)/(pcmaxi_+1e-6);
+        else
+            return pcmaxd_/(pcmaxi_+1e-6);
+    }
+
+    Scalar curvatureCapPrs() const
+    { return curvatureCapPrs_;}
+
+
     /*!
      * \brief Notify the hysteresis law that a given wetting-phase saturation has been seen
      *
@@ -241,8 +339,17 @@ public:
     void update(Scalar pcSw, Scalar /* krwSw */, Scalar krnSw)
     {
         bool updateParams = false;
-        if (pcSw < pcSwMdc_) {
+
+        if (config().pcHysteresisModel() == 0 && pcSw < pcSwMdc_) {
+            if (pcSwMdc_ == 2.0 && pcSw+1.0e-6 < Swcrd_ && oilWaterSystem_) {
+               initialImb_ = true;
+            }
             pcSwMdc_ = pcSw;
+            updateParams = true;
+        }
+
+        if (initialImb_ && pcSw > pcSwMic_) {
+            pcSwMic_ = pcSw;
             updateParams = true;
         }
 
@@ -261,6 +368,7 @@ public:
 
         if (krnSw < krnSwMdc_) {
             krnSwMdc_ = krnSw;
+            KrndHy_ = EffLawT::twoPhaseSatKrn(drainageParams(), krnSwMdc_);
             updateParams = true;
         }
 
@@ -279,10 +387,13 @@ private:
         Scalar SwKrwMdcImbibition = EffLawT::twoPhaseSatKrwInv(imbibitionParams(), krwMdcDrainage);
         deltaSwImbKrw_ = SwKrwMdcImbibition - krwSwMdc_;
 */
-
-        Scalar krnMdcDrainage = EffLawT::twoPhaseSatKrn(drainageParams(), krnSwMdc_);
-        Scalar SwKrnMdcImbibition = EffLawT::twoPhaseSatKrnInv(imbibitionParams(), krnMdcDrainage);
-        deltaSwImbKrn_ = SwKrnMdcImbibition - krnSwMdc_;
+        if (config().krHysteresisModel() == 0 || config().krHysteresisModel() == 1) {
+            Scalar krnMdcDrainage = EffLawT::twoPhaseSatKrn(drainageParams(), krnSwMdc_);
+            Scalar SwKrnMdcImbibition = EffLawT::twoPhaseSatKrnInv(imbibitionParams(), krnMdcDrainage);
+            deltaSwImbKrn_ = SwKrnMdcImbibition - krnSwMdc_;
+            assert(std::abs(EffLawT::twoPhaseSatKrn(imbibitionParams(), krnSwMdc_ + deltaSwImbKrn_)
+                            - EffLawT::twoPhaseSatKrn(drainageParams(), krnSwMdc_)) < 1e-8);
+        }
 
         // Scalar pcMdcDrainage = EffLawT::twoPhaseSatPcnw(drainageParams(), pcSwMdc_);
         // Scalar SwPcMdcImbibition = EffLawT::twoPhaseSatPcnwInv(imbibitionParams(), pcMdcDrainage);
@@ -290,16 +401,20 @@ private:
 
 //        assert(std::abs(EffLawT::twoPhaseSatPcnw(imbibitionParams(), pcSwMdc_ + deltaSwImbPc_)
 //                        - EffLawT::twoPhaseSatPcnw(drainageParams(), pcSwMdc_)) < 1e-8);
-        assert(std::abs(EffLawT::twoPhaseSatKrn(imbibitionParams(), krnSwMdc_ + deltaSwImbKrn_)
-                        - EffLawT::twoPhaseSatKrn(drainageParams(), krnSwMdc_)) < 1e-8);
+//        assert(std::abs(EffLawT::twoPhaseSatKrn(imbibitionParams(), krnSwMdc_ + deltaSwImbKrn_)
+//                        - EffLawT::twoPhaseSatKrn(drainageParams(), krnSwMdc_)) < 1e-8);
 //        assert(std::abs(EffLawT::twoPhaseSatKrw(imbibitionParams(), krwSwMdc_ + deltaSwImbKrw_)
 //                        - EffLawT::twoPhaseSatKrw(drainageParams(), krwSwMdc_)) < 1e-8);
 
-#if 0
-        Scalar Snhy = 1.0 - SwMdc_;
-
-        Sncrt_ = Sncrd_ + (Snhy - Sncrd_)/(1 + C_*(Snhy - Sncrd_));
-#endif
+        if (config().krHysteresisModel() == 2 || config().krHysteresisModel() == 3 || config().pcHysteresisModel() == 0) {
+            Scalar Snhy = 1.0 - krnSwMdc_;
+            if (Snhy > Sncrd_)
+                Sncrt_ = Sncrd_ + (Snhy - Sncrd_)/((1.0+config().modParamTrapped()*(Snmaxd_-Snhy)) + C_*(Snhy - Sncrd_));
+            else
+            {
+                Sncrt_ = Sncrd_;
+            }
+        }
     }
 
     std::shared_ptr<EclHysteresisConfig> config_;
@@ -313,6 +428,13 @@ private:
     Scalar krnSwMdc_;
     Scalar pcSwMdc_;
 
+    // largest wettinging phase saturation along main imbibition curve
+    Scalar pcSwMic_;
+    // Initial process is imbibition (for initial saturations at or below critical drainage saturation)
+    bool initialImb_;
+
+    bool oilWaterSystem_;
+
     // offsets added to wetting phase saturation uf using the imbibition curves need to
     // be used to calculate the wetting phase relperm, the non-wetting phase relperm and
     // the capillary pressure
@@ -321,20 +443,34 @@ private:
     //Scalar deltaSwImbPc_;
 
     // trapped non-wetting phase saturation
-    //Scalar Sncrt_;
+    Scalar Sncrt_;
 
     // the following uses the conventions of the Eclipse technical description:
     //
     // Sncrd_: critical non-wetting phase saturation for the drainage curve
     // Sncri_: critical non-wetting phase saturation for the imbibition curve
+    // Swcri_: critical wetting phase saturation for the imbibition curve
+    // Swcrd_: critical wetting phase saturation for the drainage curve
+    // Swmaxi_; maximum wetting phase saturation for the imbibition curve
     // Snmaxd_: non-wetting phase saturation where the non-wetting relperm reaches its
     //          maximum on the drainage curve
     // C_: factor required to calculate the trapped non-wetting phase saturation using
     //     the Killough approach
-    //Scalar Sncrd_;
-    //Scalar Sncri_;
-    //Scalar Snmaxd_;
-    //Scalar C_;
+    Scalar Sncrd_;
+    Scalar Sncri_;
+    Scalar Swcri_;
+    Scalar Swcrd_;
+    Scalar Swmaxi_;
+    Scalar Snmaxd_;
+    Scalar C_;
+
+    Scalar KrndMax_; // Krn_drain(Snmaxd_)
+    Scalar KrndHy_;  // Krn_drain(1-krnSwMdc_)
+
+    Scalar pcmaxd_;  // max pc for drain
+    Scalar pcmaxi_;  // max pc for imb
+
+    Scalar curvatureCapPrs_; // curvature parameter used for capillary pressure hysteresis 
 };
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -303,7 +303,9 @@ public:
                 gasOilDrainParams.setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
                 gasOilDrainParams.finalize();
 
-                gasOilParams->setDrainageParams(gasOilDrainParams);
+                gasOilParams->setDrainageParams(gasOilDrainParams,
+                                                gasOilScaledInfo,
+                                                EclGasOilSystem);
             }
 
             if (hasOil && hasWater) {
@@ -314,7 +316,9 @@ public:
                 oilWaterDrainParams.setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
                 oilWaterDrainParams.finalize();
 
-                oilWaterParams->setDrainageParams(oilWaterDrainParams);
+                oilWaterParams->setDrainageParams(oilWaterDrainParams,
+                                                  owinfo,
+                                                  EclOilWaterSystem);
             }
 
             if (hasGas && hasWater && !hasOil) {
@@ -325,7 +329,9 @@ public:
                 gasWaterDrainParams.setEffectiveLawParams(gasWaterEffectiveParamVector_[satRegionIdx]);
                 gasWaterDrainParams.finalize();
 
-                gasWaterParams->setDrainageParams(gasWaterDrainParams);
+                gasWaterParams->setDrainageParams(gasWaterDrainParams,
+                                                  gasWaterScaledInfo,
+                                                  EclGasWaterSystem);
             }
 
             if (enableHysteresis()) {
@@ -373,7 +379,7 @@ public:
                     oilWaterImbParamsHyst.finalize();
 
                     oilWaterParams->setImbibitionParams(oilWaterImbParamsHyst,
-                                                        gasOilScaledImbInfo,
+                                                        oilWaterScaledImbInfo,
                                                         EclOilWaterSystem);
                 }
 

--- a/tests/test_eclmateriallawmanager.cpp
+++ b/tests/test_eclmateriallawmanager.cpp
@@ -248,7 +248,7 @@ static const char* hysterDeckString =
     "\n"
     "\n"
     "EHYSTR\n"
-    "0.1   0  0.1 1* KR /\n"
+    "0.1   0  0.1 1* BOTH /\n"
     "\n"
     "SATOPTS\n"
     "HYSTER /\n"


### PR DESCRIPTION
Functionality related to kw `EHYSTR`, item#2 (flags 2 and 3) and item#5 (flags PC and BOTH). 
Related pull requests: https://github.com/OPM/opm-common/pull/3170 and https://github.com/OPM/opm-simulators/pull/4148.