### PR TITLE
Raising a fatal error by default in cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ project(opm-material C CXX)
 
 cmake_minimum_required (VERSION 3.10)
 
+message(FATAL_ERROR "\
+THIS MODULE IS DEPRECATED. \
+The material module has been integrated into opm-common. ")
+
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 
 if(SIBLING_SEARCH AND NOT opm-common_DIR)


### PR DESCRIPTION
We've had some unfortunate incidences where people have used automated build scripts to build OPM, but have not been notified of the deprecation of this module. As it stands, opm-material will fail to compile due to some dependency not being met.

This PR addes a fatal error at the top of `CMakeLists.txt` such that running `cmake <path to opm-material>` results in 

```
CMake Error at CMakeLists.txt:26 (message):
  THIS MODULE IS DEPRECATED.  The material module have been integrated into
  opm-common.
```

If one really wants to build it, one can specify `-DBUILD_DEPRECATD_OPM_MATERIAL=ON` and have it built (provided one can find matching versions of the other repositories). 